### PR TITLE
UI: Lazy-load DagreD3Plot and SwaggerUI

### DIFF
--- a/mwdb/web/src/components/Docs.js
+++ b/mwdb/web/src/components/Docs.js
@@ -1,5 +1,4 @@
-import React, { useContext, useEffect, useState } from "react";
-import SwaggerUI from "swagger-ui-react";
+import React, { Suspense, useContext, useEffect, useState } from "react";
 
 import api from "@mwdb-web/commons/api";
 import { AuthContext } from "@mwdb-web/commons/auth";
@@ -8,6 +7,7 @@ import { View } from "@mwdb-web/commons/ui";
 export default function Docs() {
     const auth = useContext(AuthContext);
     const [apiSpec, setApiSpec] = useState({});
+    const SwaggerUI = React.lazy(() => import("swagger-ui-react"));
 
     async function updateSpec() {
         const spec = await api.getServerDocs();
@@ -28,14 +28,19 @@ export default function Docs() {
 
     return (
         <View ident="docs">
-            <SwaggerUI
-                spec={apiSpec}
-                url=""
-                docExpansion="list"
-                onComplete={(swagger) => {
-                    swagger.preauthorizeApiKey("bearerAuth", auth.user.token);
-                }}
-            />
+            <Suspense fallback={<div>Loading SwaggerUI...</div>}>
+                <SwaggerUI
+                    spec={apiSpec}
+                    url=""
+                    docExpansion="list"
+                    onComplete={(swagger) => {
+                        swagger.preauthorizeApiKey(
+                            "bearerAuth",
+                            auth.user.token
+                        );
+                    }}
+                />
+            </Suspense>
         </View>
     );
 }

--- a/mwdb/web/src/components/RelationsPlot.js
+++ b/mwdb/web/src/components/RelationsPlot.js
@@ -1,4 +1,4 @@
-import React, { useState, useLayoutEffect, useContext } from "react";
+import React, { Suspense, useState, useLayoutEffect, useContext } from "react";
 import { useHistory } from "react-router";
 
 import queryString from "query-string";
@@ -6,7 +6,6 @@ import queryString from "query-string";
 import { APIContext } from "@mwdb-web/commons/api/context";
 import { capitalize } from "@mwdb-web/commons/helpers";
 
-import DagreD3Plot from "./DagreD3Plot";
 import { Tag } from "@mwdb-web/commons/ui";
 
 function RelationsNode(props) {
@@ -190,15 +189,20 @@ function RelationsPlot(props) {
         for (let node of expandedNodes) expandNode(node);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
+
+    const DagreD3Plot = React.lazy(() => import("./DagreD3Plot"));
+
     return (
-        <DagreD3Plot
-            width={defaultProps.width}
-            height={height ? height : defaultProps.height}
-            nodes={nodes.nodes}
-            edges={nodes.edges}
-            onNodeClick={onNodeClick}
-            nodeComponent={RelationsNode}
-        />
+        <Suspense fallback={<div />}>
+            <DagreD3Plot
+                width={defaultProps.width}
+                height={height ? height : defaultProps.height}
+                nodes={nodes.nodes}
+                edges={nodes.edges}
+                onNodeClick={onNodeClick}
+                nodeComponent={RelationsNode}
+            />
+        </Suspense>
     );
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

Main web bundle is huge and has almost 4MB which results in slow loading time.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

SwaggerUI and DagreD3Plot (d3) components are lazy-loaded, so the main application bundle is small enough to boot quickly. 

**Test plan**
<!-- Explain how to test your changes -->
Check if Relations and Docs still work correctly.
<!-- After submitting, your code will be tested by the CI pipeline. Please

