### PR TITLE
Docs: workaround for broken bullet lists

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,5 @@
 Sphinx==3.2.1
-sphinx-rtd-theme==0.5.0
+sphinx-rtd-theme==0.5.2
 jsx-lexer==1.0.0
+# FIX: https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
+docutils==0.16


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- Bullet lists are broken due to regression in sphinx_rtd_theme (https://github.com/readthedocs/sphinx_rtd_theme/issues/1115)
![image](https://user-images.githubusercontent.com/8720367/114304505-ce9b6700-9ad3-11eb-8a45-9c213fb55cc4.png)

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- Pinned `docutils==0.16` as a workaround for this problem. Pin should be removed after `sphinx_rtd_theme` fix.
![image](https://user-images.githubusercontent.com/8720367/114304526-f25ead00-9ad3-11eb-8aa5-5d4774769072.png)
