### PR TITLE
Fix: ISE 500 on member add/remove when is already added/removed

### DIFF
--- a/mwdb/resources/group.py
+++ b/mwdb/resources/group.py
@@ -298,7 +298,8 @@ class GroupMemberResource(Resource):
         if member.pending:
             raise Forbidden("User is pending and need to be accepted first")
 
-        group.users.append(member)
+        if not group.add_member(member):
+            raise Conflict("Member is already added")
         db.session.commit()
 
         logger.info(
@@ -353,6 +354,8 @@ class GroupMemberResource(Resource):
                     group is immutable or user is pending
             404:
                 description: When user or group doesn't exist
+            409:
+                description: When member is already added
         """
         group_name_obj = load_schema({"name": name}, GroupNameSchemaBase())
 
@@ -434,6 +437,8 @@ class GroupMemberResource(Resource):
                     group is immutable or user is pending
             404:
                 description: When user or group doesn't exist
+            409:
+                description: When member is already removed
         """
         group_name_obj = load_schema({"name": name}, GroupNameSchemaBase())
         user_login_obj = load_schema({"login": login}, UserLoginSchemaBase())
@@ -471,7 +476,8 @@ class GroupMemberResource(Resource):
         if member.pending:
             raise Forbidden("User is pending and need to be accepted first")
 
-        group.users.remove(member)
+        if not group.remove_member(member):
+            raise Conflict("Member is already removed")
         db.session.commit()
 
         logger.info(

--- a/tests/backend/test_multigroup_groups.py
+++ b/tests/backend/test_multigroup_groups.py
@@ -17,6 +17,24 @@ def test_member_public_groups():
         session.remove_member("public", Alice.identity)
 
 
+def test_existing_member_groups():
+    testCase = RelationTestCase()
+
+    Alice = testCase.new_user("Alice")
+    Group = testCase.new_group("Group")
+
+    session = MwdbTest()
+    session.login()
+
+    session.add_member(Group.identity, Alice.identity)
+    with ShouldRaise(status_code=409):
+        session.add_member(Group.identity, Alice.identity)
+
+    session.remove_member(Group.identity, Alice.identity)
+    with ShouldRaise(status_code=409):
+        session.remove_member(Group.identity, Alice.identity)
+
+
 def test_member_private_groups():
     testCase = RelationTestCase()
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [x] I've added automated tests for my change (if applicable, optional)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- API returns ISE 500 when member was added/removed before

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- API returns 409 Conflict in situation described above

**Test plan**
<!-- Explain how to test your changes -->
- Added automated test for that condition
