### PR TITLE
Remote API: Push and pull with share option

### DIFF
--- a/mwdb/resources/__init__.py
+++ b/mwdb/resources/__init__.py
@@ -3,10 +3,11 @@ from json import JSONDecodeError
 
 from flask import g, request
 from marshmallow import EXCLUDE, ValidationError
-from werkzeug.exceptions import BadRequest, Forbidden, Unauthorized
+from werkzeug.exceptions import BadRequest, Forbidden, NotFound, Unauthorized
 
 from mwdb.core import log
-from mwdb.model import Config, File, Object, TextBlob
+from mwdb.core.capabilities import Capabilities
+from mwdb.model import Config, File, Group, Object, TextBlob
 
 logger = log.getLogger()
 
@@ -99,3 +100,27 @@ def load_schema(request_data, schema):
         raise BadRequest(f"JSONDecodeError: {json_decode_err}")
 
     return obj
+
+
+def get_shares_group(upload_as):
+    if upload_as == "*":
+        # If '*' is provided: share with all user's groups except 'public'
+        share_with = [group for group in g.auth_user.groups if group.name != "public"]
+    elif upload_as == "private":
+        share_with = [Group.get_by_name(g.auth_user.login)]
+    else:
+        share_group = Group.get_by_name(upload_as)
+        # Does group exist?
+        if share_group is None:
+            raise NotFound(f"Group {upload_as} doesn't exist")
+        # Has user access to group?
+        if share_group not in g.auth_user.groups and not g.auth_user.has_rights(
+            Capabilities.sharing_objects
+        ):
+            raise NotFound(f"Group {upload_as} doesn't exist")
+        # Is group pending?
+        if share_group.pending_group is True:
+            raise NotFound(f"Group {upload_as} is pending")
+        share_with = [share_group, Group.get_by_name(g.auth_user.login)]
+
+    return share_with

--- a/mwdb/resources/__init__.py
+++ b/mwdb/resources/__init__.py
@@ -102,7 +102,11 @@ def load_schema(request_data, schema):
     return obj
 
 
-def get_shares_group(upload_as):
+def get_shares_for_upload(upload_as):
+    """
+    Translates 'upload_as' value from API into list of groups that
+    object will be shared with
+    """
     if upload_as == "*":
         # If '*' is provided: share with all user's groups except 'public'
         share_with = [group for group in g.auth_user.groups if group.name != "public"]

--- a/mwdb/resources/object.py
+++ b/mwdb/resources/object.py
@@ -18,7 +18,7 @@ from mwdb.schema.object import (
 )
 
 from . import (
-    get_shares_group,
+    get_shares_for_upload,
     get_type_from_str,
     load_schema,
     logger,
@@ -70,7 +70,7 @@ class ObjectUploader:
                 )
 
         # Validate upload_as argument
-        share_with = get_shares_group(params["upload_as"])
+        share_with = get_shares_for_upload(params["upload_as"])
 
         item, is_new = self._create_object(params, parent_object, share_with, metakeys)
 

--- a/mwdb/resources/object.py
+++ b/mwdb/resources/object.py
@@ -8,7 +8,7 @@ from werkzeug.exceptions import BadRequest, Forbidden, MethodNotAllowed, NotFoun
 from mwdb.core.capabilities import Capabilities
 from mwdb.core.plugins import hooks
 from mwdb.core.search import SQLQueryBuilder, SQLQueryBuilderBaseException
