### PR TITLE
User sessions are not invalidated when group has been changed

### DIFF
--- a/mwdb/resources/group.py
+++ b/mwdb/resources/group.py
@@ -220,11 +220,6 @@ class GroupResource(Resource):
 
         if obj["capabilities"] is not None:
             group.capabilities = obj["capabilities"]
-
-        # Invalidate all sessions due to potentially changed capabilities
-        for member in group.users:
-            member.reset_sessions()
-
         db.session.commit()
 
         logger.info(
@@ -304,7 +299,6 @@ class GroupMemberResource(Resource):
             raise Forbidden("User is pending and need to be accepted first")
 
         group.users.append(member)
-        member.reset_sessions()
         db.session.commit()
 
         logger.info(
@@ -392,8 +386,6 @@ class GroupMemberResource(Resource):
             raise Forbidden("User is pending and need to be accepted first")
 
         member.set_group_admin(group.id, membership["group_admin"])
-
-        member.reset_sessions()
         db.session.commit()
 
         logger.info(
@@ -444,7 +436,6 @@ class GroupMemberResource(Resource):
                 description: When user or group doesn't exist
         """
         group_name_obj = load_schema({"name": name}, GroupNameSchemaBase())
-
         user_login_obj = load_schema({"login": login}, UserLoginSchemaBase())
 
         group = (
@@ -481,7 +472,6 @@ class GroupMemberResource(Resource):
             raise Forbidden("User is pending and need to be accepted first")
 
         group.users.remove(member)
-        member.reset_sessions()
         db.session.commit()
 
         logger.info(

--- a/mwdb/web/src/commons/auth/provider.js
+++ b/mwdb/web/src/commons/auth/provider.js
@@ -127,6 +127,26 @@ export function AuthProvider(props) {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
+    // Effect for 403 Forbidden to handle unexpected loss of permissions
+    useEffect(() => {
+        // Set 403 Forbidden interceptor when AuthProvider is mounted
+        const interceptor = api.axios.interceptors.response.use(
+            (_) => _,
+            (error) => {
+                // Asynchronically refresh session with 403 expecting new set of capabilities
+                if (error.response && error.response.status === 403)
+                    refreshSession();
+                return Promise.reject(error);
+            }
+        );
+
+        // Unset the interceptor when AuthProvider is unmounted
+        return () => {
+            api.axios.interceptors.response.eject(interceptor);
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
     // Effect for periodic session refresh
     useEffect(() => {
         function setRefreshTimer() {


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- All password-based sessions are invalidated when one of user groups are changed due to possible permission desync. This is pretty annoying, so we decided to remove it.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- Changes in groups doesn't invalidate user session. The only invalidating actions are ban of user account and password change
- Web part intercepts 403 and schedules async session refresh, so permissions will be synced ASAP after such event.

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #138 