### PR TITLE
Dev workflow: Bump version with the first PR that introduces change

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ https://gist.github.com/Chaser324/ce0505fbed06b947d962).
    
    Version bump should be included in the same PR.
 
-6. When you feel like you're done, commit the files:
+7. When you feel like you're done, commit the files:
 
 ```bash
 $ git add -A

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,20 @@ https://gist.github.com/Chaser324/ce0505fbed06b947d962).
    npx prettier --write src/
    ```
 
+6. If setup.py version matches the latest release version: 
+   include version bump in your commit according to the [semantic versioning](https://semver.org)
+   
+   e.g.
+   ```
+   python3 dev/bump_version 1.2.3
+   ```
+   
+   - Bump MAJOR version (2.2.2 => 3.0.0) when your change breaks the API compatibility.
+   - Bump MINOR version (2.2.2 => 2.3.0) when you add functionality in a backwards compatible manner.
+   - Bump PATCH version (2.2.2 => 2.2.3) when you provide a bug fix.
+   
+   Version bump should be included in the same PR.
+
 6. When you feel like you're done, commit the files:
 
 ```bash

--- a/dev/bump_version.json
+++ b/dev/bump_version.json
@@ -7,5 +7,5 @@
         "mwdb/web/src/commons/package.json": "\"version\": \"$VERSION\"",
         "docs/conf.py": "release = '$VERSION'"
     },
-    "regex": "(\\d.\\d.\\d(?:-(post|dev|alpha|beta|rc)[0-9])?)"
+    "regex": "(\\d[.]\\d[.]\\d(?:-(post|dev|alpha|beta|rc)[0-9])?)"
 }

--- a/dev/bump_version.json
+++ b/dev/bump_version.json
@@ -7,5 +7,5 @@
         "mwdb/web/src/commons/package.json": "\"version\": \"$VERSION\"",
         "docs/conf.py": "release = '$VERSION'"
     },
-    "regex": "(\\d[.]\\d[.]\\d(?:-(post|dev|alpha|beta|rc)[0-9])?)"
+    "regex": "(\\d+[.]\\d+[.]\\d+(?:-(post|dev|alpha|beta|rc)[0-9])?)"
 }

--- a/dev/bump_version.json
+++ b/dev/bump_version.json
@@ -1,0 +1,11 @@
+{
+    "files": {
+        "setup.py": "version=\"$VERSION\"",
+        "mwdb/version.py": "app_version = \"$VERSION\"",
+        "mwdb/web/package.json": "\"version\": \"$VERSION\"",
+        "mwdb/web/package-lock.json": "\"version\": \"$VERSION\"",
+        "mwdb/web/src/commons/package.json": "\"version\": \"$VERSION\"",
+        "docs/conf.py": "release = '$VERSION'"
+    },
+    "regex": "(\\d.\\d.\\d(?:-(post|dev|alpha|beta|rc)[0-9])?)"
+}

--- a/dev/bump_version.py
+++ b/dev/bump_version.py
@@ -1,0 +1,73 @@
+import difflib
+import re
+import sys
+from pathlib import Path
+
+CURRENT_DIR = Path.cwd()
+VERSION_FILES = {
+    CURRENT_DIR / "setup.py": 'version="$VERSION"',
+    CURRENT_DIR / "mwdb" / "version.py": 'app_version = "$VERSION"',
+    CURRENT_DIR / "mwdb" / "web" / "package.json": '"version": "$VERSION"',
+    CURRENT_DIR / "mwdb" / "web" / "package-lock.json": '"version": "$VERSION"',
+    CURRENT_DIR / "mwdb" / "web" / "src" / "commons" / "package.json": '"version": "$VERSION"',
+    CURRENT_DIR / "docs" / "conf.py": "release = '$VERSION'"
+}
+VERSION_REGEX = r"(\d.\d.\d(?:-(post|dev|alpha|beta|rc)[0-9])?)"
+
+
+def main(new_version):
+    input_files = {}
+    output_files = {}
+    old_version = None
+
+    if not re.match(fr"^{VERSION_REGEX}$", new_version):
+        print(f"[!] '{new_version}' doesn't match the regex: {VERSION_REGEX}")
+        return
+
+    def subst_version(repl):
+        return repl.string[repl.start(0):repl.start(1)] + new_version + repl.string[repl.end(1):repl.end(0)]
+
+    for path in VERSION_FILES.keys():
+        if not path.exists():
+            print(f"[!] File {str(path)} is missing. Are you in project root dir?")
+            return False
+
+        with open(path, "r") as f:
+            content = input_files[path] = f.read()
+
+        pattern = VERSION_FILES[path].replace("$VERSION", VERSION_REGEX)
+        version = next(re.finditer(pattern, content)).group(1)
+        output_files[path] = re.sub(pattern, subst_version, content, count=1)
+
+        if old_version is not None and version != old_version:
+            print(f"[!] {str(path)} contains different version than other files ({version} != {old_version})")
+        old_version = version
+
+    for path in VERSION_FILES.keys():
+        input_lines = input_files[path].splitlines()
+        output_lines = output_files[path].splitlines()
+        if input_lines == output_lines:
+            print("[*] No changes detected.")
+            return
+        print("=== " + str(path))
+        for line in difflib.unified_diff(input_lines, output_lines, lineterm=''):
+            print(line)
+
+    response = ''
+    while response.lower() not in {"y", "n", "yes", "no"}:
+        response = input("[*] Check above diff ^ Is it correct? (y/n): ")
+
+    if response.lower() in {"y", "yes"}:
+        for path, content in output_files.items():
+            with open(path, "w") as f:
+                f.write(content)
+        print("[+] Changes applied!")
+    else:
+        print("[-] Changes discarded.")
+
+
+if __name__ == "__main__":
+    if not sys.argv[1:]:
+        print("Usage: bump_version.py [new_version]")
+    else:
+        main(sys.argv[1])

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,1 +1,2 @@
 _build/
+venv/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ copyright = '2021, CERT Polska'
 author = 'CERT Polska'
 
 # The full version, including alpha/beta/rc tags
-release = '2.2.2'
+release = '2.3.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/mwdb/version.py
+++ b/mwdb/version.py
@@ -4,5 +4,5 @@ try:
 except IOError:
     git_revision = ""
 
-app_version = "2.2.2"
+app_version = "2.3.0"
 app_build_version = f"{app_version}+{git_revision}" if git_revision else app_version

--- a/mwdb/web/package-lock.json
+++ b/mwdb/web/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mwdb-web",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/mwdb/web/package.json
+++ b/mwdb/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mwdb-web",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.0-14",

--- a/mwdb/web/src/commons/package.json
+++ b/mwdb/web/src/commons/package.json
@@ -2,7 +2,7 @@
     "name": "@mwdb-web/commons",
     "main": "index.js",
     "private": true,
-    "version": "2.2.2",
+    "version": "2.3.0",
     "peerDependencies": {
         "@fortawesome/react-fontawesome": "*",
         "lodash": "*",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ Under the hood of mwdb.cert.pl service hosted by CERT.pl.
 """
 
 setup(name="mwdb-core",
-      version="2.2.2",
+      version="2.3.0",
       description="MWDB Core malware database",
       long_description=LONG_DESCRIPTION,
       author="CERT Polska",


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).

**What is the current behaviour?**
<!-- Explain how the code works currently -->

Although current master branch contains new features under development, it has the same version number as latest release. That may be misleading for mwdb-core users.

It's a good practice to bump version with the first pull-request, so version number in `master` branch always fulfills [the semantic versioning](https://semver.org/) requirements.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- Because version bump requires to change all the 6 files that contain the version number: added helper script `dev/bump_version.py` that assists in that change.
- Added bump recommendation to CONTRIBUTING.md
- Bumped version to 2.3.0 to apply the recommendation to current master branch, which introduces new features comparing to the current stable.

Example output from `dev/bump_version.py`:
```diff
$ python dev/bump_version.py 2.3.0
=== /home/psrok1/mwdb-core/setup.py
--- 
+++ 
@@ -7,7 +7,7 @@
 """
 
 setup(name="mwdb-core",
-      version="2.2.2",
+      version="2.3.0",
       description="MWDB Core malware database",
       long_description=LONG_DESCRIPTION,
       author="CERT Polska",
=== /home/psrok1/mwdb-core/mwdb/version.py
--- 
+++ 
@@ -4,5 +4,5 @@
 except IOError:
     git_revision = ""
 
-app_version = "2.2.2"
+app_version = "2.3.0"
 app_build_version = f"{app_version}+{git_revision}" if git_revision else app_version
=== /home/psrok1/mwdb-core/mwdb/web/package.json
--- 
+++ 
@@ -1,6 +1,6 @@
 {
   "name": "mwdb-web",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.0-14",
=== /home/psrok1/mwdb-core/mwdb/web/package-lock.json
--- 
+++ 
@@ -1,6 +1,6 @@
 {
   "name": "mwdb-web",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
=== /home/psrok1/mwdb-core/mwdb/web/src/commons/package.json
--- 
+++ 
@@ -2,7 +2,7 @@
     "name": "@mwdb-web/commons",
     "main": "index.js",
     "private": true,
-    "version": "2.2.2",
+    "version": "2.3.0",
     "peerDependencies": {
         "@fortawesome/react-fontawesome": "*",
         "lodash": "*",
=== /home/psrok1/mwdb-core/docs/conf.py
--- 
+++ 
@@ -21,7 +21,7 @@
 author = 'CERT Polska'
 
 # The full version, including alpha/beta/rc tags
-release = '2.2.2'
+release = '2.3.0'
 
 
 # -- General configuration ---------------------------------------------------
[*] Check above diff ^ Is it correct? (y/n): y
[+] Changes applied!
```

