### PR TITLE
Fix: Ensure UTC timestamps everywhere and recover previous serialization

### DIFF
--- a/mwdb/core/search/fields.py
+++ b/mwdb/core/search/fields.py
@@ -1,6 +1,6 @@
 import re
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from typing import List, Union, Type, Any
 
 from flask import g

--- a/mwdb/core/search/fields.py
+++ b/mwdb/core/search/fields.py
@@ -1,6 +1,6 @@
 import re
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import List, Union, Type, Any
 
 from flask import g

--- a/mwdb/model/api_key.py
+++ b/mwdb/model/api_key.py
@@ -1,8 +1,8 @@
+import datetime
 import uuid
 
 from itsdangerous import JSONWebSignatureSerializer, SignatureExpired, BadSignature
 
-from sqlalchemy import func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -16,7 +16,7 @@ class APIKey(db.Model):
 
     id = db.Column(UUID(as_uuid=True), primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
-    issued_on = db.Column(db.DateTime, default=func.now(), nullable=False)
+    issued_on = db.Column(db.DateTime, default=datetime.datetime.utcnow, nullable=False)
     issued_by = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
 
     issuer = db.relationship('User', foreign_keys=[issued_by], uselist=False)

--- a/mwdb/model/blob.py
+++ b/mwdb/model/blob.py
@@ -34,12 +34,12 @@ class TextBlob(Object):
             blob_name=blob_name,
             blob_size=len(content),
             blob_type=blob_type,
-            last_seen=datetime.datetime.now(),
+            last_seen=datetime.datetime.utcnow(),
             _content=content.encode("unicode_escape").decode("utf-8")
         )
         blob_obj, is_new = cls._get_or_create(blob_obj, parent=parent, metakeys=metakeys, share_with=share_with)
         # If object exists yet: we need to refresh last_seen timestamp
         if not is_new:
-            blob_obj.last_seen = datetime.datetime.now()
+            blob_obj.last_seen = datetime.datetime.utcnow()
 
         return blob_obj, is_new

--- a/mwdb/model/object.py
+++ b/mwdb/model/object.py
@@ -16,7 +16,7 @@ relation = db.Table(
     'relation',
     db.Column('parent_id', db.Integer, db.ForeignKey('object.id'), index=True),
     db.Column('child_id', db.Integer, db.ForeignKey('object.id'), index=True),
-    db.Column('creation_time', db.DateTime, default=datetime.datetime.now),
+    db.Column('creation_time', db.DateTime, default=datetime.datetime.utcnow),
     db.Index('ix_relation_parent_child', 'parent_id', 'child_id', unique=True)
 )
 
@@ -41,7 +41,7 @@ class ObjectPermission(db.Model):
         db.Index('ix_permission_group_object', 'object_id', 'group_id', unique=True),
     )
 
-    access_time = db.Column(db.DateTime, nullable=False, index=True, default=func.now())
+    access_time = db.Column(db.DateTime, nullable=False, index=True, default=datetime.datetime.utcnow)
 
     reason_type = db.Column(db.String(32))
     related_object_id = db.Column(db.Integer, db.ForeignKey('object.id'))
@@ -120,7 +120,7 @@ class Object(db.Model):
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     type = db.Column(db.String(50), nullable=False)
     dhash = db.Column(db.String(64), unique=True, index=True, nullable=False)
-    upload_time = db.Column(db.DateTime, nullable=False, index=True, default=func.now())
+    upload_time = db.Column(db.DateTime, nullable=False, index=True, default=datetime.datetime.utcnow)
 
     parents = db.relationship(
         "Object", secondary=relation,
@@ -256,7 +256,7 @@ class Object(db.Model):
             new_cls = obj
             try:
                 # Try to create the requested object
-                new_cls.upload_time = datetime.datetime.now()
+                new_cls.upload_time = datetime.datetime.utcnow()
                 db.session.add(new_cls)
                 db.session.flush()
                 db.session.commit()

--- a/mwdb/model/user.py
+++ b/mwdb/model/user.py
@@ -74,7 +74,7 @@ class User(db.Model):
     def set_password(self, password):
         self.password_hash = bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt(12)).decode('utf-8')
         self.password_ver = os.urandom(8).hex()
