### PR TITLE
Fixed frontend plugin discovery

### DIFF
--- a/mwdb/web/config-overrides.js
+++ b/mwdb/web/config-overrides.js
@@ -2,15 +2,18 @@ const { override, babelInclude, removeModuleScopePlugin, addWebpackModuleRule } 
 const fs = require("fs");
 const path = require('path');
 
-const pluginPackagePrefix = "@mwdb-web/plugin";
+const mwdbPackageNamespace = "@mwdb-web";
+const pluginPackagePrefix = "plugin-";
 const pluginsIndexFile = path.join(require.resolve("@mwdb-web/commons"), 'extensions', '..', 'plugins.js');
 
 function findInstalledPlugins() {
     let modules = {};
-    const modulesDir = path.join(__dirname, "node_modules", pluginPackagePrefix);
+    const modulesDir = path.join(__dirname, "node_modules", mwdbPackageNamespace);
     if(!fs.existsSync(modulesDir))
         return modules;
     for(const pluginName of fs.readdirSync(modulesDir)) {
+        if(!pluginName.startsWith(pluginPackagePrefix))
+            continue;
         let realPath = path.join(modulesDir, pluginName);
         try {
             realPath = path.resolve(modulesDir, fs.readlinkSync(realPath));
@@ -18,7 +21,7 @@ function findInstalledPlugins() {
             if(e.errno != -22 /* EINVAL */)
                 throw e;
         }
-        modules[pluginPackagePrefix + "/" + pluginName] = realPath;
+        modules[mwdbPackageNamespace + "/" + pluginName] = realPath;
     }
     return modules;
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

- Current Webpack script doesn't correctly find frontend plugins. By convention, their names are prefixed with `@mwdb-web/plugin-`

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

- Webpack is able to link web plugins
