### PR TITLE
UI: Settings main page with overview and plugin information

### DIFF
--- a/mwdb/app.py
+++ b/mwdb/app.py
@@ -65,9 +65,9 @@ from mwdb.resources.remotes import (
 from mwdb.resources.search import SearchResource
 from mwdb.resources.server import (
     PingResource,
+    ServerAdminInfoResource,
     ServerDocsResource,
     ServerInfoResource,
-    ServerPluginInfoResource,
 )
 from mwdb.resources.share import ShareGroupListResource, ShareResource
 from mwdb.resources.tag import TagListResource, TagResource
@@ -201,7 +201,7 @@ def require_auth():
 # Server health endpoints
 api.add_resource(PingResource, "/ping")
 api.add_resource(ServerInfoResource, "/server")
-api.add_resource(ServerPluginInfoResource, "/server/plugins")
+api.add_resource(ServerAdminInfoResource, "/server/admin")
 api.add_resource(ServerDocsResource, "/docs")
 
 # Authentication endpoints

--- a/mwdb/schema/server.py
+++ b/mwdb/schema/server.py
@@ -14,5 +14,7 @@ class ServerInfoResponseSchema(Schema):
     recaptcha_site_key = fields.Str(required=True, allow_none=True)
 
 
-class ServerPluginInfoResponseSchema(Schema):
+class ServerAdminInfoResponseSchema(Schema):
+    rate_limit_enabled = fields.Boolean(required=True, allow_none=False)
+    plugins_enabled = fields.Boolean(required=True, allow_none=False)
     active_plugins = fields.Dict(required=True, allow_none=False)

--- a/mwdb/web/src/App.js
+++ b/mwdb/web/src/App.js
@@ -120,6 +120,21 @@ function DefaultRoute() {
     );
 }
 
