### PR TITLE
Fix: Require adding_configs for legacy config upload endpoint

### DIFF
--- a/mwdb/resources/config.py
+++ b/mwdb/resources/config.py
@@ -287,6 +287,7 @@ class ConfigItemResource(ObjectItemResource, ConfigUploader):
         return super().get(identifier)
 
     @requires_authorization
+    @requires_capabilities(Capabilities.adding_configs)
     def put(self, identifier):
         """
         ---


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

- `adding_configs` requirement for uploading configuration is not enforced if user has been used legacy upload endpoint (`PUT /config/<parent hash>`) e.g. using older version of mwdblib.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- `PUT /config/<parent hash>` returns 403 when user doesn't have `adding_configs` capability
