### PR TITLE
Fix '/api/user' performance issues

### DIFF
--- a/mwdb/schema/user.py
+++ b/mwdb/schema/user.py
@@ -3,7 +3,7 @@ import re
 from marshmallow import Schema, ValidationError, fields, validates
 
 from .api_key import APIKeyListItemResponseSchema
-from .group import GroupBasicResponseSchema, GroupItemResponseSchema
+from .group import GroupBasicResponseSchema, GroupNameSchemaBase
 from .utils import UTCDateTime
 
 
@@ -74,7 +74,7 @@ class UserListItemResponseSchema(UserLoginSchemaBase):
     disabled = fields.Boolean(required=True, allow_none=False)
     pending = fields.Boolean(required=True, allow_none=False)
     groups = fields.Nested(
-        GroupItemResponseSchema, many=True, required=True, allow_none=False
+        GroupNameSchemaBase, many=True, required=True, allow_none=False
     )
 
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
UserListResource tries to return too much information which results in n+1 SQL queries.

```
UserListResponseSchema {
    users [
        UserListItemResponseSchema {
            ...
            groups [
                GroupItemResponseSchema {
                    ...
                    users [ <login> ]
                    admins [ <login> ]
                }
            ]
    ]
}
```

Because that endpoint is used in multiple places, it slows down Manage users, Set user and Set group views.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

Returning `GroupNameSchemaBase` instead of `GroupItemResponseSchema`, so `groups` collection exposes only `name` field. 

This is API breaking change, but applies only to the user management API which is usually not used directly by users. It also doesn't break the current frontend code.

**Test plan**
<!-- Explain how to test your changes -->
Check if 'Manage users' still works.
<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #234 