+function SettingsRoute() {
+    const auth = useContext(AuthContext);
+    return (
+        <ProtectedRoute
+            condition={
+                auth.hasCapability(Capability.managingAttributes) ||
+                auth.hasCapability(Capability.manageUsers)
+            }
+            path="/admin"
+        >
+            <SettingsView />
+        </ProtectedRoute>
+    );
+}
+
 export default function App() {
     const auth = useContext(AuthContext);
     const config = useContext(ConfigContext);
@@ -222,9 +237,7 @@ export default function App() {
             <ProtectedRoute path="/remote/:remote">
                 <RemoteViews />
             </ProtectedRoute>
-            <ProtectedRoute path="/admin">
-                <SettingsView />
-            </ProtectedRoute>
+            <SettingsRoute />
             <ProtectedRoute path={["/profile/user/:user", "/profile"]}>
                 <ProfileView />
             </ProtectedRoute>

--- a/mwdb/web/src/App.js
+++ b/mwdb/web/src/App.js
@@ -120,7 +120,7 @@ function DefaultRoute() {
     );
 }
 
-function SettingsRoute() {
+function SettingsRoute(args) {
     const auth = useContext(AuthContext);
     return (
         <ProtectedRoute
@@ -128,7 +128,7 @@ function SettingsRoute() {
                 auth.hasCapability(Capability.managingAttributes) ||
                 auth.hasCapability(Capability.manageUsers)
             }
-            path="/admin"
+            {...args}
         >
             <SettingsView />
         </ProtectedRoute>
@@ -237,7 +237,7 @@ export default function App() {
             <ProtectedRoute path="/remote/:remote">
                 <RemoteViews />
             </ProtectedRoute>
-            <SettingsRoute />
+            <SettingsRoute path="/admin" />
             <ProtectedRoute path={["/profile/user/:user", "/profile"]}>
                 <ProfileView />
             </ProtectedRoute>

--- a/mwdb/web/src/commons/api/index.js
+++ b/mwdb/web/src/commons/api/index.js
@@ -44,8 +44,8 @@ function getServerInfo() {
     return axios.get("/server");
 }
 
-function getServerPluginInfo() {
-    return axios.get("/server/plugins");
+function getServerAdminInfo() {
+    return axios.get("/server/admin");
 }
 
 function authLogin(login, password) {
@@ -466,7 +466,7 @@ export default {
     getApiForEnvironment,
     getServerDocs,
     getServerInfo,
-    getServerPluginInfo,
+    getServerAdminInfo,
     authLogin,
     authGroups,
     authRefresh,

--- a/mwdb/web/src/components/About.js
+++ b/mwdb/web/src/components/About.js
@@ -1,55 +1,12 @@
-import React, { useCallback, useContext, useEffect, useState } from "react";
+import React, { useContext } from "react";
 
-import api from "@mwdb-web/commons/api";
 import { ConfigContext } from "@mwdb-web/commons/config";
 import { View } from "@mwdb-web/commons/ui";
 
 import logo from "../assets/logo.png";
 
-function PluginItems(props) {
-    const { name, info } = props;
-    const { active, version, description } = info;
-
-    return (
-        <tr>
-            <td>
-                {name}{" "}
-                {active ? (
-                    <span className="badge badge-success">Active</span>
-                ) : (
-                    <span className="badge badge-danger">Inactive</span>
-                )}
-            </td>
-            <td>{description}</td>
-            <td>{version}</td>
-        </tr>
-    );
-}
-
 export default function About() {
     const config = useContext(ConfigContext);
-    const [pluginsList, setPluginsList] = useState([]);
-
-    async function updatePlugins() {
-        try {
-            const response = await api.getServerPluginInfo();
-            setPluginsList(
-                Object.entries(response.data["active_plugins"]).sort()
-            );
-        } catch (e) {
-            console.error(e);
-        }
-    }
-
-    const getPlugins = useCallback(updatePlugins, []);
-
-    useEffect(() => {
-        getPlugins();
-    }, [getPlugins]);
-
-    const plugins = pluginsList.map(([key, value]) => (
-        <PluginItems name={key} info={value} />
-    ));
 
     return (
         <div className="align-items-center">
@@ -82,27 +39,6 @@ export default function About() {
                     </div>
                 </View>
             </div>
-            {plugins.length ? (
-                <div className="container">
-                    <table className="table table-striped table-bordered wrap-table">
-                        <thead>
-                            <tr>
-                                <th>Plugin name</th>
-                                <th>Description</th>
-                                <th>Version</th>
-                            </tr>
-                        </thead>
-                        <tbody>{plugins}</tbody>
-                    </table>
-                </div>
-            ) : (
-                <p style={{ textAlign: "center" }}>
-                    No plugins are installed. Visit our{" "}
-                    <a href="https://mwdb.readthedocs.io/">documentation</a> to
-                    learn about MWDB plugins and how they can be used and
-                    installed.
-                </p>
-            )}
         </div>
     );
 }

--- a/mwdb/web/src/components/Settings/SettingsView.js
+++ b/mwdb/web/src/components/Settings/SettingsView.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useContext } from "react";
-import { NavLink, Switch } from "react-router-dom";
+import { NavLink, Route, Switch } from "react-router-dom";
 
 import { faUsersCog } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -128,9 +128,9 @@ export default function SettingsView(props) {
                 <div className="col-8">
                     <div className="tab-content">
                         <Switch>
-                            <AdministrativeRoute exact path="/admin">
+                            <Route exact path="/admin">
                                 <SettingsOverview />
-                            </AdministrativeRoute>
+                            </Route>
                             <AdministrativeRoute path="/admin/pending">
                                 <ShowPendingUsers />
                             </AdministrativeRoute>

--- a/mwdb/web/src/components/Settings/SettingsView.js
+++ b/mwdb/web/src/components/Settings/SettingsView.js
@@ -51,11 +51,16 @@ function SettingsNav() {
     }, [isAdmin]);
 
     const adminLinks = [
-        ...(auth.hasCapability(Capability.manageUsers)
+        ...(auth.hasCapability(Capability.managingAttributes) ||
+        auth.hasCapability(Capability.manageUsers)
             ? [
                   <NavLink to="/admin" className="nav-link">
                       Overview
                   </NavLink>,
+              ]
+            : []),
+        ...(auth.hasCapability(Capability.manageUsers)
+            ? [
                   ...(config.config["is_registration_enabled"]
                       ? [
                             <NavLink

--- a/mwdb/web/src/components/Settings/SettingsView.js
+++ b/mwdb/web/src/components/Settings/SettingsView.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useContext } from "react";
-import { NavLink, Redirect, Switch } from "react-router-dom";
+import { NavLink, Switch } from "react-router-dom";
 
 import { faUsersCog } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -23,6 +23,7 @@ import AttributeDefine from "./Views/AttributeDefine";
 import UserView from "./Views/UserView";
 import AccessControl from "./Views/AccessControl";
 import GroupView from "./Views/GroupView";
+import SettingsOverview from "./Views/SettingsOverview";
 
 function SettingsNav() {
     const auth = useContext(AuthContext);
@@ -52,6 +53,9 @@ function SettingsNav() {
     const adminLinks = [
         ...(auth.hasCapability(Capability.manageUsers)
             ? [
+                  <NavLink to="/admin" className="nav-link">
+                      Overview
+                  </NavLink>,
                   ...(config.config["is_registration_enabled"]
                       ? [
                             <NavLink
@@ -125,7 +129,7 @@ export default function SettingsView(props) {
                     <div className="tab-content">
                         <Switch>
                             <AdministrativeRoute exact path="/admin">
-                                <Redirect to="/admin/pending" />
+                                <SettingsOverview />
                             </AdministrativeRoute>
                             <AdministrativeRoute path="/admin/pending">
                                 <ShowPendingUsers />

--- a/mwdb/web/src/components/Settings/Views/SettingsOverview.js
+++ b/mwdb/web/src/components/Settings/Views/SettingsOverview.js
@@ -1,0 +1,144 @@
+import React, { useCallback, useContext, useEffect, useState } from "react";
+
+import api from "@mwdb-web/commons/api";
+import { ConfigContext } from "@mwdb-web/commons/config";
+
+function PluginItems(props) {
+    const { name, info } = props;
+    const { active, version, description } = info;
+
+    return (
+        <tr>
+            <td>
+                {name}{" "}
+                {active ? (
+                    <span className="badge badge-success">Active</span>
+                ) : (
+                    <span className="badge badge-danger">Inactive</span>
+                )}
+            </td>
+            <td>{description}</td>
+            <td>{version}</td>
+        </tr>
+    );
+}
+
+export default function SettingsOverview() {
+    const config = useContext(ConfigContext);
+    const [extendedInfo, setExtendedInfo] = useState();
+
+    async function updateExtendedInfo() {
+        try {
+            const response = await api.getServerAdminInfo();
+            setExtendedInfo(response.data);
+        } catch (e) {
+            console.error(e);
+        }
+    }
+
+    function FlagBadge({ enabled }) {
+        return enabled ? (
+            <span className="badge badge-success">enabled</span>
+        ) : (
+            <span className="badge badge-danger">disabled</span>
+        );
+    }
+
+    const getExtendedInfo = useCallback(updateExtendedInfo, []);
+
+    useEffect(() => {
+        getExtendedInfo();
+    }, [getExtendedInfo]);
+
+    if (!extendedInfo) return [];
+
+    const plugins = Object.entries(extendedInfo["active_plugins"])
+        .sort()
+        .map(([key, value]) => <PluginItems name={key} info={value} />);
+
+    return (
+        <div className="container">
+            <h2>Overview</h2>
+            <p className="lead">
+                Basic overview of MWDB Core general settings. Specific features
+                can be enabled in configuration file or using environment
+                variables.
+            </p>
+            <h5>Feature set</h5>
+            <table className="table table-bordered wrap-table">
+                <tbody>
+                    <tr>
+                        <th className="col-2">Server version</th>
+                        <td>
+                            <span className="badge badge-primary">
+                                {config.config["server_version"]}
+                            </span>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>User registration</th>
+                        <td>
+                            <FlagBadge
+                                enabled={
+                                    config.config["is_registration_enabled"]
+                                }
+                            />
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>Rate limits</th>
+                        <td>
+                            <FlagBadge
+                                enabled={extendedInfo["rate_limits_enabled"]}
+                            />
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>Karton integration</th>
+                        <td>
+                            <FlagBadge
+                                enabled={config.config["is_karton_enabled"]}
+                            />
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>Maintenance mode</th>
+                        <td>
+                            <FlagBadge
+                                enabled={config.config["is_maintenance_set"]}
+                            />
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>Plugins</th>
+                        <td>
+                            <FlagBadge
+                                enabled={extendedInfo["plugins_enabled"]}
+                            />
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <h5>Active plugins</h5>
+            {plugins.length ? (
+                <table className="table table-striped table-bordered wrap-table">
+                    <thead>
+                        <tr>
+                            <th>Plugin name</th>
+                            <th>Description</th>
+                            <th>Version</th>
+                        </tr>
+                    </thead>
+                    <tbody>{plugins}</tbody>
+                </table>
+            ) : (
+                <p>
+                    No plugins are installed. Visit our{" "}
+                    <a href="https://mwdb.readthedocs.io/">documentation</a> to
+                    learn about MWDB plugins and how they can be used and
+                    installed.
+                </p>
+            )}
+        </div>
+    );
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- Plugin information stays in `About` page even if we have better place for that kind of info
- We don't have good starting page for administration view

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- Moved plugin information to admin-restricted endpoint `GET /server/admin` as an replacement of `/server/plugins`
- UI: Moved plugin information from About to the new view
- Added SettingsOverview page available under `/settings` in Web UI

![image](https://user-images.githubusercontent.com/8720367/117705777-c286f000-b1cc-11eb-9738-6c14dbb23057.png)
