### PR TITLE
Ignore Karton integration plugin in plugin loader

### DIFF
--- a/mwdb/core/plugins.py
+++ b/mwdb/core/plugins.py
@@ -153,6 +153,15 @@ def load_plugins(app_context: PluginAppContext):
         for plugin_name in plugin_list:
             try:
                 plugin = importlib.import_module(plugin_name)
+                if getattr(plugin, "__doc__", "").startswith(
+                    "Karton integration plugin"
+                ):
+                    logger.warning(
+                        "Karton integration features are built-in from v2.3.0. "
+                        "Ignoring '%s'...",
+                        plugin_name,
+                    )
+                    continue
                 if hasattr(plugin, "__plugin_entrypoint__"):
                     getattr(plugin, "__plugin_entrypoint__")(app_context)
                 loaded_plugins[plugin_name] = plugin


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- Migrations are designed to migrate Karton attribute into new KartonAnalysis object.
- If Karton plugin is enabled, it sets back Karton attributes resulting in incorrect behavior.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- Ignore all plugins which description starting with `Karton integration plugin`

