### PR TITLE
File.get_path and other changes in File interface

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -32,12 +32,13 @@ services:
       MWDB_RECAPTCHA_SITE_KEY: "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"
       MWDB_RECAPTCHA_SECRET: "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe"
       MWDB_ENABLE_REGISTRATION: 1
-      MWDB_STORAGE_PROVIDER: s3
-      MWDB_HASH_PATHING: 0
-      MWDB_S3_STORAGE_ENDPOINT: "minio:9000"
-      MWDB_S3_STORAGE_ACCESS_KEY: "mwdb-test-access"
-      MWDB_S3_STORAGE_SECRET_KEY: "mwdb-test-key"
-      MWDB_S3_STORAGE_BUCKET_NAME: "mwdb"
+      # Uncomment if you want to test S3 functions
+      # MWDB_STORAGE_PROVIDER: s3
+      # MWDB_HASH_PATHING: 0
+      # MWDB_S3_STORAGE_ENDPOINT: "minio:9000"
+      # MWDB_S3_STORAGE_ACCESS_KEY: "mwdb-test-access"
+      # MWDB_S3_STORAGE_SECRET_KEY: "mwdb-test-key"
+      # MWDB_S3_STORAGE_BUCKET_NAME: "mwdb"
     volumes:
       - "./docker/mail_templates:/app/mail_templates"
       - "./mwdb:/app/mwdb"

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -2,6 +2,16 @@
 
 version: "3.3"
 services:
+  minio:
+    image: minio/minio
+    command: server /data
+    volumes:
+      - /tmp/minio:/data
+    ports:
+      - "127.0.0.1:9000:9000"
+    environment:
+      - MINIO_ACCESS_KEY=mwdb-test-access
+      - MINIO_SECRET_KEY=mwdb-test-key
   mwdb:
     build:
       context: .
@@ -9,6 +19,7 @@ services:
     depends_on:
       - postgres
       - redis
+      - minio
     restart: on-failure
     env_file:
       # NOTE: use gen_vars.sh in order to generate this file
@@ -21,6 +32,12 @@ services:
       MWDB_RECAPTCHA_SITE_KEY: "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"
       MWDB_RECAPTCHA_SECRET: "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe"
       MWDB_ENABLE_REGISTRATION: 1
+      MWDB_STORAGE_PROVIDER: s3
+      MWDB_HASH_PATHING: 0
+      MWDB_S3_STORAGE_ENDPOINT: "minio:9000"
+      MWDB_S3_STORAGE_ACCESS_KEY: "mwdb-test-access"
+      MWDB_S3_STORAGE_SECRET_KEY: "mwdb-test-key"
+      MWDB_S3_STORAGE_BUCKET_NAME: "mwdb"
     volumes:
       - "./docker/mail_templates:/app/mail_templates"
       - "./mwdb:/app/mwdb"

--- a/mwdb/core/util.py
+++ b/mwdb/core/util.py
@@ -62,7 +62,7 @@ def calc_hash(stream, hash_obj, digest_cb):
 def get_fd_path(stream):
     """
     Return Unix path for file-like stream. Hack for libraries
-    not supporting the stream or file descriptor input.
+    that does not support a stream or file descriptor input.
     """
     try:
         return f"/proc/self/fd/{stream.fileno()}"
@@ -86,6 +86,7 @@ def calc_magic(stream):
             return magic.maybe_decode(magic.magic_buffer(magic_cookie, stream.read()))
     finally:
         magic.magic_close(magic_cookie)
+    return None
 
 
 def calc_ssdeep(stream):

--- a/mwdb/model/file.py
+++ b/mwdb/model/file.py
@@ -140,16 +140,17 @@ class File(Object):
         if type(self.upload_stream.name) is str:
             return self.upload_stream.name
 
-        try:
-            return get_fd_path(self.upload_stream)
-        except OSError:
-            # If not a file (BytesIO), copy contents to the named temporary file
-            tmpfile = tempfile.NamedTemporaryFile()
-            self.upload_stream.seek(0, os.SEEK_SET)
-            tmpfile.write(self.upload_stream.read())
-            self.upload_stream.close()
-            self.upload_stream = tmpfile
-            return self.upload_stream.name
+        fd_path = get_fd_path(self.upload_stream)
+        if fd_path:
+            return fd_path
+
+        # If not a file (BytesIO), copy contents to the named temporary file
+        tmpfile = tempfile.NamedTemporaryFile()
+        self.upload_stream.seek(0, os.SEEK_SET)
+        tmpfile.write(self.upload_stream.read())
+        self.upload_stream.close()
+        self.upload_stream = tmpfile
+        return self.upload_stream.name
 
     def open(self):
         """

--- a/mwdb/model/file.py
+++ b/mwdb/model/file.py
@@ -192,9 +192,8 @@ class File(Object):
         """
         fh = self.open()
         try:
