### PR TITLE
Removal of deprecated API features

### DIFF
--- a/app.py
+++ b/app.py
@@ -125,11 +125,6 @@ def require_auth():
         # Not a session token? Maybe APIKey token
         if g.auth_user is None:
             g.auth_user = APIKey.verify_token(token)
-        # Still nothing? Maybe legacy API key
-        if g.auth_user is None:
-            g.auth_user = User.verify_legacy_token(token)
-            if g.auth_user is not None:
-                log.getLogger().warning("'%s' used legacy auth token for authentication", g.auth_user.login)
 
     if g.auth_user:
         if app_config.malwarecage.enable_maintenance and g.auth_user.login != app_config.malwarecage.admin_login:

--- a/core/search/mappings.py
+++ b/core/search/mappings.py
@@ -9,7 +9,6 @@ from .fields import BaseField, StringField, IntegerField, ListField, AttributeFi
 object_mapping: Dict[str, Type[Object]] = {
     "file": File,
     "object": Object,
-    "static": Config,
     "config": Config,
     "blob": TextBlob
 }

--- a/model/user.py
+++ b/model/user.py
@@ -126,10 +126,6 @@ class User(db.Model):
     def verify_set_password_token(token):
         return User._verify_token(token, ["password_ver"])
 
-    @staticmethod
-    def verify_legacy_token(token):
-        return User._verify_token(token, ["version_uid"])
-
     def is_member(self, group_id):
         groups = db.session.query(member.c.group_id) \
             .filter(member.c.user_id == self.id)

--- a/resources/object.py
+++ b/resources/object.py
@@ -29,12 +29,6 @@ class ObjectListResource(Resource):
             - object
         parameters:
             - in: query
-              name: page
-              schema:
-                type: integer
-              description: Page number (deprecated)
-              required: false
-            - in: query
               name: older_than
               schema:
                 type: string
@@ -54,13 +48,6 @@ class ObjectListResource(Resource):
             400:
                 description: Syntax error in Lucene query
         """
-        if 'page' in request.args and 'older_than' in request.args:
-            raise BadRequest("page and older_than can't be used simultaneously. Use `older_than` for new code.")
-
-        if 'page' in request.args:
-            logger.warning("'%s' used legacy 'page' parameter", g.auth_user.login)
-
-        page = max(1, int(request.args.get('page', 1)))
         query = request.args.get('query')
 
         pivot_obj = None
@@ -84,9 +71,6 @@ class ObjectListResource(Resource):
         )
         if pivot_obj:
             db_query = db_query.filter(Object.id < pivot_obj.id)
-        # Legacy parameter - to be removed
-        elif page > 1:
-            db_query = db_query.offset((page - 1) * 10)
 
         db_query = db_query.limit(10)
         objects = db_query.all()


### PR DESCRIPTION
## Removal of legacy Malwarecage API tokens

Early versions of Malwarecage supported simplified version of API tokens that were unmanagable and unrevokable.

Users of mwdb.cert.pl service need to **register new API key** using `API keys` section in https://mwdb.cert.pl/profile. After generating a key (`Create a new key`) - new token can be accessed by clicking `Show API token` button (token is usually a long string that starts with `ey...`). That key can be used for authentication in `mwdblib.Malwarecage` instance via `api_key` parameter:

```python
api_key = "ey..."
mwdb = Malwarecage(api_key=api_key)
```

##  `page` argument is no longer supported for `Recent objects` endpoints

`page` used `LIMIT ... OFFSET ...` queries which were really slow when used for pagination. Now, the only supported and documented argument is `older_than=<last fetched hash>`

Users of mwdb.cert.pl service should **upgrade mwdblib version at least to the 2.6.0 version** (https://github.com/CERT-Polska/mwdblib/releases/tag/2.6.0). We highly recommend an upgrade to the latest version (breaking changes are listed here: https://github.com/CERT-Polska/mwdblib/releases/tag/3.0.0)

Documentation of mwdblib can be found here: https://mwdblib.readthedocs.io/en/latest/

## Removed `static.*:` search field (alias for `config.*:`)

In first Malwarecage version only static configurations were supported, so search field was also named `static:`. Along with providing support for parsed dynamic configurations, search field was renamed to `config:` and `static:` has been left as an alias due to backwards compatibility.

Because `static` suggests that only static configurations will be included in search results, it is deprecated and will be no longer supported. If you want to search only for static configurations, use `config.type:static`