### PR TITLE
ShowObject: more universal tabPath extraction

### DIFF
--- a/mwdb/web/src/components/ShowObject/Views/ObjectBox.js
+++ b/mwdb/web/src/components/ShowObject/Views/ObjectBox.js
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { useHistory } from "react-router";
+import { useRouteMatch } from "react-router-dom";
 
 import { TabContext } from "@mwdb-web/commons/ui";
 
@@ -19,18 +20,16 @@ export default function ObjectBox(props) {
     const history = useHistory();
     const [Component, setComponent] = useComponentState(() => []);
     const [actions, setActions] = useState([]);
-
-    const tab = history.location.pathname.split("/")[3] || props.defaultTab;
-    const subTab = history.location.pathname.split("/")[4];
+    // /sample/:hash/details
+    // routePath => /sample/:hash
+    // tabPath => /details
+    const routePath = useRouteMatch().url;
+    const tabPath = history.location.pathname.slice(routePath.length);
+    const tab = tabPath.split("/")[1] || props.defaultTab;
+    const subTab = tabPath.split("/")[2];
 
     function getTabLink(tab, subtab) {
-        let pathElements = history.location.pathname.split("/");
-        let newPath = pathElements
-            .slice(0, 3)
-            .concat([tab])
-            .concat(subtab ? [subtab] : [])
-            .join("/");
-        return newPath;
+        return routePath + "/" + [tab].concat(subtab ? [subtab] : []).join("/");
     }
 
     const tabButtons = props.children;


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- `tab` and `subtab` extraction from path works only for `/<type>/<id>` paths, because param positions are hardcoded
- Tabs won't work correctly for routes that doesn't follow that path structure (e.g. `/remote/<remote_name>/<type>/<id>`)

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- pathname is splitted into `routePath` and `tabPath`, so there is no need to use fixed positions for tab parameters

**Test plan**
<!-- Explain how to test your changes -->
- Check if tabs in ShowSample still work

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

