### PR TITLE
Web: Reworked error/success handling a bit

### DIFF
--- a/mwdb/web/src/commons/ui/ErrorBoundary.js
+++ b/mwdb/web/src/commons/ui/ErrorBoundary.js
@@ -1,5 +1,4 @@
 import React, { Component } from "react";
-
 import { intersperse } from "../helpers";
 
 function getErrorMessage(error) {
@@ -36,41 +35,52 @@ export function Alert(props) {
     return <div />;
 }
 
-class ErrorBoundary extends Component {
-    constructor(props) {
-        super(props);
+function CriticalError(props) {
+    return (
+        <div className="container-fluid">
+            <div className="alert alert-danger" role="alert">
+                <h4 className="alert-heading">Critical error occurred</h4>
+                <p>
+                    Something really bad happened during rendering this view. If
+                    this is not your fault, let us know by leaving a bug report
+                    in{" "}
+                    <a href="https://github.com/CERT-Polska/mwdb-core/issues">
+                        Issues
+                    </a>
+                    <br />
+                    Remember to copy-paste the error message shown below to the
+                    bug report.
+                </p>
+                <hr />
+                <p className="mb-0">{props.error.toString()}</p>
+            </div>
+        </div>
+    );
+}
 
-        let error = props.error;
+export default class ErrorBoundary extends Component {
+    state = {};
 
-        if (!error) {
-            error = null;
-        }
-
-        this.state = { error: error };
+    static getDerivedStateFromProps(props) {
+        // Derived state for external critical errors
+        return { propsError: props.error };
     }
 
-    componentDidUpdate(prevProps, prevState, snapshot) {
-        if (this.props.error !== this.state.error) {
-            this.setState({ error: this.props.error });
-        }
-    }
-
-    componentDidCatch(error, info) {
-        this.setState({ error: error });
+    static getDerivedStateFromError(error) {
+        // Derived state for render() errors
+        return { renderError: error };
     }
 
     render() {
-        if (this.state.error) {
-            // You can render any custom fallback UI
+        if (this.state.renderError)
+            return <CriticalError error={this.state.renderError} />;
+        else if (this.state.propsError) {
+            // Fallback to single Alert
             return (
                 <div className="container-fluid">
-                    <Alert error={this.state.error} />
+                    <Alert error={this.state.propsError} />
                 </div>
             );
-        }
-
-        return this.props.children;
+        } else return this.props.children;
     }
 }
-
-export default ErrorBoundary;

--- a/mwdb/web/src/commons/ui/ProtectedRoute.js
+++ b/mwdb/web/src/commons/ui/ProtectedRoute.js
@@ -1,7 +1,7 @@
 import React, { useContext } from "react";
 import { Route } from "react-router-dom";
 
-import ErrorBoundary from "./ErrorBoundary";
+import { Alert } from "./ErrorBoundary";
 
 import { AuthContext } from "../auth";
 
@@ -15,7 +15,9 @@ export default function ProtectedRoute(props) {
         return props.condition ? (
             <props.component {...renderProps} />
         ) : (
-            <ErrorBoundary error="You don't have permission to see that page" />
+            <div className="container-fluid">
+                <Alert error="You don't have permission to see that page" />
+            </div>
         );
     }
     return <Route {...props} component={undefined} render={routeRender} />;

--- a/mwdb/web/src/commons/ui/View.js
+++ b/mwdb/web/src/commons/ui/View.js
@@ -1,22 +1,49 @@
 import React from "react";
-import ErrorBoundary, { Alert } from "./ErrorBoundary";
+import { useLocation } from "react-router-dom";
+import { Alert } from "./ErrorBoundary";
 import { Extendable } from "../extensions";
 
-export default function View(props) {
-    let ident = props.ident;
+function ViewAlert(props) {
+    const locationState = useLocation().state || {};
     return (
-        <ErrorBoundary>
-            <div
-                className={props.fluid ? "container-fluid" : "container"}
-                style={props.style}
-            >
-                <Alert {...props} />
-                {ident ? (
-                    <Extendable ident={ident}>{props.children}</Extendable>
-                ) : (
-                    props.children
-                )}
-            </div>
-        </ErrorBoundary>
+        <Alert
+            success={props.success || locationState.success}
+            error={props.error || locationState.error}
+            warning={props.warning || locationState.warning}
+        />
+    );
+}
+
+export default function View(props) {
+    /**
+     * View component for all main views. Views shouldn't be nested.
+     * Properties spec:
+     *
+     * ident - identifier that makes View Extendable by plugins
+     * error/success/warning - shows alert with appropriate message
+     * location.state.error/success/warning - the same based on location.state
+     * showIf - allows to show view conditionally (e.g. if all required data are loaded)
+     * fluid - uses wide fluid view instead of default container
+     * style - custom container styling
+     */
+    const children = props.ident ? (
+        <Extendable ident={props.ident}>{props.children}</Extendable>
+    ) : (
+        props.children
+    );
+    // If condition is undefined => assume default true
+    const showIf = props.showIf === undefined || props.showIf;
+    return (
+        <div
+            className={props.fluid ? "container-fluid" : "container"}
+            style={props.style}
+        >
+            <ViewAlert
+                error={props.error}
+                success={props.success}
+                warning={props.warning}
+            />
+            {showIf ? children : []}
+        </div>
     );
 }

--- a/mwdb/web/src/components/AttributeUpdate.js
+++ b/mwdb/web/src/components/AttributeUpdate.js
@@ -454,7 +454,11 @@ class AttributeUpdate extends Component {
         );
 
         return (
-            <View error={this.state.error} success={success}>
+            <View
+                ident="attributeUpdate"
+                error={this.state.error}
+                success={success}
+            >
                 <ConfirmationModal
                     isOpen={this.state.isModalOpen}
                     onRequestClose={() => this.setState({ isModalOpen: false })}

--- a/mwdb/web/src/components/DiffTextBlob.js
+++ b/mwdb/web/src/components/DiffTextBlob.js
@@ -9,7 +9,7 @@ import "brace/mode/text";
 import "brace/theme/chrome";
 
 import { APIContext } from "@mwdb-web/commons/api/context";
-import { ErrorBoundary } from "@mwdb-web/commons/ui";
+import { View } from "@mwdb-web/commons/ui";
 import { useRemote } from "@mwdb-web/commons/remotes";
 
 class DiffTextBlobContentPresenter extends Component {
@@ -170,7 +170,7 @@ class DiffView extends Component {
             ? `/remote/${this.props.remote}`
             : "";
         return (
-            <ErrorBoundary error={this.state.error}>
+            <View fluid error={this.state.error}>
                 {this.state.current && this.state.previous ? (
                     <div className="card-body">
                         <div className="card-header">
@@ -239,7 +239,7 @@ class DiffView extends Component {
                 ) : (
                     []
                 )}
-            </ErrorBoundary>
+            </View>
         );
     }
 }

--- a/mwdb/web/src/components/ManageAttributes.js
+++ b/mwdb/web/src/components/ManageAttributes.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import { Link } from "react-router-dom";
 
 import api from "@mwdb-web/commons/api";
-import { ErrorBoundary, PagedList } from "@mwdb-web/commons/ui";
+import { PagedList, View } from "@mwdb-web/commons/ui";
 
 class ManageAttributes extends Component {
     state = {
@@ -43,32 +43,26 @@ class ManageAttributes extends Component {
 
     render() {
         return (
-            <div className="container-fluid">
-                <ErrorBoundary error={this.state.error}>
-                    <Link to="/attributes/new">
-                        <button type="button" className="btn btn-success">
-                            Define attribute
-                        </button>
-                    </Link>
-                    <PagedList
-                        listItem={MetakeyItem}
-                        columnNames={[
-                            "Key (Label)",
-                            "Description",
-                            "URL Template",
-                        ]}
-                        items={this.items.slice(
-                            (this.state.activePage - 1) * 10,
-                            this.state.activePage * 10
-                        )}
-                        itemCount={this.items.length}
-                        activePage={this.state.activePage}
-                        filterValue={this.state.keyFilter}
-                        onPageChange={this.handlePageChange}
-                        onFilterChange={this.handleFilterChange}
-                    />
-                </ErrorBoundary>
-            </div>
+            <View fluid error={this.state.error}>
+                <Link to="/attributes/new">
+                    <button type="button" className="btn btn-success">
+                        Define attribute
+                    </button>
+                </Link>
+                <PagedList
+                    listItem={MetakeyItem}
+                    columnNames={["Key (Label)", "Description", "URL Template"]}
+                    items={this.items.slice(
+                        (this.state.activePage - 1) * 10,
+                        this.state.activePage * 10
+                    )}
+                    itemCount={this.items.length}
+                    activePage={this.state.activePage}
+                    filterValue={this.state.keyFilter}
+                    onPageChange={this.handlePageChange}
+                    onFilterChange={this.handleFilterChange}
+                />
+            </View>
         );
     }
 }

--- a/mwdb/web/src/components/RecentView/QuickQueryAddModal.js
+++ b/mwdb/web/src/components/RecentView/QuickQueryAddModal.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { ConfirmationModal, View } from "@mwdb-web/commons/ui";
+import { Alert, ConfirmationModal } from "@mwdb-web/commons/ui";
 
 class QuickQueryAddModal extends Component {
     constructor(props) {
@@ -42,19 +42,18 @@ class QuickQueryAddModal extends Component {
                 onConfirm={this.handleSubmit}
             >
                 <form onSubmit={this.handleSubmit}>
-                    <View error={this.props.error}>
-                        <div className="row pb-2">
-                            <input
-                                type="text"
-                                className="form-control"
-                                style={{ width: "470px" }}
-                                placeholder="Set name for your quick query"
-                                onChange={this.handleValueChange}
-                                name="name"
-                                required
-                            />
-                        </div>
-                    </View>
+                    <Alert error={this.props.error} />
+                    <div className="row pb-2">
+                        <input
+                            type="text"
+                            className="form-control"
+                            style={{ width: "470px" }}
+                            placeholder="Set name for your quick query"
+                            onChange={this.handleValueChange}
+                            name="name"
+                            required
+                        />
+                    </div>
                 </form>
             </ConfirmationModal>
         );

--- a/mwdb/web/src/components/RecentView/RecentView.js
+++ b/mwdb/web/src/components/RecentView/RecentView.js
@@ -133,7 +133,7 @@ export default function RecentView(props) {
             []
         );
     return (
-        <View fluid ident="RecentObjects" error={error}>
+        <View fluid ident="recentObjects" error={error}>
             <div className="table-responsive">
                 <form
                     className="searchForm"

--- a/mwdb/web/src/components/ShowGroups.js
+++ b/mwdb/web/src/components/ShowGroups.js
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 import { UserLink } from "./ShowUsers";
 
 import api from "@mwdb-web/commons/api";
-import { ErrorBoundary, PagedList, HighlightText } from "@mwdb-web/commons/ui";
+import { PagedList, HighlightText, View } from "@mwdb-web/commons/ui";
 
 class ShowGroups extends Component {
     state = {
@@ -47,28 +47,26 @@ class ShowGroups extends Component {
 
     render() {
         return (
-            <div className="container-fluid">
-                <ErrorBoundary error={this.state.error}>
-                    <Link to="/groups/new">
-                        <button type="button" className="btn btn-success">
-                            Create group
-                        </button>
-                    </Link>
-                    <PagedList
-                        listItem={GroupItem}
-                        columnNames={["Name", "Members"]}
-                        items={this.items.slice(
-                            (this.state.activePage - 1) * 10,
-                            this.state.activePage * 10
-                        )}
-                        itemCount={this.items.length}
-                        activePage={this.state.activePage}
-                        filterValue={this.state.groupFilter}
-                        onPageChange={this.handlePageChange}
-                        onFilterChange={this.handleFilterChange}
-                    />
-                </ErrorBoundary>
-            </div>
+            <View fluid error={this.state.error}>
+                <Link to="/groups/new">
+                    <button type="button" className="btn btn-success">
+                        Create group
+                    </button>
+                </Link>
+                <PagedList
+                    listItem={GroupItem}
+                    columnNames={["Name", "Members"]}
+                    items={this.items.slice(
+                        (this.state.activePage - 1) * 10,
+                        this.state.activePage * 10
+                    )}
+                    itemCount={this.items.length}
+                    activePage={this.state.activePage}
+                    filterValue={this.state.groupFilter}
+                    onPageChange={this.handlePageChange}
+                    onFilterChange={this.handleFilterChange}
+                />
+            </View>
         );
     }
 }

--- a/mwdb/web/src/components/ShowObject/Actions/RelationsAddModal.js
+++ b/mwdb/web/src/components/ShowObject/Actions/RelationsAddModal.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { ConfirmationModal, View } from "@mwdb-web/commons/ui";
+import { Alert, ConfirmationModal } from "@mwdb-web/commons/ui";
 
 export default function RelationsAddModal(props) {
     const [relation, setRelation] = useState("");
@@ -29,38 +29,35 @@ export default function RelationsAddModal(props) {
             onConfirm={handleSubmit}
         >
             <form onSubmit={handleSubmit}>
-                <View error={props.error}>
-                    <table>
-                        <tr>
-                            <td>
-                                <select
-                                    className="form-control"
-                                    value={relation}
-                                    onChange={(ev) =>
-                                        setRelation(ev.target.value)
-                                    }
-                                >
-                                    <option value="" hidden>
-                                        Select relationship
-                                    </option>
-                                    <option value="parent">parent</option>
-                                    <option value="child">child</option>
-                                </select>
-                            </td>
-                            <td>
-                                <input
-                                    type="text"
-                                    className="form-control"
-                                    style={{ width: "600px" }}
-                                    placeholder="Type object sha256 identifier..."
-                                    onChange={(ev) => setValue(ev.target.value)}
-                                    value={value}
-                                    required
-                                />
-                            </td>
-                        </tr>
-                    </table>
-                </View>
+                <Alert error={props.error} />
+                <table>
+                    <tr>
+                        <td>
+                            <select
+                                className="form-control"
+                                value={relation}
+                                onChange={(ev) => setRelation(ev.target.value)}
+                            >
+                                <option value="" hidden>
+                                    Select relationship
+                                </option>
+                                <option value="parent">parent</option>
+                                <option value="child">child</option>
+                            </select>
+                        </td>
+                        <td>
+                            <input
+                                type="text"
+                                className="form-control"
+                                style={{ width: "600px" }}
+                                placeholder="Type object sha256 identifier..."
+                                onChange={(ev) => setValue(ev.target.value)}
+                                value={value}
+                                required
+                            />
+                        </td>
+                    </tr>
+                </table>
             </form>
         </ConfirmationModal>
     );

--- a/mwdb/web/src/components/Upload.js
+++ b/mwdb/web/src/components/Upload.js
@@ -136,7 +136,9 @@ export default class Upload extends Component {
                 this.state.attributes
             );
             this.sha256 = response.data.sha256;
-            this.props.history.replace("/file/" + this.sha256);
+            this.props.history.replace("/file/" + this.sha256, {
+                success: "File uploaded successfully.",
+            });
         } catch (error) {
             this.setState({ error });
         }
@@ -173,16 +175,12 @@ export default class Upload extends Component {
     };
 
     render() {
-        if (this.state.groups === null) {
-            return (
-                <View error={this.state.error} success={this.state.success} />
-            );
-        }
         return (
             <View
                 ident="upload"
                 error={this.state.error}
                 success={this.state.success}
+                showIf={this.state.groups !== null}
             >
                 <form>
                     <UploadDropzone
@@ -232,7 +230,7 @@ export default class Upload extends Component {
                                 value={this.state.shareWith}
                                 onChange={this.updateSharingMode}
                             >
-                                {this.state.groups.length
+                                {this.state.groups && this.state.groups.length
                                     ? [
                                           <option value="default">
                                               All my groups

--- a/mwdb/web/src/components/UserLogin.js
+++ b/mwdb/web/src/components/UserLogin.js
@@ -16,9 +16,6 @@ export default function UserLogin(props) {
     const [loginError, setLoginError] = useState(null);
 
     const locationState = history.location.state || {};
-    const error = loginError || locationState.error;
-    const success = !error && locationState.success;
-
     async function tryLogin() {
         try {
             const response = await api.authLogin(login, password);
@@ -33,7 +30,7 @@ export default function UserLogin(props) {
     if (auth.isAuthenticated) return <Redirect to="/" />;
 
     return (
-        <View ident="userLogin" error={error} success={success}>
+        <View ident="userLogin" error={loginError}>
             <h2>Login</h2>
             <form
                 onSubmit={(ev) => {

--- a/mwdb/web/src/components/UserProfile.js
+++ b/mwdb/web/src/components/UserProfile.js
@@ -5,7 +5,7 @@ import { capabilitiesList } from "./Capabilities";
 import api from "@mwdb-web/commons/api";
 import { AuthContext } from "@mwdb-web/commons/auth";
 import { makeSearchLink } from "@mwdb-web/commons/helpers";
-import { View, DateString, ErrorBoundary } from "@mwdb-web/commons/ui";
+import { View, DateString } from "@mwdb-web/commons/ui";
 
 import ManageAPIKeys from "./ManageAPIKeys";
 
@@ -77,8 +77,6 @@ export default class UserProfile extends Component {
     render() {
         if (!this.state.profile && !this.state.error) {
             return <div>Loading...</div>;
-        } else if (!this.state.profile && this.state.error) {
-            return <ErrorBoundary error={this.state.error} />;
         }
 
         return (
@@ -86,6 +84,7 @@ export default class UserProfile extends Component {
                 ident="userProfile"
                 error={this.state.error}
                 success={this.state.success}
+                showIf={this.state.profile}
             >
                 <table className="table table-striped table-bordered wrap-table">
                     <thead>


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

There is complete mess in error handling:
- `render()` errors are not handled correctly. In most cases, web app goes into infinite loop trying to re-render faulty view and sending lots of API requests.
- we can't easily redirect to another view with "success" message without special handling on the target site
- in some places: ErrorBoundaries, Views are used incorrectly, in the manner that was unexpected.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

ErrorBoundary works correctly, so if something bad happens in `render()` - it fallbacks to a more friendly page.
![image](https://user-images.githubusercontent.com/8720367/111524674-05908e00-875d-11eb-8964-04c422b49d61.png). It shouldn't be used anywhere else than App.js, but I left this in `commons` for compatibility reasons.

Reworked `View` component. That component should be always top-level for "views" and receives success/error messages both from props and location state. To show how it works, I have added:

- error for default route shown in '/' (if you go to the non-existent route)

![image](https://user-images.githubusercontent.com/8720367/111525868-55bc2000-875e-11eb-9713-f4cf1d1b34d5.png)

- success if file was uploaded correctly shown in sample view
  
![image](https://user-images.githubusercontent.com/8720367/111525806-48069a80-875e-11eb-8ff5-7793542452a2.png)


If you want to show error inside the View (e.g. in Modal), just use single Alert instead of making nested views (they will receive location state as well which might be confusing for the user)

There is still some work to do e.g. we need to ensure that all route targets are correct View components with correct `ident` (so plugins can extend every view). But this should be done in another refactor PR.

**Test plan**
<!-- Explain how to test your changes -->
- Check if all touched components still work correctly
<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

