### PR TITLE
Raising Bad Request when there are other keys on the same level as in…

### DIFF
--- a/mwdb/resources/config.py
+++ b/mwdb/resources/config.py
@@ -119,6 +119,8 @@ class ConfigUploader(ObjectUploader):
                     blob_obj = self._get_embedded_blob(second["in-blob"], share_with, metakeys)
                     config[first]["in-blob"] = blob_obj.dhash
                     blobs.append(blob_obj)
+                elif isinstance(second, dict) and ("in-blob" in list(second.keys())):
+                    raise BadRequest("'in-blob' should be the only key")
 
             obj, is_new = Config.get_or_create(
                 config,


### PR DESCRIPTION
…-blob (sibilings)

<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
It is possible to add other keys than in-blob in config on the same level (as siblings).

**What is the new behaviour?**
It is not possible to add other keys than in-blob in config on the same level (as siblings).

**Test plan**
Add config with in-blob with other keys on the same level in dictionary.

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #197
