### PR TITLE
Fix: removed abandoned check in ListField

### DIFF
--- a/mwdb/core/search/fields.py
+++ b/mwdb/core/search/fields.py
@@ -151,8 +151,6 @@ class ListField(BaseField):
         value = get_term_value(expression)
 
         if expression.has_wildcard():
-            if not self.support_wildcards:
-                raise UnsupportedGrammarException("Wildcards are not allowed here")
             return self.column.any(self.value_column.like(value))
         else:
             return self.column.any(self.value_column == value)


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- ListField doesn't work with wildcard values due to abandoned part of code introduced in https://github.com/CERT-Polska/mwdb-core/pull/298 (dev, current stable not affected)

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- Removed check that references non-existent `support_wildcards` attribute

Noticed by @ITAYC0HEN.
