### PR TITLE
Fix: Disable multiple option in upload Dropzone

### DIFF
--- a/mwdb/web/src/components/Upload.js
+++ b/mwdb/web/src/components/Upload.js
@@ -141,7 +141,8 @@ export default class Upload extends Component {
                     <Dropzone className="dropzone-ready dropzone"
                               activeClassName="dropzone-active"
                               rejectClassName="dropzone-reject"
-                              onDrop={this.onDrop}>
+                              onDrop={this.onDrop}
+                              multiple={false}>
                         <div className="card">
                             <div className="card-body">
                                 <h5 className="card-title">


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
Upload file form allows to select multiple files although only the first one is accepted.

**What is the new behaviour?**
Disabled multiple option in react Dropzone component.

**Test plan**
<!-- Explain how to test your changes -->
Check if the upload component work fine

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #261 
