### PR TITLE
Fix for premature session expiration

### DIFF
--- a/mwdb/web/src/commons/config/provider.js
+++ b/mwdb/web/src/commons/config/provider.js
@@ -99,7 +99,7 @@ export function ConfigProvider(props) {
             return () => {
                 clearInterval(timer);
             };
-        } else return;
+        }
     }, [
         auth.isAuthenticated,
         auth.isAdmin,


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
Multiple MWDB users are reporting problems with unexpected session expiration during normal usage or after leaving the MWDB opened for a longer time.

![image](https://user-images.githubusercontent.com/8720367/121235695-6bd90880-c895-11eb-9e9d-38c9aa806f6a.png)

This is pretty annoying and is caused by few flaws in client-side code that handles authentication.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

This PR applies few fixes:
- Webapp periodically refreshes the session to prevent expiration when tab is opened for a longer time. Unfortunately, that mechanism caused the opposite effect, because there are huge chances that some of `/api/refresh` requests will fail after multiple periodic calls, causing the logout. Changed handling of that situation from logout to silent error reported in console. If session has really expired, user will be notified anyway via HTTP 401 handling.

- There was a race-condition on mount: some API requests were sent on component mount before the authorization token is set in Axios request headers. That situation results in HTTP 401 and logout even if correct session token is available in localStorage. Added `useAxiosEffect` to setup interceptors and headers as a part of initial render (like componentWillMount), so Axios will be set-up first.

- `getStoredAuthSession` haven't checked for empty `user` key in localStorage, which results in error reported in dev console. Added proper check.

![image](https://user-images.githubusercontent.com/8720367/121236031-cb371880-c895-11eb-8d19-1c2cb1050284.png)


**Test plan**
<!-- Explain how to test your changes -->

- Check if problem is fixed and there is no regression
