### PR TITLE
Fix Enter key behavior in Autocomplete list

### DIFF
--- a/mwdb/web/src/commons/ui/Autocomplete.js
+++ b/mwdb/web/src/commons/ui/Autocomplete.js
@@ -28,6 +28,7 @@ export default function Autocomplete({
                     <button
                         key={itemValue(item)}
                         className="dropdown-item"
+                        type="button"
                         onClick={(ev) => {
                             ev.preventDefault();
                             onChange(itemValue(item));

--- a/mwdb/web/src/commons/ui/Autocomplete.js
+++ b/mwdb/web/src/commons/ui/Autocomplete.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef } from "react";
 
 export default function Autocomplete({
     items,
@@ -13,6 +13,7 @@ export default function Autocomplete({
     const itemValue = getItemValue || ((item) => item);
     const ItemComponent = renderItem || (({ item }) => itemValue(item));
     const menuStyle = items.length === 0 ? { display: "none" } : {};
+    const inputRef = useRef(null);
 
     return (
         <div className="dropdown input-group">
@@ -22,6 +23,7 @@ export default function Autocomplete({
                 onChange={(ev) => onChange(ev.target.value)}
                 {...(inputProps || {})}
                 data-toggle="dropdown"
+                ref={inputRef}
             />
             <div className="dropdown-menu" role="menu" style={menuStyle}>
                 {items.map((item) => (
@@ -30,8 +32,9 @@ export default function Autocomplete({
                         className="dropdown-item"
                         type="button"
                         onClick={(ev) => {
-                            ev.preventDefault();
                             onChange(itemValue(item));
+                            // Focus on input after choosing dropdown item
+                            inputRef.current.focus();
                         }}
                     >
                         <ItemComponent item={item} />


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
Dropdown menu buttons have not correct type. Default button type is `submit`, so they take over Enter key handling after dropdown appear.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
Added `type="button"` to dropdown menu buttons, so input is correctly submitted.


**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #401 
