### PR TITLE
Limit /api/server information and add authentication requirement for /api/docs

### DIFF
--- a/mwdb/app.py
+++ b/mwdb/app.py
@@ -62,7 +62,12 @@ from mwdb.resources.remotes import (
     RemoteTextBlobPushResource,
 )
 from mwdb.resources.search import SearchResource
-from mwdb.resources.server import PingResource, ServerDocsResource, ServerInfoResource
+from mwdb.resources.server import (
+    PingResource,
+    ServerDocsResource,
+    ServerInfoResource,
+    ServerPluginInfoResource,
+)
 from mwdb.resources.share import ShareGroupListResource, ShareResource
 from mwdb.resources.tag import TagListResource, TagResource
 from mwdb.resources.user import (
@@ -195,6 +200,7 @@ def require_auth():
 # Server health endpoints
 api.add_resource(PingResource, "/ping")
 api.add_resource(ServerInfoResource, "/server")
+api.add_resource(ServerPluginInfoResource, "/server/plugins")
 api.add_resource(ServerDocsResource, "/docs")
 
 # Authentication endpoints

--- a/mwdb/resources/server.py
+++ b/mwdb/resources/server.py
@@ -4,8 +4,14 @@ from flask_restful import Resource
 from mwdb.core.app import api
 from mwdb.core.config import app_config
 from mwdb.core.plugins import get_plugin_info
-from mwdb.schema.server import ServerInfoResponseSchema, ServerPingResponseSchema
+from mwdb.schema.server import (
+    ServerInfoResponseSchema,
+    ServerPingResponseSchema,
+    ServerPluginInfoResponseSchema,
+)
 from mwdb.version import app_build_version
+
+from . import requires_authorization
 
 
 class PingResource(Resource):
@@ -52,19 +58,41 @@ class ServerInfoResource(Resource):
                 "is_maintenance_set": app_config.mwdb.enable_maintenance,
                 "is_registration_enabled": app_config.mwdb.enable_registration,
                 "recaptcha_site_key": app_config.mwdb.recaptcha_site_key,
-                "base_url": app_config.mwdb.base_url,
-                "active_plugins": get_plugin_info(),
-                "remotes": app_config.mwdb.remotes,
             }
         )
 
 
+class ServerPluginInfoResource(Resource):
+    @requires_authorization
+    def get(self):
+        """
+        ---
+        summary: Get plugin information
+        description: Returns information about installed plugins
+        security:
+            - bearerAuth: []
+        tags:
+            - server
+        responses:
+            200:
+              description: Server plugin info with public configuration
+              content:
+                application/json:
+                  schema: ServerInfoResponseSchema
+        """
+        schema = ServerPluginInfoResponseSchema()
+        return schema.dump({"active_plugins": get_plugin_info()})
+
+
 class ServerDocsResource(Resource):