-        self.set_password_on = datetime.datetime.now()
+        self.set_password_on = datetime.datetime.utcnow()
 
     def reset_sessions(self):
         # Should be also called for fresh user objects
@@ -112,9 +112,9 @@ class User(db.Model):
 
         if not pending:
             user.registered_by = g.auth_user.id
-            user.registered_on = datetime.datetime.now()
+            user.registered_on = datetime.datetime.utcnow()
         else:
-            user.requested_on = datetime.datetime.now()
+            user.requested_on = datetime.datetime.utcnow()
 
         db.session.add(user)
         if commit:

--- a/mwdb/schema/api_key.py
+++ b/mwdb/schema/api_key.py
@@ -1,16 +1,18 @@
 from marshmallow import Schema, fields
 
+from .utils import UTCDateTime
+
 
 class APIKeyIdentifierBase(Schema):
     id = fields.UUID(required=True, allow_none=False)
 
 
 class APIKeyTokenResponseSchema(APIKeyIdentifierBase):
-    issued_on = fields.DateTime(required=True, allow_none=False)
+    issued_on = UTCDateTime(required=True, allow_none=False)
     issuer_login = fields.Str(required=True, allow_none=False)
     token = fields.Str(required=True, allow_none=False)
 
 
 class APIKeyListItemResponseSchema(APIKeyIdentifierBase):
-    issued_on = fields.DateTime(required=True, allow_none=False)
+    issued_on = UTCDateTime(required=True, allow_none=False)
     issuer_login = fields.Str(required=True, allow_none=False)

--- a/mwdb/schema/auth.py
+++ b/mwdb/schema/auth.py
@@ -1,7 +1,5 @@
 from marshmallow import Schema, fields, validates, ValidationError
 
-from .api_key import APIKeyListItemResponseSchema
-from .group import GroupBasicResponseSchema
 from .user import UserLoginSchemaBase
 
 

--- a/mwdb/schema/blob.py
+++ b/mwdb/schema/blob.py
@@ -1,5 +1,6 @@
 from marshmallow import fields, Schema
 