-            if app_config.mwdb.storage_provider == StorageProviderType.S3:
-                for chunk in fh.stream(chunk_size):
-                    yield chunk
+            if hasattr(fh, "stream"):
+                yield from fh.stream(chunk_size)
             else:
                 while True:
                     chunk = fh.read(chunk_size)

--- a/mwdb/model/file.py
+++ b/mwdb/model/file.py
@@ -143,7 +143,7 @@ class File(Object):
         if not self.upload_stream:
             raise ValueError("Can't retrieve local path for this file")
 
-        if type(self.upload_stream.name) is str:
+        if isinstance(self.upload_stream.name, str) or isinstance(self.upload_stream, bytes):
             return self.upload_stream.name
 
         fd_path = get_fd_path(self.upload_stream)
@@ -171,7 +171,9 @@ class File(Object):
                 return io.BytesIO(self.upload_stream.getbuffer())
             else:
                 dupfd = os.dup(self.upload_stream.fileno())
-                return os.fdopen(dupfd, "rb")
+                stream = os.fdopen(dupfd, "rb")
+                stream.seek(0, os.SEEK_SET)
+                return stream
         if app_config.mwdb.storage_provider == StorageProviderType.S3:
             return get_minio_client(
                 app_config.mwdb.s3_storage_endpoint,

--- a/mwdb/model/file.py
+++ b/mwdb/model/file.py
@@ -53,7 +53,7 @@ class File(Object):
     @property
     def upload_stream(self):
         """
-        Stream with file contents if file is uploaded in current request.
+        Stream with file contents if a file is uploaded in current request.
 
         In that case, we don't need to download it from object storage.
         """

--- a/mwdb/model/object.py
+++ b/mwdb/model/object.py
@@ -362,6 +362,14 @@ class Object(db.Model):
         # Well.. I've tried
         return None
 
+    def release_after_upload(self):
+        """
+        Release additional resources used by uploaded file.
+
+        For objects other than File it's just no-op.
+        """
+        return
+
     def get_tags(self):
         """
         Get object tags

--- a/mwdb/resources/object.py
+++ b/mwdb/resources/object.py
@@ -76,14 +76,17 @@ class ObjectUploader:
 
         item, is_new = self._create_object(params, parent_object, share_with, metakeys)
 
-        db.session.commit()
+        try:
+            db.session.commit()
 
-        if is_new:
-            hooks.on_created_object(item)
-            self.on_created(item)
-        else:
-            hooks.on_reuploaded_object(item)
-            self.on_reuploaded(item)
+            if is_new:
+                hooks.on_created_object(item)
+                self.on_created(item)
+            else:
+                hooks.on_reuploaded_object(item)
+                self.on_reuploaded(item)
+        finally:
+            item.release_after_upload()
 
         logger.info(f'{self.ObjectType.__name__} added', extra={
             'dhash': item.dhash,

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ requests==2.24.0
 apispec[yaml,validation]==3.3.1
 bcrypt==3.1.4
 pycodestyle==2.4.0
-python-magic==0.4.15
+python-magic==0.4.18
 luqum==0.7.4
 logmatic-python==0.1.7
 click==6.7


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

File access interface needs to be improved, especially when S3 storage is used. 

mwdb-core 2.0.0 stored the files using local file system, so we could assume that we're always able to return the valid path for the uploaded file. 2.1.0 introduced support for S3-compatible object storage which breaks that assumption.

The preferred way to access the file is stream, but some libraries/plugins can only use the buffer or path. That's why they use get_path to access the just uploaded file. Unfortunately, the get_path method was removed by object storage PR, because it was no longer valid.

**What is the new behaviour?**

- File upload temporarily stores the reference to the original stream object in `model.File.upload_stream` so it can be reused by other methods called in the same request context
- Added `get_path` method which:
   - returns the local file path if local storage is used (disk)
   - If it's not a local file, retrieves the path of `upload_stream`. If it's anonymous file: returns `/proc/self/fd/{fileno}`
   - If it's not a file (BytesIO), stores the file in NamedTemporaryFile and puts the reference in the `upload_stream`. Then returns the path to the temporary file.
- `File.open` method tries to reuse the `upload_stream`. If it can be reused, duplicates the file descriptor (for files) or creates an independent copy of BytesIO (for in-memory streams). It prevents re-downloading the file from object storage if plugin just wants to access the currently uploaded file.

Other changes:
- `calc_magic` no longer loads the whole file into memory (closes #24). Waiting for PR https://github.com/ahupp/python-magic/pull/227 to simplify the code in the future.
- Added minio to dev environment to manually test the related features

**Test plan**
- Tested by uploading files in various sizes with enabled Minio storage
