### PR TITLE
Add hooks for tags and comments

### DIFF
--- a/mwdb/core/plugins.py
+++ b/mwdb/core/plugins.py
@@ -8,7 +8,7 @@ from mwdb.core.app import api, app
 from mwdb.core.config import app_config
 from mwdb.core.log import getLogger
 from mwdb.core.util import is_subdir
-from mwdb.model import Config, File, Object, TextBlob
+from mwdb.model import Comment, Config, File, Object, Tag, TextBlob
 
 logger = getLogger()
 
@@ -76,6 +76,18 @@ class PluginHookBase(object):
 
     @hook_handler_method
     def on_reuploaded_text_blob(self, blob: TextBlob):
+        pass
+
+    @hook_handler_method
+    def on_created_tag(self, object: Object, tag: Tag):
+        pass
+
+    @hook_handler_method
+    def on_reuploaded_tag(self, tag: Tag):
+        pass
+
+    @hook_handler_method
+    def on_created_comment(self, object: Object, comment: Comment):
         pass
 
 

--- a/mwdb/core/plugins.py
+++ b/mwdb/core/plugins.py
@@ -83,7 +83,7 @@ class PluginHookBase(object):
         pass
 
     @hook_handler_method
-    def on_reuploaded_tag(self, tag: Tag):
+    def on_reuploaded_tag(self, object: Object, tag: Tag):
         pass
 
     @hook_handler_method

--- a/mwdb/resources/comment.py
+++ b/mwdb/resources/comment.py
@@ -17,8 +17,6 @@ from . import (
 
 
 class CommentResource(Resource):
-    on_created = hooks.on_created_comment
-
     @requires_authorization
     def get(self, type, identifier):
         """

--- a/mwdb/resources/comment.py
+++ b/mwdb/resources/comment.py
@@ -3,6 +3,7 @@ from flask_restful import Resource
 from werkzeug.exceptions import NotFound
 
 from mwdb.core.capabilities import Capabilities
+from mwdb.core.plugins import hooks
 from mwdb.model import Comment, db
 from mwdb.schema.comment import CommentItemResponseSchema, CommentRequestSchema
 
@@ -16,6 +17,8 @@ from . import (
 
 
 class CommentResource(Resource):
+    on_created = hooks.on_created_comment
+
     @requires_authorization
     def get(self, type, identifier):
         """
@@ -121,6 +124,7 @@ class CommentResource(Resource):
         logger.info("comment added", extra={"comment": comment.object_id})
 
         db.session.refresh(comment)
+        hooks.on_created_comment(db_object, comment)
         schema = CommentItemResponseSchema()
         return schema.dump(comment)
 

--- a/mwdb/resources/tag.py
+++ b/mwdb/resources/tag.py
@@ -4,6 +4,7 @@ from sqlalchemy.sql import and_
 from werkzeug.exceptions import NotFound
 
 from mwdb.core.capabilities import Capabilities
+from mwdb.core.plugins import hooks
 from mwdb.model import ObjectPermission, Tag, db, object_tag_table
 from mwdb.schema.tag import (
     TagItemResponseSchema,
@@ -78,6 +79,9 @@ class TagListResource(Resource):
 
 
 class TagResource(Resource):
+    on_created = hooks.on_created_tag
+    on_reuploaded = hooks.on_reuploaded_tag
+
     @requires_authorization
     def get(self, type, identifier):
         """
@@ -179,10 +183,15 @@ class TagResource(Resource):
             raise NotFound("Object not found")
 
         tag_name = obj["tag"]
-        db_object.add_tag(tag_name)
+        is_new = db_object.add_tag(tag_name)
 
         logger.info("Tag added", extra={"tag": tag_name, "dhash": db_object.dhash})
         db.session.refresh(db_object)
+        if is_new:
+            hooks.on_created_tag(db_object, tag_name)
+        else:
+            hooks.on_reuploaded_tag(db_object, tag_name)
+
         schema = TagItemResponseSchema(many=True)
         return schema.dump(db_object.tags)
 

--- a/mwdb/resources/tag.py
+++ b/mwdb/resources/tag.py
@@ -79,7 +79,6 @@ class TagListResource(Resource):
 
 
 class TagResource(Resource):
-
     @requires_authorization
     def get(self, type, identifier):
         """

--- a/mwdb/resources/tag.py
+++ b/mwdb/resources/tag.py
@@ -79,8 +79,6 @@ class TagListResource(Resource):
 
 
 class TagResource(Resource):
-    on_created = hooks.on_created_tag
-    on_reuploaded = hooks.on_reuploaded_tag
 
     @requires_authorization
     def get(self, type, identifier):


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
No hooks are available for tags and comments creation.

**What is the new behaviour?**
New hooks are added for
1. Creating tags
2. Re-creating tags
3. Creating comments

**Test plan**
I used the following plugin for testing:

```python
import logging

from mwdb.core.plugins import PluginAppContext, PluginHookHandler
from mwdb.model import Tag, Comment, Object

logger = logging.getLogger("mwdb.plugin.test")


class TestHookHandler(PluginHookHandler):

    def on_created_tag(self, object: Object, tag: Tag):
        logger.info("[ES] Tag created: \n\tTag:%s (type: %s)\n\tObject: %s (type: %s)", tag, type(tag), object, type(object))
    
    def on_reuploaded_tag(self, object: Object, tag: Tag):
        logger.info("[ES] Tag reuploaded: \n\tTag:%s (type: %s)\n\tObject: %s (type: %s)", tag, type(tag), object, type(object))

    def on_created_comment(self, object: Object, comment: Comment):
        logger.info("[ES] Comment created: \n\Comment:%s (type: %s)\n\tObject: %s (type: %s)", comment, type(comment), object, type(object))


def entrypoint(app_context: PluginAppContext):
    app_context.register_hook_handler(TestHookHandler)

__plugin_entrypoint__ = entrypoint
```

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

Makes partial progress in #348