### PR TITLE
Added adding_configs capability and changing test

### DIFF
--- a/mwdb/core/capabilities.py
+++ b/mwdb/core/capabilities.py
@@ -12,6 +12,7 @@ class Capabilities(object):
     adding_all_attributes = "adding_all_attributes"
     managing_attributes = "managing_attributes"
     removing_attributes = "removing_attributes"
+    adding_configs = "adding_configs"
     adding_blobs = "adding_blobs"
     unlimited_requests = "unlimited_requests"
     removing_objects = "removing_objects"

--- a/mwdb/resources/config.py
+++ b/mwdb/resources/config.py
@@ -187,6 +187,7 @@ class ConfigResource(ObjectResource, ConfigUploader):
         return super().get()
 
     @requires_authorization
+    @requires_capabilities(Capabilities.adding_configs)
     def post(self):
         """
         ---

--- a/mwdb/web/src/components/Capabilities.js
+++ b/mwdb/web/src/components/Capabilities.js
@@ -15,6 +15,7 @@ export let capabilitiesList = {
     "adding_all_attributes": "Can add all attributes to object",
     "managing_attributes": "Can define new attributes and manage them",
     "removing_attributes": "Can remove attribute from objects",
+    "adding_configs": "Can upload configs",
     "adding_blobs": "Can upload text blobs",
     "unlimited_requests": "API requests are not rate-limited for this group",
     "removing_objects": "Can remove objects",

--- a/tests/backend/test_config.py
+++ b/tests/backend/test_config.py
@@ -4,7 +4,7 @@ from .relations import *
 def test_adding_config_with_inblobs():
     testCase = RelationTestCase()
 
-    Alice = testCase.new_user("Alice", capabilities=["reading_blobs", "adding_blobs"])
+    Alice = testCase.new_user("Alice", capabilities=["reading_blobs", "adding_blobs", "adding_configs"])
 
     config_json = {
         "cnc": [1, 2, 3],


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [x] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
The is no adding_configs capability so anyone can upload configs.

**What is the new behaviour?**
Only users with adding_configs capability can upload configs.

**Test plan**
Try to upload config with user that has no adding_configs capability and then try to add it with one that has.

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #187
