### PR TITLE
Fix: "Latest config" is not the latest one

### DIFF
--- a/mwdb/model/object.py
+++ b/mwdb/model/object.py
@@ -153,9 +153,12 @@ class Object(db.Model):
         from .config import Config
         return (
             db.session.query(Config)
-                      .filter(Config.id.in_(db.session.query(relation.c.child_id)
-                                                      .filter(relation.c.parent_id == self.id)))
-                      .filter(g.auth_user.has_access_to_object(Config.id)).first())
+                      .join(relation, and_(
+                          relation.c.parent_id == self.id,
+                          relation.c.child_id == Config.id))
+                      .filter(g.auth_user.has_access_to_object(Config.id))
+                      .order_by(relation.c.creation_time.desc()).first()
+        )
 
     def add_parent(self, parent, commit=True):
         """


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- There is no ordering in `latest_config` attribute so MWDB shows arbitrary child config if sample has more than one of them.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- MWDB shows the latest config child
