### PR TITLE
Fix for 'joinedload' misuse introduced in 2.1.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,11 +17,11 @@
 # -- Project information -----------------------------------------------------
 
 project = 'mwdb-core'
-copyright = '2020, CERT Polska'
+copyright = '2021, CERT Polska'
 author = 'CERT Polska'
 
 # The full version, including alpha/beta/rc tags
-release = '2.1.1'
+release = '2.1.2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/mwdb/core/search/fields.py
+++ b/mwdb/core/search/fields.py
@@ -262,11 +262,13 @@ class UploaderField(BaseField):
 
         if g.auth_user.has_rights(Capabilities.manage_users):
             uploaders = (db.session.query(User)
-                         .options(joinedload(User.memberships, Member.group))
+                         .join(User.memberships)
+                         .join(Member.group)
                          .filter(Group.name == value)).all()
         else:
             uploaders = (db.session.query(User)
-                         .options(joinedload(User.memberships, Member.group))
+                         .join(User.memberships)
+                         .join(Member.group)
                          .filter(g.auth_user.is_member(Group.id))
                          .filter(or_(Group.name == value, User.login == value))).all()
             # Regular users can see only uploads to its own groups

--- a/mwdb/core/search/fields.py
+++ b/mwdb/core/search/fields.py
@@ -269,7 +269,10 @@ class UploaderField(BaseField):
             uploaders = (db.session.query(User)
                          .join(User.memberships)
                          .join(Member.group)
-                         .filter(g.auth_user.is_member(Group.id))
+                         .filter(and_(
+                            g.auth_user.is_member(Group.id),
+                            Group.name != "public"
+                         ))
                          .filter(or_(Group.name == value, User.login == value))).all()
             # Regular users can see only uploads to its own groups
             condition = and_(

--- a/mwdb/resources/user.py
+++ b/mwdb/resources/user.py
@@ -458,7 +458,8 @@ class UserProfileResource(Resource):
             user = db.session.query(User).filter(User.login == login).first()
         else:
             user = (db.session.query(User)
-                              .options(joinedload(User.memberships, Member.group))
+                              .join(User.memberships)
+                              .join(Member.group)
                               .filter(Group.name != "public")
                               .filter(g.auth_user.is_member(Group.id))
                               .filter(User.login == login)).first()

--- a/mwdb/version.py
+++ b/mwdb/version.py
@@ -4,5 +4,5 @@ try:
 except IOError:
     git_revision = ""
 
-app_version = "2.1.1"
+app_version = "2.1.2"
 app_build_version = f"{app_version}+{git_revision}" if git_revision else app_version

--- a/mwdb/web/package-lock.json
+++ b/mwdb/web/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mwdb-web",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/mwdb/web/package.json
+++ b/mwdb/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mwdb-web",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.0-14",

--- a/mwdb/web/src/commons/package.json
+++ b/mwdb/web/src/commons/package.json
@@ -2,7 +2,7 @@
     "name": "@mwdb-web/commons",
     "main": "index.js",
     "private": true,
-    "version": "2.1.1",
+    "version": "2.1.2",
     "dependencies": {
         "axios": "0.19.2",
         "identicon.js": "^2.3.2",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ Under the hood of mwdb.cert.pl service hosted by CERT.pl.
 """
 
 setup(name="mwdb-core",
-      version="2.1.1",
+      version="2.1.2",
       description="MWDB Core malware database",
       long_description=LONG_DESCRIPTION,
       author="CERT Polska",

--- a/tests/backend/test_search.py
+++ b/tests/backend/test_search.py
@@ -331,3 +331,51 @@ def test_child_mixed():
 
     found_objs = test.search(f'child:(config.cfg.config.field:test AND child:(file.size:7500 AND tag:{tag}))')
     assert len(found_objs) == 1 and found_objs[0]["id"] == sample["id"]
+
+
+def test_uploader_query():
+    admin_session = MwdbTest()
+    admin_session.login()
+
+    testCase = RelationTestCase()
+
+    Alice = testCase.new_user("Alice")
+    Bob = testCase.new_user("Bob")
+
+    Workgroup = testCase.new_group("Workgroup")
+
+    # Alice and Bob are in Workgroup
+    Workgroup.add_member(Alice)
+    Workgroup.add_member(Bob)
+
+    # FileA is created by Alice and shared with nobody else
+    FileA = testCase.new_sample("File")
+    FileA.create(Alice, upload_as=Alice.identity)
+    # FileB is created by Bob and shared with nobody else
+    FileB = testCase.new_sample("File")
+    FileB.create(Bob, upload_as=Bob.identity)
+    # FileC is created by Alice and shared with Public
+    FileC = testCase.new_sample("File")
+    FileC.create(Alice, upload_as="public")
+
+    # Alice looks for own files
+    results = [
+        result["id"] for result in
+        Alice.session().search(f"uploader:{Alice.identity}")
+    ]
+    assert sorted(results) == sorted([FileA.identity, FileC.identity])
+    # Bob looks for own files
+    results = [
+        result["id"] for result in
+        Bob.session().search(f"uploader:{Bob.identity}")
+    ]
+    assert sorted(results) == sorted([FileB.identity])
+    # Alice looks for files uploaded by Bob
+    results = Alice.session().search(f"uploader:{Bob.identity}")
+    assert len(results) == 0
+    # Bob looks for files uploaded by Alice
+    results = [
+        result["id"] for result in
+        Bob.session().search(f"uploader:{Alice.identity}")
+    ]
+    assert sorted(results) == sorted([FileC.identity])

--- a/tests/backend/test_search.py
+++ b/tests/backend/test_search.py
@@ -363,13 +363,13 @@ def test_uploader_query():
         result["id"] for result in
         Alice.session().search(f"uploader:{Alice.identity}")
     ]
-    assert sorted(results) == sorted([FileA.identity, FileC.identity])
+    assert sorted(results) == sorted([FileA.dhash, FileC.dhash])
     # Bob looks for own files
     results = [
         result["id"] for result in
         Bob.session().search(f"uploader:{Bob.identity}")
     ]
-    assert sorted(results) == sorted([FileB.identity])
+    assert sorted(results) == sorted([FileB.dhash])
     # Alice looks for files uploaded by Bob
     results = Alice.session().search(f"uploader:{Bob.identity}")
     assert len(results) == 0
@@ -378,4 +378,4 @@ def test_uploader_query():
         result["id"] for result in
         Bob.session().search(f"uploader:{Alice.identity}")
     ]
-    assert sorted(results) == sorted([FileC.identity])
+    assert sorted(results) == sorted([FileC.dhash])


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [x] I've added automated tests for my change (if applicable, optional)

**What is the current behaviour?**
- Bugs like #257 
- Users can see profiles of users out of their own groups (if they know the nickname). The information is not very detailed though, but it still should be considered as a bug.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- `uploader:` query works as expected
- `/profile/<user>` properly checks for user access permission.

**Review comments**
- Check another uses of `joinedload` introduced in 2.1.0: https://github.com/CERT-Polska/mwdb-core/compare/v2.0.0...v2.1.1

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #257 
