### PR TITLE
UI: Unified error/success handling via useViewAlert

### DIFF
--- a/mwdb/web/src/commons/ui/View.js
+++ b/mwdb/web/src/commons/ui/View.js
@@ -1,6 +1,6 @@
 import React from "react";
-import { useLocation } from "react-router-dom";
-import { Alert } from "./ErrorBoundary";
+import { useHistory, useLocation } from "react-router-dom";
+import { Alert, getErrorMessage } from "./ErrorBoundary";
 import { Extendable } from "../extensions";
 
 function ViewAlert(props) {
@@ -12,6 +12,43 @@ function ViewAlert(props) {
             warning={props.warning || locationState.warning}
         />
     );
+}
+
+export function useViewAlert() {
+    const history = useHistory();
+
+    function setAlert({ success, error: rawError, warning, state }) {
+        const { pathname, search } = history.location;
+        const error = rawError && getErrorMessage(rawError);
+        history.replace(
+            { pathname, search },
+            {
+                ...history.location.state,
+                ...(state || {}),
+                success,
+                error,
+                warning,
+            }
+        );
+    }
+
+    function redirectToAlert({
+        success,
+        error: rawError,
+        warning,
+        target,
+        state,
+    }) {
+        const error = rawError && getErrorMessage(rawError);
+        history.push(target, {
+            ...(state || {}),
+            success,
+            error,
+            warning,
+        });
+    }
+
+    return { setAlert, redirectToAlert };
 }
 
 export default function View(props) {

--- a/mwdb/web/src/commons/ui/index.js
+++ b/mwdb/web/src/commons/ui/index.js
@@ -27,7 +27,7 @@ export {
 } from "./ProtectedRoute";
 export { default as RefString } from "./RefString";
 export { default as SortedList } from "./SortedList";
-export { default as View } from "./View";
+export { default as View, useViewAlert } from "./View";
 export { default as ActionCopyToClipboard } from "./ActionCopyToClipboard";
 
 export { Tag, TagList } from "./Tag";

--- a/mwdb/web/src/components/Profile/ProfileView.js
+++ b/mwdb/web/src/components/Profile/ProfileView.js
@@ -1,18 +1,12 @@
 import React, { useCallback, useContext, useEffect, useState } from "react";
-import {
-    NavLink,
-    Route,
-    Switch,
-    useHistory,
-    useParams,
-} from "react-router-dom";
+import { NavLink, Route, Switch, useParams } from "react-router-dom";
 
 import { faUserCog } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 import api from "@mwdb-web/commons/api";
 import { AuthContext } from "@mwdb-web/commons/auth";
-import { View, getErrorMessage } from "@mwdb-web/commons/ui";
+import { View } from "@mwdb-web/commons/ui";
 
 import ProfileDetails from "./Views/ProfileDetails";
 import ProfileAPIKeys from "./Views/ProfileAPIKeys";
@@ -20,6 +14,7 @@ import ProfileCapabilities from "./Views/ProfileCapabilities";
 import ProfileResetPassword from "./Views/ProfileResetPassword";
 import ProfileGroup from "./Views/ProfileGroup";
 import ProfileGroups from "./Views/ProfileGroups";
+import { useViewAlert } from "../../commons/ui";
 
 function ProfileNav() {
     return (
@@ -48,7 +43,7 @@ function ProfileNav() {
 
 export default function ProfileView() {
     const auth = useContext(AuthContext);
-    const history = useHistory();
+    const viewAlert = useViewAlert();
     const user = useParams().user || auth.user.login;
     const [profile, setProfile] = useState();
 
@@ -57,9 +52,9 @@ export default function ProfileView() {
             const response = await api.getUserProfile(user);
             setProfile(response.data);
         } catch (error) {
-            history.push({
-                pathname: "/profile",
-                state: { error: getErrorMessage(error) },
+            viewAlert.redirectToAlert({
+                target: "/profile",
+                error,
             });
         }
     }

--- a/mwdb/web/src/components/Profile/Views/ProfileAPIKeys.js
+++ b/mwdb/web/src/components/Profile/Views/ProfileAPIKeys.js
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { CopyToClipboard } from "react-copy-to-clipboard";
-import { useHistory, useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 
 import {
     faCopy,
@@ -15,13 +15,13 @@ import api from "@mwdb-web/commons/api";
 import {
     ConfirmationModal,
     DateString,
-    getErrorMessage,
     ShowIf,
+    useViewAlert,
 } from "@mwdb-web/commons/ui";
 
 export default function ProfileAPIKeys({ profile, updateProfile }) {
-    const history = useHistory();
     const location = useLocation();
+    const viewAlert = useViewAlert();
     const [currentApiToken, setCurrentApiToken] = useState({});
     const [apiKeyToRemove, setApiKeyToRemove] = useState();
     const [removeModalOpened, setRemoveModalOpened] = useState(false);
@@ -34,10 +34,7 @@ export default function ProfileAPIKeys({ profile, updateProfile }) {
             const response = await api.apiKeyGetToken(apiKeyId);
             setCurrentApiToken(response.data);
         } catch (error) {
-            history.push({
-                pathname: location.pathname,
-                state: { error: getErrorMessage(error) },
-            });
+            viewAlert.setAlert({ error });
         }
     }
 
@@ -46,18 +43,14 @@ export default function ProfileAPIKeys({ profile, updateProfile }) {
             const response = await api.apiKeyAdd(profile.login);
             setCurrentApiToken(response.data);
             updateProfile();
-            history.push({
-                pathname: location.pathname,
+            viewAlert.setAlert({
+                success: "New API key successfully added",
                 state: {
-                    success: "New API key successfully added",
                     addedKey: response.data.id,
                 },
             });
         } catch (error) {
-            history.push({
-                pathname: location.pathname,
-                state: { error: getErrorMessage(error) },
-            });
+            viewAlert.setAlert({ error });
         }
     }
 
@@ -68,17 +61,14 @@ export default function ProfileAPIKeys({ profile, updateProfile }) {
             setApiKeyToRemove(undefined);
             updateProfile();
             setRemoveModalOpened(false);
-            history.push({
-                pathname: location.pathname,
+            viewAlert.setAlert({
+                success: "API key successfully removed",
                 state: {
-                    success: "API key successfully removed",
+                    addedKey: null,
                 },
             });
         } catch (error) {
-            history.push({
-                pathname: location.pathname,
-                state: { error: getErrorMessage(error) },
-            });
+            viewAlert.setAlert({ error });
         }
     }
 
@@ -105,8 +95,7 @@ export default function ProfileAPIKeys({ profile, updateProfile }) {
             {profile.api_keys.map((apiKey) => (
                 <div
                     className={`card ${
-                        history.location.state &&
-                        history.location.state.addedKey === apiKey.id
+                        location.state && location.state.addedKey === apiKey.id
                             ? "border-success"
                             : ""
                     }`}

--- a/mwdb/web/src/components/Profile/Views/ProfileGroup.js
+++ b/mwdb/web/src/components/Profile/Views/ProfileGroup.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useContext, useEffect, useState } from "react";
-import { Link, Redirect, useParams, useHistory } from "react-router-dom";
+import { Link, Redirect, useParams } from "react-router-dom";
 
 import { faUsersCog } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -7,7 +7,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import api from "@mwdb-web/commons/api";
 import { AuthContext, Capability } from "@mwdb-web/commons/auth";
 import { makeSearchLink } from "@mwdb-web/commons/helpers";
-import { GroupBadge, ShowIf, getErrorMessage } from "@mwdb-web/commons/ui";
+import { GroupBadge, ShowIf, useViewAlert } from "@mwdb-web/commons/ui";
 
 function ProfileItem(props) {
     if (!props.value) return [];
@@ -21,7 +21,7 @@ function ProfileItem(props) {
 
 export default function ProfileGroup({ profile }) {
     const auth = useContext(AuthContext);
-    const history = useHistory();
+    const viewAlert = useViewAlert();
     const { group: groupName } = useParams();
     const [workspaces, setWorkspaces] = useState();
 
@@ -30,11 +30,9 @@ export default function ProfileGroup({ profile }) {
             const response = await api.authGroups();
             setWorkspaces(response.data["groups"]);
         } catch (error) {
-            history.push({
-                pathname: "/profile",
-                state: {
-                    error: getErrorMessage(error),
-                },
+            viewAlert.redirectToAlert({
+                target: "/profile",
+                error,
             });
         }
     }

--- a/mwdb/web/src/components/Profile/Views/ProfileGroups.js
+++ b/mwdb/web/src/components/Profile/Views/ProfileGroups.js
@@ -1,12 +1,10 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { useHistory } from "react-router-dom";
 
 import api from "@mwdb-web/commons/api";
-import { getErrorMessage } from "@mwdb-web/commons/ui";
-import { GroupBadge } from "../../../commons/ui";
+import { GroupBadge, useViewAlert } from "../../../commons/ui";
 
 export default function ProfileGroups({ profile }) {
-    const history = useHistory();
+    const viewAlert = useViewAlert();
     const [workspaces, setWorkspaces] = useState();
 
     async function updateWorkspaces() {
@@ -14,11 +12,9 @@ export default function ProfileGroups({ profile }) {
             const response = await api.authGroups();
             setWorkspaces(response.data["groups"]);
         } catch (error) {
-            history.push({
-                pathname: "/profile",
-                state: {
-                    error: getErrorMessage(error),
-                },
+            viewAlert.redirectToAlert({
+                target: "/profile",
+                error,
             });
         }
     }

--- a/mwdb/web/src/components/Profile/Views/ProfileResetPassword.js
+++ b/mwdb/web/src/components/Profile/Views/ProfileResetPassword.js
@@ -1,31 +1,24 @@
 import React, { useState } from "react";
-import { Link, useHistory } from "react-router-dom";
+import { Link } from "react-router-dom";
 
 import api from "@mwdb-web/commons/api";
-import { ShowIf, getErrorMessage } from "@mwdb-web/commons/ui";
+import { ShowIf, useViewAlert } from "@mwdb-web/commons/ui";
 
 export default function ProfileResetPassword({ profile }) {
     const [pending, setPending] = useState(false);
-    const history = useHistory();
+    const viewAlert = useViewAlert();
 
     async function resetPassword() {
         setPending(true);
         try {
             await api.authRequestPasswordChange();
-            history.push({
-                pathname: "/profile",
-                state: {
-                    success:
-                        "Password reset link was successfully sent to your e-mail address.",
-                },
+            viewAlert.redirectToAlert({
+                target: "/profile",
+                success:
+                    "Password reset link was successfully sent to your e-mail address.",
             });
         } catch (error) {
-            history.push({
-                pathname: "/profile",
-                state: {
-                    error: getErrorMessage(error),
-                },
-            });
+            viewAlert.setAlert({ error });
         }
     }
 

--- a/mwdb/web/src/components/Settings/SettingsView.js
+++ b/mwdb/web/src/components/Settings/SettingsView.js
@@ -119,14 +119,9 @@ function SettingsNav() {
     );
 }
 
-export default function SettingsView(props) {
+export default function SettingsView() {
     return (
-        <View
-            ident="settings"
-            error={props.error}
-            success={props.success}
-            fluid
-        >
+        <View ident="settings" fluid>
             <div className="row">
                 <div className="col-sm-2">
                     <SettingsNav />

--- a/mwdb/web/src/components/Settings/Views/AccessControl.js
+++ b/mwdb/web/src/components/Settings/Views/AccessControl.js
@@ -13,6 +13,7 @@ import {
     ConfirmationModal,
     GroupBadge,
     ShowIf,
+    useViewAlert,
 } from "@mwdb-web/commons/ui";
 
 function GroupAppliesTo({ group }) {
@@ -195,6 +196,7 @@ function CapabilityChangeCard({ groups, onSubmit }) {
 
 export default function AccessControl() {
     const [groups, setGroups] = useState(null);
+    const viewAlert = useViewAlert();
 
     const [isChangeModalOpen, setChangeModalOpen] = useState(false);
     const [disabledModalButton, setDisabledModalButton] = useState(false);
@@ -211,7 +213,7 @@ export default function AccessControl() {
             );
             setGroups(groupList);
         } catch (error) {
-            console.error(error);
+            viewAlert.setAlert({ error });
         }
     }
 
@@ -220,8 +222,11 @@ export default function AccessControl() {
             setDisabledModalButton(true);
             await api.updateGroup(group, undefined, capabilities);
             await updateGroups();
-        } catch (e) {
-            // todo
+            viewAlert.setAlert({
+                success: `Group '${group}' capabilities successfully changed`,
+            });
+        } catch (error) {
+            viewAlert.setAlert({ error });
         } finally {
             setDisabledModalButton(false);
             setChangeModalOpen(false);

--- a/mwdb/web/src/components/Settings/Views/AttributeDetails.js
+++ b/mwdb/web/src/components/Settings/Views/AttributeDetails.js
@@ -1,10 +1,10 @@
 import React, { useState, useContext } from "react";
-import { Link, useHistory } from "react-router-dom";
+import { Link } from "react-router-dom";
 import api from "@mwdb-web/commons/api";
 import {
-    getErrorMessage,
     ConfirmationModal,
     EditableItem,
+    useViewAlert,
 } from "@mwdb-web/commons/ui";
 import { AuthContext, Capability } from "@mwdb-web/commons/auth";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -21,7 +21,7 @@ function AttributeItem(props) {
 
 export function AttributeDetails({ attribute, getAttribute }) {
     const auth = useContext(AuthContext);
-    const history = useHistory();
+    const viewAlert = useViewAlert();
     const [isDeleteModalOpen, setDeleteModalOpen] = useState(false);
     const [isDeleteModalDisabled, setDeleteModalDisabled] = useState(false);
 
@@ -34,10 +34,7 @@ export function AttributeDetails({ attribute, getAttribute }) {
         try {
             await api.updateMetakeyDefinition(attribute.key, newValue);
         } catch (error) {
-            history.push({
-                pathname: `/admin/attribute/${attribute.key}`,
-                state: { error: getErrorMessage(error) },
-            });
+            viewAlert.setAlert({ error });
         } finally {
             getAttribute();
         }
@@ -47,12 +44,12 @@ export function AttributeDetails({ attribute, getAttribute }) {
         try {
             setDeleteModalDisabled(true);
             await api.removeMetakeyDefinition(attribute.key);
-            history.push("/admin/attributes");
-        } catch (error) {
-            history.push({
-                pathname: `/admin/attribute/${attribute.key}`,
-                state: { error: getErrorMessage(error) },
+            viewAlert.redirectToAlert({
+                target: "/admin/attributes",
+                success: `Attribute '${attribute.key}' successfully removed.`,
             });
+        } catch (error) {
+            viewAlert.setAlert({ error });
         }
     }
 

--- a/mwdb/web/src/components/Settings/Views/AttributePermissions.js
+++ b/mwdb/web/src/components/Settings/Views/AttributePermissions.js
@@ -3,10 +3,10 @@ import React, { Component, useState, useEffect, useCallback } from "react";
 import api from "@mwdb-web/commons/api";
 import {
     Autocomplete,
-    getErrorMessage,
     ConfirmationModal,
+    useViewAlert,
 } from "@mwdb-web/commons/ui";
-import { Link, useHistory, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 
 class AttributePermissionsBox extends Component {
     state = {
@@ -241,7 +241,7 @@ class AttributePermissionsBox extends Component {
 
 export function AttributesPermissions({ attribute, getAttribute }) {
     const { metakey } = useParams();
-    const history = useHistory();
+    const viewAlert = useViewAlert();
     const [allGroups, setAllGroups] = useState([]);
     const [permissions, setPermissions] = useState({});
     const [modalSpec, setModalSpec] = useState({});
@@ -252,7 +252,7 @@ export function AttributesPermissions({ attribute, getAttribute }) {
             await api.setMetakeyPermission(attribute.key, group, false, false);
             getAttribute();
         } catch (error) {
-            this.setState({ error });
+            viewAlert.setAlert({ error });
         }
     }
 
@@ -267,10 +267,7 @@ export function AttributesPermissions({ attribute, getAttribute }) {
             getAttribute();
             setModalOpen(false);
         } catch (error) {
-            history.push({
-                pathname: `/admin/attribute/${attribute.key}`,
-                state: { error: getErrorMessage(error) },
-            });
+            viewAlert.setAlert({ error });
         }
     }
 
@@ -290,7 +287,7 @@ export function AttributesPermissions({ attribute, getAttribute }) {
             getAttribute();
             setModalOpen(false);
         } catch (error) {
-            this.setState({ error });
+            viewAlert.setAlert({ error });
         }
     }
 
@@ -309,10 +306,7 @@ export function AttributesPermissions({ attribute, getAttribute }) {
             let response = await api.getGroups();
             setAllGroups(response.data.groups);
         } catch (error) {
-            history.push({
-                pathname: `/admin/attribute/${metakey}`,
-                state: { error: getErrorMessage(error) },
-            });
+            viewAlert.setAlert({ error });
         }
     }
 

--- a/mwdb/web/src/components/Settings/Views/AttributeView.js
+++ b/mwdb/web/src/components/Settings/Views/AttributeView.js
@@ -1,19 +1,13 @@
 import React, { useCallback, useEffect, useState } from "react";
-import {
-    Link,
-    Switch,
-    useHistory,
-    useLocation,
-    useParams,
-} from "react-router-dom";
+import { Link, Switch, useLocation, useParams } from "react-router-dom";
 import api from "@mwdb-web/commons/api";
 import { AttributeDetails } from "./AttributeDetails";
-import { AttributeRoute, getErrorMessage } from "@mwdb-web/commons/ui";
+import { AttributeRoute, useViewAlert } from "@mwdb-web/commons/ui";
 import { AttributesPermissions } from "./AttributePermissions";
 
 export default function AttributeView() {
     const location = useLocation();
-    const history = useHistory();
+    const viewAlert = useViewAlert();
     const { metakey } = useParams();
     const [attribute, setAttribute] = useState({});
 
@@ -22,10 +16,7 @@ export default function AttributeView() {
             let response = await api.getMetakeyDefinition(metakey);
             setAttribute(response.data);
         } catch (error) {
-            history.push({
-                pathname: `/admin/attribute/${metakey}`,
-                state: { error: getErrorMessage(error) },
-            });
+            viewAlert.setAlert({ error });
         }
     }
 

--- a/mwdb/web/src/components/Settings/Views/GroupDetails.js
+++ b/mwdb/web/src/components/Settings/Views/GroupDetails.js
@@ -1,10 +1,10 @@
 import React, { useState } from "react";
-import { Link, useHistory, useLocation } from "react-router-dom";
+import { Link } from "react-router-dom";
 import api from "@mwdb-web/commons/api";
 import {
-    getErrorMessage,
     ConfirmationModal,
     EditableItem,
+    useViewAlert,
 } from "@mwdb-web/commons/ui";
 import { makeSearchLink } from "@mwdb-web/commons/helpers";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -20,23 +20,18 @@ function GroupItem(props) {
 }
 
 export default function GroupDetails({ group }) {
-    const history = useHistory();
-    const location = useLocation();
-    const pathNames = location.pathname.split("/");
+    const viewAlert = useViewAlert();
     const [isDeleteModalOpen, setDeleteModalOpen] = useState(false);
     const [isDeleteModalDisabled, setDeleteModalDisabled] = useState(false);
 
     async function handleSubmit(newName) {
         try {
             await api.updateGroup(group.name, newName["name"], undefined);
-            history.push({
-                pathname: `/${pathNames[1]}/${pathNames[2]}/${newName["name"]}`,
+            viewAlert.setAlert({
+                success: `Group successfully updated.`,
             });
         } catch (error) {
-            history.push({
-                pathname: `/admin/group/${group.name}`,
-                state: { error: getErrorMessage(error) },
-            });
+            viewAlert.setAlert({ error });
         }
     }
 
@@ -44,15 +39,12 @@ export default function GroupDetails({ group }) {
         try {
             setDeleteModalDisabled(true);
             await api.removeGroup(group.name);
-            history.push({
-                pathname: `/admin/groups/`,
-                state: { success: "Group has been successfully removed" },
+            viewAlert.redirectToAlert({
+                target: `/admin/groups/`,
+                success: `Group '${group.name}' has been successfully removed`,
             });
         } catch (error) {
-            history.push({
-                pathname: `/admin/group/${group.name}`,
-                state: { error: getErrorMessage(error) },
-            });
+            viewAlert.setAlert({ error });
             setDeleteModalOpen(false);
             setDeleteModalDisabled(false);
         }

--- a/mwdb/web/src/components/Settings/Views/GroupMembers.js
+++ b/mwdb/web/src/components/Settings/Views/GroupMembers.js
@@ -1,26 +1,25 @@
 import React, { useEffect, useState, useCallback } from "react";
 import { UserLink } from "./ShowUsers";
 import api from "@mwdb-web/commons/api";
-import { MemberList, getErrorMessage } from "@mwdb-web/commons/ui";
-import { useHistory } from "react-router-dom";
+import { MemberList, useViewAlert } from "@mwdb-web/commons/ui";
 
 export let GroupMemberList = (props) => (
     <MemberList nameKey="login" itemLinkClass={UserLink} {...props} />
 );
 
 export default function GroupMembers({ group, getGroup }) {
-    const history = useHistory();
+    const viewAlert = useViewAlert();
     const [allUsers, setAllUsers] = useState([]);
 
     async function addMember(login) {
         try {
             await api.addGroupMember(group.name, login);
             getGroup();
-        } catch (error) {
-            history.push({
-                pathname: `/admin/group/${group.name}`,
-                state: { error: getErrorMessage(error) },
+            viewAlert.setAlert({
+                success: `Member '${login}' successfully added.`,
             });
+        } catch (error) {
+            viewAlert.setAlert({ error });
         }
     }
 
@@ -28,22 +27,22 @@ export default function GroupMembers({ group, getGroup }) {
         try {
             await api.removeGroupMember(group.name, login);
             getGroup();
-        } catch (error) {
-            history.push({
-                pathname: `/admin/group/${group.name}`,
-                state: { error: getErrorMessage(error) },
+            viewAlert.setAlert({
+                success: `Member '${login}' successfully removed.`,
             });
+        } catch (error) {
+            viewAlert.setAlert({ error });
         }
     }
     async function setAdminMembership(login, membership) {
         try {
             await api.setGroupAdmin(group.name, login, membership);
             getGroup();
-        } catch (error) {
-            history.push({
-                pathname: `/admin/group/${group.name}`,
-                state: { error: getErrorMessage(error) },
+            viewAlert.setAlert({
+                success: `Member '${login}' successfully updated.`,
             });
+        } catch (error) {
+            viewAlert.setAlert({ error });
         }
     }
 
@@ -52,10 +51,7 @@ export default function GroupMembers({ group, getGroup }) {
             let response = await api.getUsers();
             setAllUsers(response.data.users);
         } catch (error) {
-            history.push({
-                pathname: `/admin/group/${group.name}`,
-                state: { error: getErrorMessage(error) },
-            });
+            viewAlert.setAlert({ error });
         }
     }
 

--- a/mwdb/web/src/components/Settings/Views/GroupView.js
+++ b/mwdb/web/src/components/Settings/Views/GroupView.js
@@ -1,14 +1,8 @@
 import React, { useCallback, useEffect, useState } from "react";
-import {
-    useHistory,
-    useParams,
-    Switch,
-    Link,
-    useLocation,
-} from "react-router-dom";
+import { useParams, Switch, Link, useLocation } from "react-router-dom";
 
 import api from "@mwdb-web/commons/api";
-import { AdministrativeRoute, getErrorMessage } from "@mwdb-web/commons/ui";
+import { AdministrativeRoute, useViewAlert } from "@mwdb-web/commons/ui";
 
 import GroupDetails from "./GroupDetails";
 import ProfileCapabilities from "../../Profile/Views/ProfileCapabilities";
@@ -16,19 +10,16 @@ import GroupMembers from "./GroupMembers";
 
 export default function GroupView() {
     const location = useLocation();
-    const history = useHistory();
+    const viewAlert = useViewAlert();
     const { name } = useParams();
     const [group, setGroup] = useState({});
-    console.log(group);
+
     async function updateGroup() {
         try {
             const response = await api.getGroup(name);
             setGroup(response.data);
         } catch (error) {
-            history.push({
-                pathname: `/admin/group/${group.name}`,
-                state: { error: getErrorMessage(error) },
-            });
+            viewAlert.setAlert({ error });
         }
     }
 

--- a/mwdb/web/src/components/Settings/Views/SettingsOverview.js
+++ b/mwdb/web/src/components/Settings/Views/SettingsOverview.js
@@ -2,6 +2,7 @@ import React, { useCallback, useContext, useEffect, useState } from "react";
 
 import api from "@mwdb-web/commons/api";
 import { ConfigContext } from "@mwdb-web/commons/config";
+import { useViewAlert } from "@mwdb-web/commons/ui";
 
 function PluginItems(props) {
     const { name, info } = props;
@@ -25,14 +26,15 @@ function PluginItems(props) {
 
 export default function SettingsOverview() {
     const config = useContext(ConfigContext);
+    const viewAlert = useViewAlert();
     const [extendedInfo, setExtendedInfo] = useState();
 
     async function updateExtendedInfo() {
         try {
             const response = await api.getServerAdminInfo();
             setExtendedInfo(response.data);
-        } catch (e) {
-            console.error(e);
+        } catch (error) {
+            viewAlert.setAlert({ error });
         }
     }
 

--- a/mwdb/web/src/components/Settings/Views/UserDetails.js
+++ b/mwdb/web/src/components/Settings/Views/UserDetails.js
@@ -1,11 +1,11 @@
 import React, { useState } from "react";
-import { Link, useHistory } from "react-router-dom";
+import { Link } from "react-router-dom";
 import api from "@mwdb-web/commons/api";
 import {
     DateString,
-    getErrorMessage,
     ConfirmationModal,
     EditableItem,
+    useViewAlert,
 } from "@mwdb-web/commons/ui";
 import { makeSearchLink } from "@mwdb-web/commons/helpers";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -21,18 +21,18 @@ function UserItem(props) {
 }
 
 export default function UserDetails({ user, getUser }) {
-    const history = useHistory();
+    const viewAlert = useViewAlert();
     const [isDeleteModalOpen, setDeleteModalOpen] = useState(false);
     const [isDeleteModalDisabled, setDeleteModalDisabled] = useState(false);
 
     async function handleSubmit(newValue) {
         try {
             await api.updateUser(user.login, newValue);
-        } catch (error) {
-            history.push({
-                pathname: `/admin/user/${user.login}`,
-                state: { error: getErrorMessage(error) },
+            viewAlert.setAlert({
+                success: "User successfully updated.",
             });
+        } catch (error) {
+            viewAlert.setAlert({ error });
         } finally {
             getUser();
         }
@@ -41,11 +41,11 @@ export default function UserDetails({ user, getUser }) {
     async function setDisabledState(ban) {
         try {
             await api.setUserDisabled(user.login, ban);
-        } catch (error) {
-            history.push({
-                pathname: `/admin/user/${user.login}`,
-                state: { error: getErrorMessage(error) },
+            viewAlert.setAlert({
+                success: `User successfully ${ban ? "blocked" : "unblocked"}.`,
             });
+        } catch (error) {
+            viewAlert.setAlert({ error });
         } finally {
             getUser();
         }
@@ -55,15 +55,12 @@ export default function UserDetails({ user, getUser }) {
         try {
             setDeleteModalDisabled(true);
             await api.removeUser(user.login);
-            history.push({
-                pathname: `/admin/users/`,
-                state: { success: "User has been successfully removed" },
+            viewAlert.redirectToAlert({
+                target: "/admin/users",
+                success: `User '${user.login}' successfully removed.`,
             });
         } catch (error) {
-            history.push({
-                pathname: `/admin/user/${user.login}`,
-                state: { error: getErrorMessage(error) },
-            });
+            viewAlert.setAlert({ error });
             setDeleteModalDisabled(false);
         }
     }

--- a/mwdb/web/src/components/Settings/Views/UserResetPassword.js
+++ b/mwdb/web/src/components/Settings/Views/UserResetPassword.js
@@ -1,34 +1,26 @@
 import React, { useState } from "react";
 import { CopyToClipboard } from "react-copy-to-clipboard";
-import { Link, useHistory } from "react-router-dom";
+import { Link } from "react-router-dom";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 import api from "@mwdb-web/commons/api";
-import { ShowIf, getErrorMessage } from "@mwdb-web/commons/ui";
+import { ShowIf, useViewAlert } from "@mwdb-web/commons/ui";
 
 export default function UserResetPassword({ user }) {
-    const history = useHistory();
+    const viewAlert = useViewAlert();
     const [pending, setPending] = useState(false);
     const [passwordURL, setPasswordURL] = useState("");
     async function resetPassword() {
         setPending(true);
         try {
             await api.authRequestPasswordChange();
-            history.push({
-                pathname: `/admin/user/${user.login}`,
-                state: {
-                    success:
-                        "Password reset link was successfully sent to your e-mail address.",
-                },
+            viewAlert.redirectToAlert({
+                target: `/admin/user/${user.login}`,
+                success: `Password reset link was successfully sent to '${user.email}'.`,
             });
         } catch (error) {
-            history.push({
-                pathname: `/admin/user/${user.login}`,
-                state: {
-                    error: getErrorMessage(error),
-                },
-            });
+            viewAlert.setAlert({ error });
         }
     }
 
@@ -39,12 +31,7 @@ export default function UserResetPassword({ user }) {
             let response = await api.generateSetPasswordToken(user.login);
             setPasswordURL(getURLFromToken(response.data.token));
         } catch (error) {
-            history.push({
-                pathname: `/admin/user/${user.login}`,
-                state: {
-                    error: getErrorMessage(error),
-                },
-            });
+            viewAlert.setAlert({ error });
         }
     }
 

--- a/mwdb/web/src/components/Settings/Views/UserSingleGroups.js
+++ b/mwdb/web/src/components/Settings/Views/UserSingleGroups.js
@@ -1,26 +1,26 @@
 import React, { useEffect, useState, useCallback } from "react";
 import { GroupLink } from "./ShowGroups";
+
 import api from "@mwdb-web/commons/api";
-import { MemberList, getErrorMessage } from "@mwdb-web/commons/ui";
-import { useHistory } from "react-router-dom";
+import { MemberList, useViewAlert } from "@mwdb-web/commons/ui";
 
 export let GroupMemberList = (props) => (
     <MemberList nameKey="name" itemLinkClass={GroupLink} {...props} />
 );
 
 export default function UserSingleGroups({ user, getUser }) {
-    const history = useHistory();
+    const viewAlert = useViewAlert();
     const [allGroups, setAllGroups] = useState([]);
 
     async function addMember(group) {
         try {
             await api.addGroupMember(group, user.login);
             getUser();
-        } catch (error) {
-            history.push({
-                pathname: `/admin/user/${user.login}`,
-                state: { error: getErrorMessage(error) },
+            viewAlert.setAlert({
+                success: `User successfully added to '${group}' group.`,
             });
+        } catch (error) {
+            viewAlert.setAlert({ error });
         }
     }
 
@@ -28,11 +28,11 @@ export default function UserSingleGroups({ user, getUser }) {
         try {
             await api.removeGroupMember(group, user.login);
             getUser();
-        } catch (error) {
-            history.push({
-                pathname: `/admin/user/${user.login}`,
-                state: { error: getErrorMessage(error) },
+            viewAlert.setAlert({
+                success: `User successfully removed from '${group}' group.`,
             });
+        } catch (error) {
+            viewAlert.setAlert({ error });
         }
     }
 
@@ -41,10 +41,7 @@ export default function UserSingleGroups({ user, getUser }) {
             let response = await api.getGroups();
             setAllGroups(response.data.groups);
         } catch (error) {
-            history.push({
-                pathname: `/admin/user/${user.login}`,
-                state: { error: getErrorMessage(error) },
-            });
+            viewAlert.setAlert({ error });
         }
     }
 

--- a/mwdb/web/src/components/Settings/Views/UserView.js
+++ b/mwdb/web/src/components/Settings/Views/UserView.js
@@ -1,14 +1,8 @@
 import React, { useCallback, useEffect, useState } from "react";
-import {
-    useHistory,
-    useParams,
-    Switch,
-    Link,
-    useLocation,
-} from "react-router-dom";
+import { useParams, Switch, Link, useLocation } from "react-router-dom";
 
 import api from "@mwdb-web/commons/api";
-import { AdministrativeRoute, getErrorMessage } from "@mwdb-web/commons/ui";
+import { AdministrativeRoute, useViewAlert } from "@mwdb-web/commons/ui";
 
 import UserDetails from "./UserDetails";
 import UserResetPassword from "./UserResetPassword";
@@ -18,7 +12,7 @@ import UserSingleGroups from "./UserSingleGroups";
 
 export default function UserView() {
     const location = useLocation();
-    const history = useHistory();
+    const viewAlert = useViewAlert();
     const { login } = useParams();
     const [user, setUser] = useState({});
 
@@ -27,10 +21,7 @@ export default function UserView() {
             const response = await api.getUser(login);
             setUser(response.data);
         } catch (error) {
-            history.push({
-                pathname: `/admin/user/${user.login}`,
-                state: { error: getErrorMessage(error) },
-            });
+            viewAlert.setAlert({ error });
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- Setting success/error alert directly via `history` is a bit too complicated. This results in error handling inconsistency.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- Added `useViewAlert` hook that unifies error handling via location state.
- Fixed error/success handling in some places in Profile/Settings views