### PR TITLE
Added support for array search in frontend + backend improvements

### DIFF
--- a/mwdb/core/search/fields.py
+++ b/mwdb/core/search/fields.py
@@ -258,11 +258,14 @@ class JSONField(BaseField):
             field = field.replace('"', '\\"')
             # Find trailing non-escaped asterisks
             asterisk_r = re.search(r"(?<!\\)([*]+)$", field)
-            asterisk_levels = len(asterisk_r.group(0)) if asterisk_r else 0
-            field = field[:-asterisk_levels]
-            asterisks = asterisk_levels * "[*]"
+            if not asterisk_r:
+                asterisks = ""
+            else:
+                asterisk_levels = len(asterisk_r.group(0))
+                field = field[:-asterisk_levels]
+                asterisks = asterisk_levels * "[*]"
             # Unescape all escaped asterisks
-            field = re.sub(r"\\[*]", "*", field)
+            field = re.sub(r"(?<!\\)\\[*]", "*", field)
             return f'"{field}"{asterisks}'
 
         """

--- a/mwdb/core/search/fields.py
+++ b/mwdb/core/search/fields.py
@@ -253,20 +253,17 @@ class JSONField(BaseField):
         value = get_term_value(expression)
 
         def jsonpath_escape(field):
-            # Escapes field to be correctly represented in jsonpath
-            asterisk = ""
+            """Escapes field to be correctly represented in jsonpath"""
             # Escape all double quotes
             field = field.replace('"', '\\"')
-            if field.endswith("*"):
-                # If asterisk is escaped: remove the escape
-                if field[-2] == "\\" and field[-3] != "\\":
-                    # aaaa\* -> "aaaa*"
-                    field = field[:-2] + "*"
-                else:
-                    # aaaa* -> "aaaa"[*]
-                    asterisk = "[*]"
-                    field = field[:-1]
-            return f'"{field}"{asterisk}'
+            # Find trailing non-escaped asterisks
+            asterisk_r = re.search(r"(?<!\\)([*]+)$", field)
+            asterisk_levels = len(asterisk_r.group(0)) if asterisk_r else 0
+            field = field[:-asterisk_levels]
+            asterisks = asterisk_levels * "[*]"
+            # Unescape all escaped asterisks
+            field = re.sub(r"\\[*]", "*", field)
+            return f'"{field}"{asterisks}'
 
         """
         Target query:

--- a/mwdb/core/search/fields.py
+++ b/mwdb/core/search/fields.py
@@ -257,7 +257,7 @@ class JSONField(BaseField):
             # Escape all double quotes
             field = field.replace('"', '\\"')
             # Find trailing non-escaped asterisks
-            asterisk_r = re.search(r"(?<!\\)([*]+)$", field)
+            asterisk_r = re.search(r"(?<!\\)(?:\\\\)*([*]+)$", field)
             if not asterisk_r:
                 asterisks = ""
             else:
@@ -265,7 +265,7 @@ class JSONField(BaseField):
                 field = field[:-asterisk_levels]
                 asterisks = asterisk_levels * "[*]"
             # Unescape all escaped asterisks
-            field = re.sub(r"(?<!\\)\\[*]", "*", field)
+            field = re.sub(r"(?<!\\)(?:\\\\)*(\\[*])", "*", field)
             return f'"{field}"{asterisks}'
 
         """

--- a/mwdb/web/src/commons/helpers/search.js
+++ b/mwdb/web/src/commons/helpers/search.js
@@ -33,12 +33,6 @@ export function makeSearchLink(field, input, noEscape, endpoint){
     return `/${endpoint === undefined ? "search" : endpoint}?q=`+encodeSearchQuery(prefix + input);
 };
 
-export function makeSearchConfigElementLink(element, value) {
-    if(value !== undefined)
-        return makeSearchLink("cfg", `*"${element}": ${escapeSearchValue(value)}*`, false, "configs")
-    return makeSearchLink("cfg", `*${escapeSearchValue(element)}*`, false, "configs")
-}
-
 export function makeSearchRangeLink(field, from, to, endpoint) {
     return makeSearchLink(field, `[${escapeSearchValue(from)} TO ${escapeSearchValue(to)}]`, true, endpoint)
 }

--- a/tests/backend/test_search.py
+++ b/tests/backend/test_search.py
@@ -174,6 +174,9 @@ def test_search_json():
         },
         "array": [
             1, 2, 3
+        ],
+        "array*array": [
+            1, [2, 3]
         ]
     })
 
@@ -206,6 +209,15 @@ def test_search_json():
 
     found_objs = test.search('config.cfg:"*\\"dict_in_list\\": \\"xxx\\"*"')
     assert len(found_objs) == 0
+
+    found_objs = test.search('config.cfg.array\\*array*:1')
+    assert len(found_objs) == 1
+
+    found_objs = test.search('config.cfg.array\\*array*:2')
+    assert len(found_objs) == 0
+
+    found_objs = test.search('config.cfg.array\\*array**:2')
+    assert len(found_objs) == 1
 
 
 def test_search_file_size_unbounded():


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [x] I've added automated tests for my change (if applicable, optional)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- Frontend still uses wildcards for querying elements inside lists
- We don't support lists in lists

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- When clicked on array element, MWDB will use
    ```
    cfg.url*:"https://example.com/wp-content/J/"
    ```
    syntax instead of
    ```
    cfg:"*\"https://example.com/wp-content/J/\"*"
    ```
- Support for `cfg.array-in-array**:2` for querying that kind of stuff:
```
{
    "array-in-array": [
        [2, 3, 4],
        [5, 6, 7]
    ]
}
```

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #180 