-from mwdb.model import Group, MetakeyDefinition, Object, db
+from mwdb.model import MetakeyDefinition, Object, db
 from mwdb.schema.object import (
     ObjectCountRequestSchema,
     ObjectCountResponseSchema,
@@ -18,6 +18,7 @@ from mwdb.schema.object import (
 )
 
 from . import (
+    get_shares_group,
     get_type_from_str,
     load_schema,
     logger,
@@ -69,26 +70,7 @@ class ObjectUploader:
                 )
 
         # Validate upload_as argument
-        upload_as = params["upload_as"]
-        if upload_as == "*":
-            # If '*' is provided: share with all user's groups except 'public'
-            share_with = [
-                group for group in g.auth_user.groups if group.name != "public"
-            ]
-        else:
-            share_group = Group.get_by_name(upload_as)
-            # Does group exist?
-            if share_group is None:
-                raise NotFound(f"Group {upload_as} doesn't exist")
-            # Has user access to group?
-            if share_group not in g.auth_user.groups and not g.auth_user.has_rights(
-                Capabilities.sharing_objects
-            ):
-                raise NotFound(f"Group {upload_as} doesn't exist")
-            # Is group pending?
-            if share_group.pending_group is True:
-                raise NotFound(f"Group {upload_as} is pending")
-            share_with = [share_group, Group.get_by_name(g.auth_user.login)]
+        share_with = get_shares_group(params["upload_as"])
 
         item, is_new = self._create_object(params, parent_object, share_with, metakeys)
 

--- a/mwdb/resources/remotes.py
+++ b/mwdb/resources/remotes.py
@@ -393,7 +393,7 @@ class RemoteFilePushResource(RemotePullResource):
             "file",
             files={
                 "file": (db_object.file_name, db_object.open()),
-                "options": json.dumps(options),
+                "options": (None, json.dumps(options)),
             },
         ).json()
         logger.info(

--- a/mwdb/resources/remotes.py
+++ b/mwdb/resources/remotes.py
@@ -112,7 +112,6 @@ class RemoteAPIResource(Resource):
 class RemotePullResource(Resource):
     ObjectType = None
     ItemResponseSchema = None
-    ShareRequestSchema = RemoteOptionsRequestSchema()
 
     on_created = None
     on_reuploaded = None
@@ -167,6 +166,12 @@ class RemoteFilePullResource(RemotePullResource):
               description: Object identifier (SHA256/SHA512/SHA1/MD5)
               schema:
                 type: string
+        requestBody:
+            required: false
+            description: Additional options for object pull
+            content:
+              application/json:
+                schema: RemoteOptionsRequestSchema
         responses:
             200:
                 description: Information about pulled file
@@ -184,7 +189,9 @@ class RemoteFilePullResource(RemotePullResource):
         response = remote.request("GET", f"file/{identifier}")
         file_name = response.json()["file_name"]
         response = remote.request("GET", f"file/{identifier}/download", stream=True)
-        options = loads_schema(request.get_data(as_text=True), self.ShareRequestSchema)
+        options = loads_schema(
+            request.get_data(as_text=True), RemoteOptionsRequestSchema()
+        )
         share_with = get_shares_for_upload(options["upload_as"])
         with SpooledTemporaryFile() as file_stream:
             for chunk in response.iter_content(chunk_size=2 ** 16):
@@ -231,6 +238,12 @@ class RemoteConfigPullResource(RemotePullResource):
               description: Config identifier
               schema:
                 type: string
+        requestBody:
+            required: false
+            description: Additional options for object pull
+            content:
+              application/json:
+                schema: RemoteOptionsRequestSchema
         responses:
             200:
                 description: Information about pulled config
@@ -250,7 +263,9 @@ class RemoteConfigPullResource(RemotePullResource):
         """
         remote = RemoteAPI(remote_name)
         config_spec = remote.request("GET", f"config/{identifier}").json()
-        options = loads_schema(request.get_data(as_text=True), self.ShareRequestSchema)
+        options = loads_schema(
+            request.get_data(as_text=True), RemoteOptionsRequestSchema()
+        )
         share_with = get_shares_for_upload(options["upload_as"])
         try:
             config = dict(config_spec["cfg"])
@@ -322,6 +337,12 @@ class RemoteTextBlobPullResource(RemotePullResource):
               description: Blob identifier
               schema:
                 type: string
+        requestBody:
+            required: false
+            description: Additional options for object pull
+            content:
+              application/json:
+                schema: RemoteOptionsRequestSchema
         responses:
             200:
                 description: Information about pulled text blob
@@ -336,7 +357,9 @@ class RemoteTextBlobPullResource(RemotePullResource):
         """
         remote = RemoteAPI(remote_name)
         spec = remote.request("GET", f"blob/{identifier}").json()
-        options = loads_schema(request.get_data(as_text=True), self.ShareRequestSchema)
+        options = loads_schema(
+            request.get_data(as_text=True), RemoteOptionsRequestSchema()
+        )
         share_with = get_shares_for_upload(options["upload_as"])
         try:
             item, is_new = TextBlob.get_or_create(
@@ -374,6 +397,12 @@ class RemoteFilePushResource(RemotePullResource):
               description: Object identifier (SHA256/SHA512/SHA1/MD5)
               schema:
                 type: string
+        requestBody:
+            required: false
+            description: Additional options for object push
+            content:
+              application/json:
+                schema: RemoteOptionsRequestSchema
         responses:
             200:
                 description: Information about pushed fie
@@ -387,7 +416,9 @@ class RemoteFilePushResource(RemotePullResource):
             raise NotFound("Object not found")
 
         remote = RemoteAPI(remote_name)
-        options = loads_schema(request.get_data(as_text=True), self.ShareRequestSchema)
+        options = loads_schema(
+            request.get_data(as_text=True), RemoteOptionsRequestSchema()
+        )
         response = remote.request(
             "POST",
             "file",
@@ -426,6 +457,12 @@ class RemoteConfigPushResource(RemotePullResource):
               description: Object identifier (SHA256/SHA512/SHA1/MD5)
               schema:
                 type: string
+        requestBody:
+            required: false
+            description: Additional options for object push
+            content:
+              application/json:
+                schema: RemoteOptionsRequestSchema
         responses:
             200:
                 description: Information about pushed config
@@ -457,7 +494,9 @@ class RemoteConfigPushResource(RemotePullResource):
                 }
 
         remote = RemoteAPI(remote_name)
-        options = loads_schema(request.get_data(as_text=True), self.ShareRequestSchema)
+        options = loads_schema(
+            request.get_data(as_text=True), RemoteOptionsRequestSchema()
+        )
         params = {
             "family": db_object.family,
             "cfg": config,
@@ -495,6 +534,12 @@ class RemoteTextBlobPushResource(RemotePullResource):
               description: Object identifier (SHA256/SHA512/SHA1/MD5)
               schema:
                 type: string
+        requestBody:
+            required: false
+            description: Additional options for object push
+            content:
+              application/json:
+                schema: RemoteOptionsRequestSchema
         responses:
             200:
                 description: Information about pushed text blob
@@ -508,7 +553,9 @@ class RemoteTextBlobPushResource(RemotePullResource):
             raise NotFound("Object not found")
 
         remote = RemoteAPI(remote_name)
-        options = loads_schema(request.get_data(as_text=True), self.ShareRequestSchema)
+        options = loads_schema(
+            request.get_data(as_text=True), RemoteOptionsRequestSchema()
+        )
         params = {
             "blob_name": db_object.blob_name,
             "blob_type": db_object.blob_type,

--- a/mwdb/schema/group.py
+++ b/mwdb/schema/group.py
@@ -8,10 +8,12 @@ class GroupNameSchemaBase(Schema):
 
     @validates("name")
     def validate_name(self, name):
-        if not re.match("^[A-Za-z0-9_-]{1,32}$", name):
+        print(name)
+        if not re.match("^[A-Za-z0-9_-]{1,32}$", name) or name.lower() == "private":
             raise ValidationError(
                 "Group should contain max 32 chars and include only "
                 "letters, digits, underscores and dashes"
+                "Group cannot be named private"
             )
 
 

--- a/mwdb/schema/group.py
+++ b/mwdb/schema/group.py
@@ -8,13 +8,13 @@ class GroupNameSchemaBase(Schema):
 
     @validates("name")
     def validate_name(self, name):
-        print(name)
-        if not re.match("^[A-Za-z0-9_-]{1,32}$", name) or name.lower() == "private":
+        if not re.match("^[A-Za-z0-9_-]{1,32}$", name):
             raise ValidationError(
                 "Group should contain max 32 chars and include only "
                 "letters, digits, underscores and dashes"
-                "Group cannot be named private"
             )
+        if name.lower() == "private":
+            raise ValidationError("Group cannot be named private")
 
 
 class GroupCreateRequestSchema(Schema):

--- a/mwdb/schema/remotes.py
+++ b/mwdb/schema/remotes.py
@@ -5,5 +5,5 @@ class RemotesListResponseSchema(Schema):
     remotes = fields.List(fields.Str())
 
 
-class RemoteShareRequestSchema(Schema):
+class RemoteOptionsRequestSchema(Schema):
     upload_as = fields.Str(required=True, allow_none=False)

--- a/mwdb/schema/remotes.py
+++ b/mwdb/schema/remotes.py
@@ -3,3 +3,7 @@ from marshmallow import Schema, fields
 
 class RemotesListResponseSchema(Schema):
     remotes = fields.List(fields.Str())
+
+
+class RemoteShareRequestSchema(Schema):
+    upload_as = fields.Str(required=True, allow_none=False)

--- a/mwdb/schema/remotes.py
+++ b/mwdb/schema/remotes.py
@@ -6,4 +6,4 @@ class RemotesListResponseSchema(Schema):
 
 
 class RemoteOptionsRequestSchema(Schema):
-    upload_as = fields.Str(required=True, allow_none=False)
+    upload_as = fields.Str(missing="*", allow_none=False)

--- a/mwdb/schema/user.py
+++ b/mwdb/schema/user.py
@@ -12,10 +12,12 @@ class UserLoginSchemaBase(Schema):
 
     @validates("login")
     def validate_login(self, value):
-        if not re.match("^[A-Za-z0-9_-]{1,32}$", value):
+        print(value)
+        if not re.match("^[A-Za-z0-9_-]{1,32}$", value) or value.lower() == "private":
             raise ValidationError(
                 "Login should contain max 32 chars and include only "
                 "letters, digits, underscores and dashes"
+                "User login cannot be named private"
             )
 
 

--- a/mwdb/schema/user.py
+++ b/mwdb/schema/user.py
@@ -12,13 +12,13 @@ class UserLoginSchemaBase(Schema):
 
     @validates("login")
     def validate_login(self, value):
-        print(value)
-        if not re.match("^[A-Za-z0-9_-]{1,32}$", value) or value.lower() == "private":
+        if not re.match("^[A-Za-z0-9_-]{1,32}$", value):
             raise ValidationError(
                 "Login should contain max 32 chars and include only "
                 "letters, digits, underscores and dashes"
-                "User login cannot be named private"
             )
+        if value.lower() == "private":
+            raise ValidationError("User cannot be named private")
 
 
 class UserCreateRequestSchema(Schema):

--- a/mwdb/web/src/commons/api/index.js
+++ b/mwdb/web/src/commons/api/index.js
@@ -354,12 +354,16 @@ function getRemoteNames() {
     return axios.get("/remote");
 }
 
-function pushObjectRemote(remote, type, identifier) {
-    return axios.post(`/remote/${remote}/push/${type}/${identifier}`);
+function pushObjectRemote(remote, type, identifier, upload_as) {
+    return axios.post(`/remote/${remote}/push/${type}/${identifier}`, {
+        upload_as: upload_as,
+    });
 }
 
-function pullObjectRemote(remote, type, identifier) {
-    return axios.post(`/remote/${remote}/pull/${type}/${identifier}`);
+function pullObjectRemote(remote, type, identifier, upload_as) {
+    return axios.post(`/remote/${remote}/pull/${type}/${identifier}`, {
+        upload_as: upload_as,
+    });
 }
 
 function getObjectRemote(remote, identifier) {

--- a/mwdb/web/src/components/Upload.js
+++ b/mwdb/web/src/components/Upload.js
@@ -112,7 +112,7 @@ export default class Upload extends Component {
     sharingModeToUploadParam = () => {
         if (this.state.shareWith === "default") return "*";
         if (this.state.shareWith === "public") return "public";
-        if (this.state.shareWith === "private") return this.context.user.login;
+        if (this.state.shareWith === "private") return "private";
         if (this.state.shareWith === "single") return this.state.group;
     };
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
You can pull and push object remote to and share it for all your groups by default

**What is the new behaviour?**
Now it is possible to choose share mode, and the remote actions forms was improved by validation

**Test plan**
Pull/push all type of object between local and remote instance with various sharing modes

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->
