### PR TITLE
Add support for mail server authentication

### DIFF
--- a/docs/developer-guide.rst
+++ b/docs/developer-guide.rst
@@ -38,7 +38,7 @@ Development environment is configured to use `Mailhog <https://github.com/mailho
 
 Mailhog provides very convenient webmail collecting all outgoing e-mails which are available here: http://127.0.0.1:8025
 
-You may also add any external SMTP server using the following enviornment variables:
+You may also add any external SMTP server using the following environment variables:
 
 .. code-block::
 
@@ -107,4 +107,3 @@ If you need to write change on your own e.g. because you need to migrate data in
 
    Alembic migrations generated inside container will be owned by root.
    If you have problem with permissions, use ``chown`` inside container to change the owner to your local UID.
-

--- a/docs/developer-guide.rst
+++ b/docs/developer-guide.rst
@@ -41,6 +41,7 @@ Mailhog provides very convenient webmail collecting all outgoing e-mails which a
 You may also add any external SMTP server using the following enviornment variables:
 
 .. code-block::
+
     MWDB_MAIL_SMTP = "smtp_server:port"
     MWDB_MAIL_FROM = "name@example.com"
     MWDB_MAIL_USERNAME = "your_username" # optional

--- a/docs/developer-guide.rst
+++ b/docs/developer-guide.rst
@@ -38,6 +38,15 @@ Development environment is configured to use `Mailhog <https://github.com/mailho
 
 Mailhog provides very convenient webmail collecting all outgoing e-mails which are available here: http://127.0.0.1:8025
 
+You may also add any external SMTP server using the following enviornment variables:
+
+.. code-block::
+    MWDB_MAIL_SMTP = "smtp_server:port"
+    MWDB_MAIL_FROM = "name@example.com"
+    MWDB_MAIL_USERNAME = "your_username" # optional
+    MWDB_MAIL_PASSWORD = "your_password" # optional
+    MWDB_MAIL_TLS = 1 # Enables StartTLS, optional, defaults to 0
+
 Auto generating Alembic migrations
 ----------------------------------
 

--- a/mwdb/core/config.py
+++ b/mwdb/core/config.py
@@ -64,6 +64,9 @@ class MWDBConfig(Config):
     mail_smtp = key(cast=str, required=False)
     mail_from = key(cast=str, required=False, default="noreply@mwdb")
     mail_templates_folder = key(cast=path, required=False, default=mail_templates_dir)
+    mail_username = key(cast=str, required=False)
+    mail_password = key(cast=str, required=False)
+    mail_tls = key(cast=intbool, required=False, default=False)
 
     recaptcha_site_key = key(cast=str, required=False)
     recaptcha_secret = key(cast=str, required=False)

--- a/mwdb/core/mail.py
+++ b/mwdb/core/mail.py
@@ -68,7 +68,7 @@ def send_email_notification(kind, subject, recipient_email, **params):
                 s.starttls()
  
             if username and password:
-                s.login(username,password)
+                s.login(username, password)
 
             s.send_message(message)
     except Exception as e:

--- a/mwdb/core/mail.py
+++ b/mwdb/core/mail.py
@@ -57,8 +57,18 @@ def send_email_notification(kind, subject, recipient_email, **params):
     else:
         smtp_host = mail_smtp
         smtp_port = 25
+    
+    username = app_config.mwdb.mail_username
+    password = app_config.mwdb.mail_password
+    tls = app_config.mwdb.mail_tls
+
     try:
         with smtplib.SMTP(smtp_host, int(smtp_port), timeout=3) as s:
-            s.send_message(message)
+            if tls:
+                s.starttls()
+ 
+            if username and password:
+                s.login(username,password)
+                s.send_message(message)
     except Exception as e:
         raise MailError("Sending mail notification failed") from e

--- a/mwdb/core/mail.py
+++ b/mwdb/core/mail.py
@@ -69,6 +69,7 @@ def send_email_notification(kind, subject, recipient_email, **params):
  
             if username and password:
                 s.login(username,password)
-                s.send_message(message)
+
+            s.send_message(message)
     except Exception as e:
         raise MailError("Sending mail notification failed") from e

--- a/mwdb/templates/mwdb.ini.tmpl
+++ b/mwdb/templates/mwdb.ini.tmpl
@@ -69,6 +69,13 @@ base_url = {{ base_url }}
 
 # mail_from = "noreply@mwdb.local"
 
+# mail_username = "username"
+
+# mail_password = "password"
+
+# Enable StartTLS connection
+# mail_tls = 1
+
 # Path to mail templates used by registration features (default: served from package bundle)
 # If you want to use customized mail templates:
 # 1. Uncomment line below


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [X] I've read the [contributing guideline](CONTRIBUTING.md).
- [X] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [X] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
Mail features are supported without authentication or StartTLS, which limits the use to a local mail server

**What is the new behaviour?**
Added support for : Username, Password and StartTLS.
All are optional, and can be set using environment variables, and are part of MWDBConfig. 

**Test plan**
Testing this feature requires actually using an external service with authentication.
Was tested manually.

**Closing issues**

closes #223 
