### PR TITLE
Create NamedTemporaryFile during file upload

### DIFF
--- a/mwdb/core/util.py
+++ b/mwdb/core/util.py
@@ -58,9 +58,8 @@ def calc_hash(stream, hash_obj, digest_cb):
     return digest_cb(hash_obj)
 
 
-def calc_magic(stream):
-    stream.seek(0, os.SEEK_SET)
-    return magic.from_buffer(stream.read())
+def calc_magic(filename):
+    return magic.from_file(filename)
 
 
 def calc_ssdeep(stream):

--- a/mwdb/model/file.py
+++ b/mwdb/model/file.py
@@ -93,7 +93,10 @@ class File(Object):
                         app_config.mwdb.s3_storage_secret_key,
                         app_config.mwdb.s3_storage_region_name,
                         app_config.mwdb.s3_storage_secure,
-                    ).put_object(app_config.mwdb.s3_storage_bucket_name, file_obj._calculate_path(), file, file_size)
+                    ).put_object(app_config.mwdb.s3_storage_bucket_name,
+                                 file_obj._calculate_path(),
+                                 file.stream,
+                                 file_size)
                 else:
                     file.save(file_obj._calculate_path())
         except:

--- a/mwdb/model/object.py
+++ b/mwdb/model/object.py
@@ -362,6 +362,14 @@ class Object(db.Model):
         # Well.. I've tried
         return None
 
+    def release_after_upload(self):
+        """
+        Release resources acquired by upload.
+
+        Currently used only by File to close NamedTemporaryFile.
+        """
+        return
+
     def get_tags(self):
         """
         Get object tags

--- a/mwdb/resources/object.py
+++ b/mwdb/resources/object.py
@@ -76,14 +76,17 @@ class ObjectUploader:
 
         item, is_new = self._create_object(params, parent_object, share_with, metakeys)
 
-        db.session.commit()
+        try:
+            db.session.commit()
 
-        if is_new:
-            hooks.on_created_object(item)
-            self.on_created(item)
-        else:
-            hooks.on_reuploaded_object(item)
-            self.on_reuploaded(item)
+            if is_new:
+                hooks.on_created_object(item)
+                self.on_created(item)
+            else:
+                hooks.on_reuploaded_object(item)
+                self.on_reuploaded(item)
+        finally:
+            item.release_after_upload()
 
         logger.info(f'{self.ObjectType.__name__} added', extra={
             'dhash': item.dhash,
@@ -236,6 +239,7 @@ class ObjectItemResource(Resource, ObjectUploader):
 
     @requires_authorization
     def post(self, identifier):
+        # Deprecated
         if self.ObjectType is Object:
             raise MethodNotAllowed()
 
@@ -246,6 +250,7 @@ class ObjectItemResource(Resource, ObjectUploader):
 
     @requires_authorization
     def put(self, identifier):
+        # Deprecated
         return self.post(identifier)
 
     @requires_authorization


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

mwdb-core 2.0.0 stored the files using local file system, so we could assume that we're always able to return the valid path for the uploaded file. 2.1.0 introduced support for S3-compatible object storage which breaks that assumption.

The preferred way to access the file is stream, but some libraries/plugins can only use the buffer or path. That's why they use `get_path` to access the just uploaded file. Unfortunately, the `get_path` method was removed by object storage PR, because it was no longer valid.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
File contents are temporarily stored in NamedTemporaryFile which is passed as a reference via `temp_file` attribute. File path is returned by the reimplemented `get_path` method.

`release_after_upload` method was added to ensure that NamedTemporaryFile will be deleted after all.

It's pretty hacky because in worst case the file is stored three times on disk (Werkzeug's TemporaryFile, NamedTemporaryFile and the actual file in `uploads/`) but currently I don't have better idea 🤔 

**Test plan**
<!-- Explain how to test your changes -->

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #24