### PR TITLE
Move mwdb/web/.dockerignore entries to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,4 +6,6 @@ venv/
 uploads/
 mwdb.ini
 mwdb.example.ini
-
+mwdb/web/build/
+mwdb/web/node_modules/
+mwdb/web/npm-debug.log

--- a/mwdb/web/.dockerignore
+++ b/mwdb/web/.dockerignore
@@ -1,3 +1,0 @@
-build/
-node_modules/
-npm-debug.log


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

Non-root .dockerignore files are ignored, it doesn't work like `.gitignore` files :disappointed: 

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- Moved entries from `mwdb/web/.dockerignore` to the `.dockerignore` in context root so these entries are not ignored by Docker.
