### PR TITLE
Fix user permissions button visibility

### DIFF
--- a/mwdb/web/src/components/UserUpdate.js
+++ b/mwdb/web/src/components/UserUpdate.js
@@ -257,12 +257,12 @@ class UserUpdate extends Component {
                                         c => <li>{capabilitiesList[c]} (inherited from: {this.inheritedFrom(c).join(", ")})</li>)
                                 }
                                 </ul>
-                                <Link to={`/group/${this.props.match.params.login}`}>
-                                    <button type="button" className="btn btn-primary">Set user permissions</button>
-                                </Link>
                             </React.Fragment>
                         : []
                     }
+                        <Link to={`/group/${this.props.match.params.login}`}>
+                            <button type="button" className="btn btn-primary">Set user permissions</button>
+                        </Link>
                     </div>
 
                     <h4>Groups</h4>


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
Set user permissions button is not visible when user doesn't have any capability

**What is the new behaviour?**
Set user permissions button is always visible

**Closing issues**
closes #212