### PR TITLE
UI: Prevent navigation to #block-user in nav-links

### DIFF
--- a/mwdb/web/src/components/Settings/Views/AttributeDetails.js
+++ b/mwdb/web/src/components/Settings/Views/AttributeDetails.js
@@ -121,7 +121,10 @@ export function AttributeDetails({ attribute, getAttribute }) {
                     <a
                         href="#remove-user"
                         className="nav-link text-danger"
-                        onClick={() => setDeleteModalOpen(true)}
+                        onClick={(ev) => {
+                            ev.preventDefault();
+                            setDeleteModalOpen(true);
+                        }}
                     >
                         <FontAwesomeIcon icon="trash" />
                         Remove attribute

--- a/mwdb/web/src/components/Settings/Views/GroupDetails.js
+++ b/mwdb/web/src/components/Settings/Views/GroupDetails.js
@@ -113,7 +113,10 @@ export default function GroupDetails({ group }) {
                     <a
                         href="#remove-group"
                         className="nav-link text-danger"
-                        onClick={() => setDeleteModalOpen(true)}
+                        onClick={(ev) => {
+                            ev.preventDefault();
+                            setDeleteModalOpen(true);
+                        }}
                     >
                         <FontAwesomeIcon icon="trash" />
                         Remove group

--- a/mwdb/web/src/components/Settings/Views/UserDetails.js
+++ b/mwdb/web/src/components/Settings/Views/UserDetails.js
@@ -169,7 +169,10 @@ export default function UserDetails({ user, getUser }) {
                         <a
                             href="#block-user"
                             className="nav-link text-danger"
-                            onClick={() => setDisabledState(false)}
+                            onClick={(ev) => {
+                                ev.preventDefault();
+                                setDisabledState(false);
+                            }}
                         >
                             <FontAwesomeIcon icon="ban" />
                             Unblock user
@@ -178,7 +181,10 @@ export default function UserDetails({ user, getUser }) {
                         <a
                             href="#block-user"
                             className="nav-link text-danger"
-                            onClick={() => setDisabledState(true)}
+                            onClick={(ev) => {
+                                ev.preventDefault();
+                                setDisabledState(true);
+                            }}
                         >
                             <FontAwesomeIcon icon="ban" />
                             Block user
@@ -187,7 +193,10 @@ export default function UserDetails({ user, getUser }) {
                     <a
                         href="#remove-user"
                         className="nav-link text-danger"
-                        onClick={() => setDeleteModalOpen(true)}
+                        onClick={(ev) => {
+                            ev.preventDefault();
+                            setDeleteModalOpen(true);
+                        }}
                     >
                         <FontAwesomeIcon icon="trash" />
                         Remove user


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- Action nav-links navigate to `#...` because of missing `preventDefault`

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- Added missing `preventDefault` invocations