+from .config import ConfigItemResponseSchema
 from .object import (
     ObjectCreateRequestSchemaBase,
     ObjectLegacyMetakeysMixin,
@@ -7,7 +8,7 @@ from .object import (
     ObjectListResponseSchemaBase,
     ObjectItemResponseSchema,
 )
-from .config import ConfigItemResponseSchema
+from .utils import UTCDateTime
 
 
 # Merge it with BlobCreateRequestSchema during legacy upload remove
@@ -29,7 +30,7 @@ class BlobListItemResponseSchema(ObjectListItemResponseSchema):
     blob_name = fields.Str(required=True, allow_none=False)
     blob_size = fields.Int(required=True, allow_none=False)
     blob_type = fields.Str(required=True, allow_none=False)
-    last_seen = fields.DateTime(required=True, allow_none=False)
+    last_seen = UTCDateTime(required=True, allow_none=False)
 
 
 class BlobListResponseSchema(ObjectListResponseSchemaBase, BlobListItemResponseSchema):
@@ -40,7 +41,7 @@ class BlobItemResponseSchema(ObjectItemResponseSchema):
     blob_name = fields.Str(required=True, allow_none=False)
     blob_size = fields.Int(required=True, allow_none=False)
     blob_type = fields.Str(required=True, allow_none=False)
-    last_seen = fields.DateTime(required=True, allow_none=False)
+    last_seen = UTCDateTime(required=True, allow_none=False)
 
     content = fields.Str(required=True, allow_none=False)
     latest_config = fields.Nested(ConfigItemResponseSchema, required=True, allow_none=True)

--- a/mwdb/schema/comment.py
+++ b/mwdb/schema/comment.py
@@ -1,5 +1,7 @@
 from marshmallow import Schema, fields, validates, ValidationError
 
+from .utils import UTCDateTime
+
 
 class CommentSchemaBase(Schema):
     comment = fields.Str(required=True, allow_none=False)
@@ -17,4 +19,4 @@ class CommentRequestSchema(CommentSchemaBase):
 class CommentItemResponseSchema(CommentSchemaBase):
     id = fields.Int(required=True, allow_none=False)
     author = fields.Str(required=True, allow_none=False, attribute="author_login")
-    timestamp = fields.DateTime(required=True, allow_none=False)
+    timestamp = UTCDateTime(required=True, allow_none=False)

--- a/mwdb/schema/object.py
+++ b/mwdb/schema/object.py
@@ -3,6 +3,7 @@ import json
 from marshmallow import Schema, fields, validates_schema, ValidationError, pre_load, post_dump
 
 from .metakey import MetakeyItemRequestSchema
+from .utils import UTCDateTime
 from .tag import TagItemResponseSchema
 
 
@@ -53,7 +54,7 @@ class ObjectListItemResponseSchema(Schema):
     id = fields.Str(attribute="dhash", required=True, allow_none=False)
     type = fields.Str(required=True, allow_none=False)
     tags = fields.Nested(TagItemResponseSchema, many=True, required=True, allow_none=False)
-    upload_time = fields.DateTime(required=True, allow_none=False)
+    upload_time = UTCDateTime(required=True, allow_none=False)
 
 
 class ObjectListResponseSchemaBase(Schema):
@@ -75,7 +76,7 @@ class ObjectItemResponseSchema(Schema):
     id = fields.Str(attribute="dhash", required=True, allow_none=False)
     type = fields.Str(required=True, allow_none=False)
     tags = fields.Nested(TagItemResponseSchema, many=True, required=True, allow_none=False)
-    upload_time = fields.DateTime(required=True, allow_none=False)
+    upload_time = UTCDateTime(required=True, allow_none=False)
 
     parents = fields.Nested(ObjectListItemResponseSchema, many=True, required=True, allow_none=False)
     children = fields.Nested(ObjectListItemResponseSchema, many=True, required=True, allow_none=False)

--- a/mwdb/schema/quick_query.py
+++ b/mwdb/schema/quick_query.py
@@ -1,5 +1,7 @@
 from marshmallow import Schema, fields, validates, ValidationError
 
+from .utils import UTCDateTime
+
 
 class QuickQuerySchemaBase(Schema):
     query = fields.Str(required=True, allow_none=False)
@@ -18,4 +20,4 @@ class QuickQueryRequestSchema(QuickQuerySchemaBase):
 
 class QuickQueryResponseSchema(QuickQuerySchemaBase):
     id = fields.Int(required=True, allow_none=False)
-    timestamp = fields.DateTime(required=True, allow_none=False)
+    timestamp = UTCDateTime(required=True, allow_none=False)

--- a/mwdb/schema/share.py
+++ b/mwdb/schema/share.py
@@ -2,6 +2,8 @@ import re
 
 from marshmallow import Schema, fields, validates, ValidationError
 
+from .utils import UTCDateTime
+
 
 class ShareRequestSchema(Schema):
     group = fields.Str(required=True, allow_none=False)
@@ -20,7 +22,7 @@ class ShareGroupListResponseSchema(Schema):
 
 class ShareItemResponseSchema(Schema):
     group_name = fields.Str(required=True, allow_none=False)
-    access_time = fields.DateTime(required=True, allow_none=False)
+    access_time = UTCDateTime(required=True, allow_none=False)
     reason_type = fields.Str(required=True, allow_none=False)
     access_reason = fields.Str(required=True, allow_none=False)  # backwards compatibility
     related_object_dhash = fields.Str(required=True, allow_none=True)

--- a/mwdb/schema/user.py
+++ b/mwdb/schema/user.py
@@ -4,6 +4,7 @@ from marshmallow import Schema, fields, validates, ValidationError
 
 from .api_key import APIKeyListItemResponseSchema
 from .group import GroupBasicResponseSchema, GroupItemResponseSchema
+from .utils import UTCDateTime
 
 
 class UserLoginSchemaBase(Schema):
@@ -51,10 +52,10 @@ class UserItemResponseSchema(UserLoginSchemaBase):
     additional_info = fields.Str(required=True, allow_none=False)
     feed_quality = fields.Str(required=True, allow_none=False)
 
-    requested_on = fields.DateTime(required=True)
-    registered_on = fields.DateTime(required=True)
-    logged_on = fields.DateTime(required=True)
-    set_password_on = fields.DateTime(required=True)
+    requested_on = UTCDateTime(required=True)
+    registered_on = UTCDateTime(required=True)
+    logged_on = UTCDateTime(required=True)
+    set_password_on = UTCDateTime(required=True)
     registrar_login = fields.Str(required=True)
 
     disabled = fields.Boolean(required=True, allow_none=False)
@@ -68,7 +69,7 @@ class UserListItemResponseSchema(UserLoginSchemaBase):
     email = fields.Email(required=True, allow_none=False)
     additional_info = fields.Str(required=True, allow_none=False)
     feed_quality = fields.Str(required=True, allow_none=False)
-    requested_on = fields.DateTime(required=True)
+    requested_on = UTCDateTime(required=True)
     disabled = fields.Boolean(required=True, allow_none=False)
     pending = fields.Boolean(required=True, allow_none=False)
     groups = fields.Nested(GroupItemResponseSchema, many=True, required=True, allow_none=False)
@@ -89,9 +90,9 @@ class UserSuccessResponseSchema(UserLoginSchemaBase):
 class UserOwnProfileResponseSchema(UserLoginSchemaBase):
     email = fields.Email(required=True, allow_none=False)
 
-    registered_on = fields.DateTime(required=True)
-    logged_on = fields.DateTime(required=True)
-    set_password_on = fields.DateTime(required=True)
+    registered_on = UTCDateTime(required=True)
+    logged_on = UTCDateTime(required=True)
+    set_password_on = UTCDateTime(required=True)
 
     capabilities = fields.List(fields.Str(), required=True, allow_none=False)
     groups = fields.Nested(GroupBasicResponseSchema, many=True, required=True, allow_none=False)
@@ -101,5 +102,5 @@ class UserOwnProfileResponseSchema(UserLoginSchemaBase):
 class UserProfileResponseSchema(UserLoginSchemaBase):
     email = fields.Email(required=True, allow_none=False)
 
-    registered_on = fields.DateTime(required=True)
-    logged_on = fields.DateTime(required=True)
+    registered_on = UTCDateTime(required=True)
+    logged_on = UTCDateTime(required=True)

--- a/mwdb/schema/utils.py
+++ b/mwdb/schema/utils.py
@@ -1,0 +1,14 @@
+from datetime import datetime, timezone
+from marshmallow import fields
+
+
+class UTCDateTime(fields.DateTime):
+    """
+    Naive timestamps were serialized by Marshmallow 2.x as UTC.
+    As we're using 3.x and timestamps from database are UTC without tzinfo.
+    we need to recover 2.x behavior.
+    """
+    def _serialize(self, value, *args, **kwargs):
+        if value and isinstance(value, datetime) and value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return super()._serialize(value, *args, **kwargs)


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

- Important fact: timestamps are stored in database as offset-naive UTC timestamps (without timezone information)
- Marshmallow 3.x stopped serializing naive datetimes as UTC (https://marshmallow.readthedocs.io/en/stable/upgrading.html#datetime-leaves-timezone-information-untouched-during-serialization). Frontend still expects getting timestamps with timezone information (`+00:00`) and timestamps without that are treated as local time.
- In addition: we're not consistent in how we get current date/time (`func.now`, `datetime.now()`, `datetime.utcnow()`).

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

- Every "now" is using `datetime.utcnow()`
- Added custom field `UTCDateTime` that recovers the 2.x Marshmallow behavior