+    @requires_authorization
     def get(self):
         """
         ---
         summary: Get server API documentation
         description: Returns API documentation in OAS3 format
+        security:
+            - bearerAuth: []
         tags:
             - server
         responses:

--- a/mwdb/schema/server.py
+++ b/mwdb/schema/server.py
@@ -11,7 +11,7 @@ class ServerInfoResponseSchema(Schema):
     is_maintenance_set = fields.Boolean(required=True, allow_none=False)
     is_registration_enabled = fields.Boolean(required=True, allow_none=False)
     recaptcha_site_key = fields.Str(required=True, allow_none=True)
-    base_url = fields.Str(required=True, allow_none=False)
-    # Dict() supporting keys and values is added to marshmallow 3.x
+
+
+class ServerPluginInfoResponseSchema(Schema):
     active_plugins = fields.Dict(required=True, allow_none=False)
-    remotes = fields.List(fields.Str(), required=True, allow_none=False)

--- a/mwdb/web/src/App.js
+++ b/mwdb/web/src/App.js
@@ -119,7 +119,7 @@ export default function App() {
     const auth = useContext(AuthContext);
     const config = useContext(ConfigContext);
 
-    const routeSwitch = config.config["server_version"] ? (
+    const routeSwitch = config.isReady ? (
         <Switch>
             <Route exact path="/login">
                 <UserLogin />

--- a/mwdb/web/src/App.js
+++ b/mwdb/web/src/App.js
@@ -119,7 +119,7 @@ export default function App() {
     const auth = useContext(AuthContext);
     const config = useContext(ConfigContext);
 
-    const routeSwitch = config.config ? (
+    const routeSwitch = config.config["server_version"] ? (
         <Switch>
             <Route exact path="/login">
                 <UserLogin />

--- a/mwdb/web/src/commons/api/index.js
+++ b/mwdb/web/src/commons/api/index.js
@@ -44,6 +44,10 @@ function getServerInfo() {
     return axios.get("/server");
 }
 
+function getServerPluginInfo() {
+    return axios.get("/server/plugins");
+}
+
 function authLogin(login, password) {
     return axios.post("/auth/login", { login, password });
 }
@@ -442,6 +446,7 @@ export default {
     getApiForEnvironment,
     getServerDocs,
     getServerInfo,
+    getServerPluginInfo,
     authLogin,
     authGroups,
     authRefresh,

--- a/mwdb/web/src/commons/config/provider.js
+++ b/mwdb/web/src/commons/config/provider.js
@@ -72,6 +72,7 @@ export function ConfigProvider(props) {
             value={{
                 config: serverConfig.config,
                 configError: serverConfig.error,
+                isReady: !!serverConfig.config["server_version"],
                 update: updateServerInfo,
             }}
         >

--- a/mwdb/web/src/commons/config/provider.js
+++ b/mwdb/web/src/commons/config/provider.js
@@ -1,6 +1,7 @@
-import React, { useEffect, useReducer } from "react";
+import React, { useContext, useEffect, useReducer } from "react";
 import api from "../api";
 import { ConfigContext } from "./context";
+import { AuthContext } from "../auth";
 
 const configUpdate = Symbol("configUpdate");
 const configError = Symbol("configError");
@@ -8,21 +9,25 @@ const configError = Symbol("configError");
 function serverConfigReducer(state, action) {
     switch (action.type) {
         case configUpdate:
-            return { config: action.config, error: null };
+            return {
+                config: { ...state.config, ...action.config },
+                error: null,
+            };
         case configError:
-            return { config: null, error: action.error };
+            return { config: state.config, error: action.error };
         default:
             return state;
     }
 }
 
 export function ConfigProvider(props) {
+    const auth = useContext(AuthContext);
     const [serverConfig, setServerConfig] = useReducer(serverConfigReducer, {
-        config: null,
+        config: {},
         error: null,
     });
 
-    async function update() {
+    async function updateServerInfo() {
         try {
             const response = await api.getServerInfo();
             setServerConfig({
@@ -37,16 +42,37 @@ export function ConfigProvider(props) {
         }
     }
 
+    async function updateRemoteInfo() {
+        try {
+            const response = await api.getRemoteNames();
+            setServerConfig({
+                type: configUpdate,
+                config: {
+                    remotes: response.data.remotes,
+                },
+            });
+        } catch (error) {
+            setServerConfig({
+                type: configError,
+                error,
+            });
+        }
+    }
+
     useEffect(() => {
-        update();
+        updateServerInfo();
     }, []);
+
+    useEffect(() => {
+        if (auth.isAuthenticated) updateRemoteInfo();
+    }, [auth.isAuthenticated]);
 
     return (
         <ConfigContext.Provider
             value={{
                 config: serverConfig.config,
                 configError: serverConfig.error,
-                update,
+                update: updateServerInfo,
             }}
         >
             {props.children}

--- a/mwdb/web/src/components/About.js
+++ b/mwdb/web/src/components/About.js
@@ -1,5 +1,6 @@
-import React, { useContext } from "react";
+import React, { useCallback, useContext, useEffect, useState } from "react";
 
+import api from "@mwdb-web/commons/api";
 import { ConfigContext } from "@mwdb-web/commons/config";
 import { View } from "@mwdb-web/commons/ui";
 
@@ -27,9 +28,28 @@ function PluginItems(props) {
 
 export default function About() {
     const config = useContext(ConfigContext);
-    let plugins = Object.entries(config.config["active_plugins"])
-        .sort()
-        .map(([key, value]) => <PluginItems name={key} info={value} />);
+    const [pluginsList, setPluginsList] = useState([]);
+
+    async function updatePlugins() {
+        try {
+            const response = await api.getServerPluginInfo();
+            setPluginsList(
+                Object.entries(response.data["active_plugins"]).sort()
+            );
+        } catch (e) {
+            console.error(e);
+        }
+    }
+
+    const getPlugins = useCallback(updatePlugins, []);
+
+    useEffect(() => {
+        getPlugins();
+    }, [getPlugins]);
+
+    const plugins = pluginsList.map(([key, value]) => (
+        <PluginItems name={key} info={value} />
+    ));
 
     return (
         <div className="align-items-center">

--- a/mwdb/web/src/components/Navigation.js
+++ b/mwdb/web/src/components/Navigation.js
@@ -98,7 +98,7 @@ function AdminDropdown() {
 
 function RemoteDropdown() {
     const config = useContext(ConfigContext);
-    if (!config.config) return [];
+    if (!config.isReady) return [];
 
     const remotes = config.config.remotes || [];
     const remoteItems = remotes.map((remote) => (
@@ -142,7 +142,7 @@ export default function Navigation() {
     const config = useContext(ConfigContext);
     const remote = useRemote();
     const remotePath = useRemotePath();
-    const navItems = config.config ? (
+    const navItems = config.isReady ? (
         <Extendable ident="navbar">
             {!auth.isAuthenticated &&
             config.config["is_registration_enabled"] ? (
@@ -243,7 +243,7 @@ export default function Navigation() {
     );
 
     const remoteNavItems =
-        config.config && auth.isAuthenticated ? (
+        config.isReady && auth.isAuthenticated ? (
             <Extendable ident="navbarAuthenticated">
                 <React.Fragment>
                     <li className="nav-item">

--- a/mwdb/web/src/components/Navigation.js
+++ b/mwdb/web/src/components/Navigation.js
@@ -100,7 +100,8 @@ function RemoteDropdown() {
     const config = useContext(ConfigContext);
     if (!config.config) return [];
 
-    const remoteItems = config.config.remotes.map((remote) => (
+    const remotes = config.config.remotes || [];
+    const remoteItems = remotes.map((remote) => (
         <Link key="remote" className="dropdown-item" to={`/remote/${remote}`}>
             {remote}
         </Link>

--- a/mwdb/web/src/index.js
+++ b/mwdb/web/src/index.js
@@ -14,13 +14,13 @@ import "swagger-ui-react/swagger-ui.css";
 
 ReactDOM.render(
     <BrowserRouter>
-        <ConfigProvider>
-            <AuthProvider>
+        <AuthProvider>
+            <ConfigProvider>
                 <APIProvider>
                     <App />
                 </APIProvider>
-            </AuthProvider>
-        </ConfigProvider>
+            </ConfigProvider>
+        </AuthProvider>
     </BrowserRouter>,
     document.getElementById("root")
 );


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**

- `/api/server` exposes too much information. Some of them shouldn't be available for unauthenticated users (e.g. list of configured remotes, list of plugins etc.)
- `/api/docs` doesn't have authentication requirement

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- Added `/api/server/plugins` endpoint that exposes plugin information and requires authentication
- Removed fields from `/api/server` response:
    - `active_plugins`
    - `remotes` (already available via `GET /api/remote`)
    - `base_url` (used only on backend by e-mail registration features)
- Added authentication requirement to `/api/docs`

**Test plan**
<!-- Explain how to test your changes -->
- :heavy_check_mark: Checked remotes, About view and Docs view
<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

closes #329 

