### PR TITLE
Fix base url for API docs

### DIFF
--- a/malwarecage/core/service.py
+++ b/malwarecage/core/service.py
@@ -48,7 +48,7 @@ class Service(Api):
         }
         spec.options["servers"] = [
             {
-                "url": "{scheme}://{host}/api",
+                "url": "{scheme}://{host}",
                 "description": 'Malwarecage API endpoint',
                 "variables": {
                     "scheme": {

--- a/malwarecage/web/src/components/Docs.js
+++ b/malwarecage/web/src/components/Docs.js
@@ -16,7 +16,7 @@ class Docs extends Component {
             And hey... we probably don't want to make it customizable here
         */
         spec.data["servers"] = [{
-            "url": new URL(api.getApiForEnvironment(), document.baseURI).href,
+            "url": new URL("/", document.baseURI).href,
             "description": 'Malwarecage API endpoint',
         }]
         this.setState({


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- In Swagger UI documentation: `/api` is doubled in path because of changes in backend code

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- Set base URL from `{scheme}://{host}/api` to `{scheme}://{host}`

**Test plan**
<!-- Explain how to test your changes -->
- Check if http://127.0.0.1/docs generates correct API requests

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

