### PR TITLE
Bump click and remove pycodestyle from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,11 +12,10 @@ psycopg2-binary==2.8.5
 requests==2.24.0
 apispec[yaml,validation]==3.3.1
 bcrypt==3.1.4
-pycodestyle==2.4.0
 python-magic==0.4.18
 luqum==0.7.4
 logmatic-python==0.1.7
-click==6.7
+click==7.1.2
 click-default-group==1.2.2
 PyYAML==5.3.1
 redis==3.2.1


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is changed?**
- Depending on the pretty old 6.x version of click is not very convenient
- I don't really know why `pycodestyle` was a part of requirements, but it's not required anyway.