### PR TITLE
Fix: Remove eager-loading of all related object attributes in MetakeyDefinition

### DIFF
--- a/mwdb/model/metakey.py
+++ b/mwdb/model/metakey.py
@@ -129,7 +129,6 @@ class MetakeyDefinition(db.Model):
     )
     metakey = db.relationship(
         "Metakey",
-        lazy="joined",
         back_populates="template",
         cascade="all, delete",
     )


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- `[url]/admin/attributes` doesn't load because request to `/api/meta/manage` takes too long. SQL query used underneath loads not only attribute keys but also attribute values

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- Removed eager-loading introduced accidently in https://github.com/CERT-Polska/mwdb-core/pull/321

Thanks @ITAYC0HEN for noticing that flaw!