### PR TITLE
Bump version: 2.3.0-rc1

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ copyright = '2021, CERT Polska'
 author = 'CERT Polska'
 
 # The full version, including alpha/beta/rc tags
-release = '2.3.0'
+release = '2.3.0-rc1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/mwdb/version.py
+++ b/mwdb/version.py
@@ -4,5 +4,5 @@ try:
 except IOError:
     git_revision = ""
 
-app_version = "2.3.0"
+app_version = "2.3.0-rc1"
 app_build_version = f"{app_version}+{git_revision}" if git_revision else app_version

--- a/mwdb/web/package-lock.json
+++ b/mwdb/web/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mwdb-web",
-  "version": "2.3.0",
+  "version": "2.3.0-rc1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/mwdb/web/package.json
+++ b/mwdb/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mwdb-web",
-  "version": "2.3.0",
+  "version": "2.3.0-rc1",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.0-14",

--- a/mwdb/web/src/commons/package.json
+++ b/mwdb/web/src/commons/package.json
@@ -2,7 +2,7 @@
     "name": "@mwdb-web/commons",
     "main": "index.js",
     "private": true,
-    "version": "2.3.0",
+    "version": "2.3.0-rc1",
     "peerDependencies": {
         "@fortawesome/react-fontawesome": "*",
         "bootstrap-select": "*",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ Under the hood of mwdb.cert.pl service hosted by CERT.pl.
 """
 
 setup(name="mwdb-core",
-      version="2.3.0",
+      version="2.3.0-rc1",
       description="MWDB Core malware database",
       long_description=LONG_DESCRIPTION,
       author="CERT Polska",


### PR DESCRIPTION
Release Candidate version of mwdb-core 2.3.0 :tada:

This release is focused mainly on MWDB administration improvements and further UI refactoring. In addiition, Karton integration is now available out-of-the-box, without need of extra plugins.

**Key changes**:

- Read-only guest accounts (https://github.com/CERT-Polska/mwdb-core/pull/334):
    - All users are by default added into additional 'registered' group that enables profile customization and file upload
    - To make a guest account, just remove it from 'registered' group, so only the 'public' capabilities will apply to this group. 'public' group doesn't have any capabilities by default, but feel free to change it depending on your needs.
    - All groups have additional properties: "workspace" and "default". `registered` group and `public` group are not *workspaces* which prevents users from seeing each other within these groups. In the same time, they are *default* so all newcomers are automatically added.
- Built-in Karton integration (https://github.com/CERT-Polska/mwdb-core/pull/298)
- Removed `managing_attributes` capability because of its inconsistency. From now, all administration tasks require `manage_users` capability (https://github.com/CERT-Polska/mwdb-core/pull/377)
- New, more user-friendly Settings and Profile view

**Minor changes and improvements**:

- More removable elements:
    - Attribute definitions (https://github.com/CERT-Polska/mwdb-core/pull/321)
    - Relations (including permission inheritance side-effects, https://github.com/CERT-Polska/mwdb-core/pull/336)
    - Groups and users (https://github.com/CERT-Polska/mwdb-core/pull/347)
- Sessions are not invalidated when group or capabilities was changed (https://github.com/CERT-Polska/mwdb-core/pull/325)
- Added hooks for tags and comments (https://github.com/CERT-Polska/mwdb-core/pull/353, thanks @ITAYC0HEN!)
- Keyboard navigation in Autocomplete components (https://github.com/CERT-Polska/mwdb-core/pull/362)
- Replaced obsolete search help with link to ReadTheDocs (https://github.com/CERT-Polska/mwdb-core/pull/339)

**Bugfixes**:

- Fixed ISE 500 when member was already added/removed (https://github.com/CERT-Polska/mwdb-core/pull/332)
- Fixed broken tag search in detailed object view (https://github.com/CERT-Polska/mwdb-core/pull/378)
- Pending users counter is immediately updated after accepting/rejecting user (https://github.com/CERT-Polska/mwdb-core/pull/386)
