### PR TITLE
Modified mail templates to be more generic

### DIFF
--- a/mwdb/templates/mail/pending.txt
+++ b/mwdb/templates/mail/pending.txt
@@ -1,11 +1,8 @@
 Hi {login},
 
-Your MWDB account is waiting for acceptance. Please remember that all submissions are reviewed manually, so the
-approval process can take a few days before you receive access to the MWDB system.
+Your mwdb-core account is waiting for acceptance.
 
-Meanwhile, please read Terms of Use of the MWDB System: {base_url}/terms/en
+Please remember that all submissions are reviewed manually by mwdb-core administrator,
+so the approval process can take some time before you receive access to the mwdb-core system.
 
-In case of any questions, feel free to contact us via our e-mail address: info@cert.pl.
-
-Regards,
-CERT.pl
+Contact your mwdb-core administrator for details.

--- a/mwdb/templates/mail/recover.txt
+++ b/mwdb/templates/mail/recover.txt
@@ -7,8 +7,3 @@ Set password link: {base_url}/setpasswd/{set_password_token}
 If you didn't request a password change, you can ignore this message
 and continue to use your current password. Someone probably typed in
 your email address by accident.
-
-In case of any questions, feel free to contact us via our e-mail address: info@cert.pl.
-
-Regards,
-CERT.pl

--- a/mwdb/templates/mail/register.txt
+++ b/mwdb/templates/mail/register.txt
@@ -1,13 +1,8 @@
 Hi {login},
 
-Your MWDB account has been successfully registered. Here are your credentials:
+Your mwdb-core account has been successfully registered.
+
+Here are your credentials:
 
 Login: {login}
 Set password link: {base_url}/setpasswd/{set_password_token}
-
-Before using MWDB service, make sure you've read our Terms Of Use: {base_url}/terms/en.
-
-In case of any questions, feel free to contact us via our e-mail address: info@cert.pl.
-
-Regards,
-CERT.pl

--- a/mwdb/templates/mail/rejection.txt
+++ b/mwdb/templates/mail/rejection.txt
@@ -1,20 +1,7 @@
 Hi {login},
 
-We appreciate that you took the time to apply for MWDB account. Unfortunately, your application did not conform to our Terms of Service ({base_url}/terms/en).
+We appreciate that you took the time to apply for mwdb-core account.
 
-Due to limited resources on our side, we're accepting requests from:
-- Independent researchers with documented, public malware research;
-- IT security specialists employed in company focused on malware analysis;
-- Specialists employed in public IT security institutions (for example national CSIRTs, banks, government institutions etc.);
+Unfortunately, your request for account registration has been rejected.
 
-Unfortunately we're not open for small-business administrators, local ISPs and students without documented malware research.
-
-You can also improve your account request by filling up form with links to your articles and write-ups from analysis.
-
-Also remember that business e-mail is preferable. If you're an independent researcher and want to use private email address,
-please confirm your identity with an account related to your research – for example, with a Twitter message to @CERT_Polska_en;
-
-Thank you for interest. In case of any questions, feel free to contact us via our e-mail address: info@cert.pl.
-
-Regards,
-CERT.pl
+Contact your mwdb-core administrator for details.


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**What is the current behaviour?**
<!-- Explain how the code works currently -->

Currently the default mail templates for mwdb-core are templates made for mwdb.cert.pl service.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

Mail templates are more suitable for custom mwdb-core instances.

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #196 

**Warning!**
We need to adapt mwdb.cert.pl deployment to use custom templates before we deploy changes from this PR!