### PR TITLE
Improvement: Search links instead of admin routes in SharesBox

### DIFF
--- a/mwdb/web/src/commons/ui/RefString.js
+++ b/mwdb/web/src/commons/ui/RefString.js
@@ -28,35 +28,3 @@ export default function RefString(props) {
         </div>
     );
 }
-
-// class RefString extends Component {
-//     render() {
-//         const reasonText =
-//             this.props.reason_type.charAt(0).toUpperCase() +
-//             this.props.reason_type.slice(1).toLowerCase();
-//         const objLink = this.props.related_object_dhash ? (
-//             <ObjectLink
-//                 type={this.props.related_object_type}
-//                 id={this.props.related_object_dhash}
-//                 inline
-//             />
-//         ) : (
-//             <span className="text-muted">(object deleted)</span>
-//         );
-//         const userLink = (
-//             <Link
-//                 to={makeSearchLink("uploader", this.props.related_user_login)}
-//             >
-//                 {this.props.related_user_login}
-//             </Link>
-//         );
-//
-//         return (
-//             <div>
-//                 {reasonText} {objLink} by {userLink}
-//             </div>
-//         );
-//     }
-// }
-//
-// export default RefString;

--- a/mwdb/web/src/commons/ui/RefString.js
+++ b/mwdb/web/src/commons/ui/RefString.js
@@ -1,30 +1,62 @@
-import React, { Component } from "react";
+import React from "react";
+import { Link } from "react-router-dom";
 import ObjectLink from "./ObjectLink";
+import { makeSearchLink } from "../helpers";
 
-class RefString extends Component {
-    render() {
-        const reasonText =
-            this.props.reason_type.charAt(0).toUpperCase() +
-            this.props.reason_type.slice(1).toLowerCase();
-        const objLink = this.props.related_object_dhash ? (
-            <ObjectLink
-                type={this.props.related_object_type}
-                id={this.props.related_object_dhash}
-                inline
-            />
-        ) : (
-            <span className="text-muted">(object deleted)</span>
-        );
-        const userLink = (
-            <ObjectLink type="user" id={this.props.related_user_login} />
-        );
+export default function RefString(props) {
+    const reasonText =
+        props.reason_type.charAt(0).toUpperCase() +
+        props.reason_type.slice(1).toLowerCase();
+    const objLink = props.related_object_dhash ? (
+        <ObjectLink
+            type={props.related_object_type}
+            id={props.related_object_dhash}
+            inline
+        />
+    ) : (
+        <span className="text-muted">(object deleted)</span>
+    );
+    const userLink = (
+        <Link to={makeSearchLink("uploader", props.related_user_login)}>
+            {props.related_user_login}
+        </Link>
+    );
 
-        return (
-            <div>
-                {reasonText} {objLink} by {userLink}
-            </div>
-        );
-    }
+    return (
+        <div>
+            {reasonText} {objLink} by {userLink}
+        </div>
+    );
 }
 
-export default RefString;
+// class RefString extends Component {
+//     render() {
+//         const reasonText =
+//             this.props.reason_type.charAt(0).toUpperCase() +
+//             this.props.reason_type.slice(1).toLowerCase();
+//         const objLink = this.props.related_object_dhash ? (
+//             <ObjectLink
+//                 type={this.props.related_object_type}
+//                 id={this.props.related_object_dhash}
+//                 inline
+//             />
+//         ) : (
+//             <span className="text-muted">(object deleted)</span>
+//         );
+//         const userLink = (
+//             <Link
+//                 to={makeSearchLink("uploader", this.props.related_user_login)}
+//             >
+//                 {this.props.related_user_login}
+//             </Link>
+//         );
+//
+//         return (
+//             <div>
+//                 {reasonText} {objLink} by {userLink}
+//             </div>
+//         );
+//     }
+// }
+//
+// export default RefString;

--- a/mwdb/web/src/components/ShowObject/Views/SharesBox.js
+++ b/mwdb/web/src/components/ShowObject/Views/SharesBox.js
@@ -1,14 +1,11 @@
 import React, { useState, useEffect, useCallback, useContext } from "react";
+import { Link } from "react-router-dom";
 import Autocomplete from "react-autocomplete";
 
 import api from "@mwdb-web/commons/api";
 import { ObjectContext } from "@mwdb-web/commons/context";
-import {
-    RefString,
-    DateString,
-    ObjectLink,
-    ConfirmationModal,
-} from "@mwdb-web/commons/ui";
+import { RefString, DateString, ConfirmationModal } from "@mwdb-web/commons/ui";
+import { makeSearchLink } from "@mwdb-web/commons/helpers";
 
 function ShareItem(props) {
     const context = useContext(ObjectContext);
@@ -23,7 +20,9 @@ function ShareItem(props) {
     return (
         <tr style={fieldStyle}>
             <td>
-                <ObjectLink type="group" id={props.group_name} />
+                <Link to={makeSearchLink("uploader", props.group_name)}>
+                    {props.group_name}
+                </Link>
                 {isCurrentObject && isUploader && (
                     <span className="ml-2">(uploader)</span>
                 )}


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [ ] I've read the [contributing guideline](CONTRIBUTING.md).
- [ ] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
In SharesBox there are routes to user/:login or group/:name.

**What is the new behaviour?**
Now there are Links that redirect to search with uploader field.

**Test plan**
Check sharesBox Links components, redirect to proper search query.

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->
#294 
