### PR TITLE
[v3] Drop legacy object upload endpoints

### DIFF
--- a/mwdb/resources/blob.py
+++ b/mwdb/resources/blob.py
@@ -8,7 +8,6 @@ from mwdb.model.object import ObjectTypeConflictError
 from mwdb.schema.blob import (
     BlobCreateRequestSchema,
     BlobItemResponseSchema,
-    BlobLegacyCreateRequestSchema,
     BlobListResponseSchema,
 )
 
@@ -156,7 +155,6 @@ class TextBlobResource(ObjectResource, TextBlobUploader):
 class TextBlobItemResource(ObjectItemResource, TextBlobUploader):
     ObjectType = TextBlob
     ItemResponseSchema = BlobItemResponseSchema
-    CreateRequestSchema = BlobLegacyCreateRequestSchema
 
     @requires_authorization
     def get(self, identifier):
@@ -187,94 +185,6 @@ class TextBlobItemResource(ObjectItemResource, TextBlobUploader):
                     or user doesn't have access to this object.
         """
         return super().get(identifier)
-
-    @requires_authorization
-    @requires_capabilities(Capabilities.adding_blobs)
-    def put(self, identifier):
-        """
-        ---
-        summary: Upload text blob
-        description: |
-            Uploads a new text blob.
-
-            Requires `adding_blobs` capability.
-        security:
-            - bearerAuth: []
-        tags:
-            - deprecated
-        parameters:
-            - in: path
-              name: identifier
-              schema:
-                type: string
-              default: root
-              description: |
-                Parent object identifier or `root` if there is no parent.
-
-                User must have `adding_parents` capability to specify a parent object.
-        requestBody:
-            required: true
-            content:
-              multipart/form-data:
-                schema:
-                  type: object
-                  description: |
-                    Blob to be uploaded with additional parameters
-                    (verbose mode)
-                  properties:
-                    json:
-                      type: object
-                      properties:
-                          blob_name:
-                             type: string
-                          blob_type:
-                             type: string
-                          content:
-                             type: string
-                      description: JSON-encoded blob object specification
-                    metakeys:
-                      type: object
-                      properties:
-                          metakeys:
-                            type: array
-                            items:
-                                $ref: '#/components/schemas/MetakeyItemRequest'
-                      description: |
-                        Attributes to be added after file upload
-
-                        User must be allowed to set specified attribute keys.
-                    upload_as:
-                      type: string
-                      default: '*'
-                      description: |
-                        Group that object will be shared with.
-
-                        If user doesn't have `sharing_objects` capability,
-                        user must be a member of specified group
-                        (unless `Group doesn't exist` error will occur).
-
-                        If default value `*` is specified - object will be
-                        exclusively shared with all user's groups excluding `public`.
-                  required:
-                    - json
-              application/json:
-                schema: BlobCreateSpecSchema
-        responses:
-            200:
-                description: Text blob uploaded succesfully
-                content:
-                  application/json:
-                    schema: BlobItemResponseSchema
-            403:
-                description: |
-                    No permissions to perform additional operations
-                    (e.g. adding metakeys)
-            404:
-                description: Specified group doesn't exist
-            409:
-                description: Object exists yet but has different type
-        """
-        return super().put(identifier)
 
     @requires_authorization
     @requires_capabilities(Capabilities.removing_objects)

--- a/mwdb/resources/file.py
+++ b/mwdb/resources/file.py
@@ -11,7 +11,6 @@ from mwdb.schema.file import (
     FileCreateRequestSchema,
     FileDownloadTokenResponseSchema,
     FileItemResponseSchema,
-    FileLegacyCreateRequestSchema,
     FileListResponseSchema,
 )
 
@@ -167,7 +166,6 @@ class FileResource(ObjectResource, FileUploader):
 class FileItemResource(ObjectItemResource, FileUploader):
     ObjectType = File
     ItemResponseSchema = FileItemResponseSchema
-    CreateRequestSchema = FileLegacyCreateRequestSchema
 
     @requires_authorization
     def get(self, identifier):
@@ -198,88 +196,6 @@ class FileItemResource(ObjectItemResource, FileUploader):
                     or user doesn't have access to this object.
         """
         return super().get(identifier)
-
-    @requires_authorization
-    @requires_capabilities(Capabilities.adding_files)
-    def post(self, identifier):
-        """
-        ---
-        summary: Upload file
-        description: |
-            Uploads a new file.
-
-            Requires `adding_files` capability.
-        security:
-            - bearerAuth: []
-        tags:
-            - deprecated
-        parameters:
-            - in: path
-              name: identifier
-              schema:
-                type: string
-              default: 'root'
-              description: |
-                Parent object identifier or `root` if there is no parent.
-
-                User must have `adding_parents` capability to specify a parent object.
-        requestBody:
-            required: true
-            content:
-              multipart/form-data:
-                schema:
-                  type: object
-                  properties:
-                    file:
-                      type: string
-                      format: binary
-                      description: File contents to be uploaded
-                    metakeys:
-                      type: object
-                      properties:
-                          metakeys:
-                            type: array
-                            items:
-                                $ref: '#/components/schemas/MetakeyItemRequest'
-                      description: |
-                        Attributes to be added after file upload
-
-                        User must be allowed to set specified attribute keys.
-                    upload_as:
-                      type: string
-                      default: '*'
-                      description: |
-                        Group that object will be shared with.
-
-                        If user doesn't have `sharing_objects` capability,
-                        user must be a member of specified group
-                        (unless `Group doesn't exist` error will occur).
-
-                        If default value `*` is specified - object will be
-                        exclusively shared with all user's groups excluding `public`.
-                  required:
-                    - file
-        responses:
-            200:
-                description: Information about uploaded file
-                content:
-                  application/json:
-                    schema: FileItemResponseSchema
-            403:
-                description: |
-                    No permissions to perform additional operations
-                    (e.g. adding parent, metakeys)
-            404:
-                description: |
-                    One of attribute keys doesn't exist or user doesn't have
-                    permission to set it.
-
-                    Specified `upload_as` group doesn't exist or user doesn't have
-                    permission to share objects with that group
-            409:
-                description: Object exists yet but has different type
-        """
-        return super().post(identifier)
 
     @requires_authorization
     @requires_capabilities(Capabilities.removing_objects)

--- a/mwdb/resources/object.py
+++ b/mwdb/resources/object.py
@@ -1,10 +1,9 @@
-import json
 from uuid import UUID
 
 from flask import g, request
 from flask_restful import Resource
 from luqum.parser import ParseError
-from werkzeug.exceptions import BadRequest, Forbidden, MethodNotAllowed, NotFound
+from werkzeug.exceptions import BadRequest, Forbidden, NotFound
 
 from mwdb.core.capabilities import Capabilities
 from mwdb.core.config import app_config
@@ -217,8 +216,6 @@ class ObjectItemResource(Resource, ObjectUploader):
     ObjectType = Object
     ItemResponseSchema = ObjectItemResponseSchema
 
-    CreateRequestSchema = None
-
     @requires_authorization
     def get(self, identifier):
         """
@@ -252,41 +249,6 @@ class ObjectItemResource(Resource, ObjectUploader):
             raise NotFound("Object not found")
         schema = self.ItemResponseSchema()
         return schema.dump(obj)
-
-    def _get_upload_args(self, parent_identifier):
-        """
-        Transforms upload arguments mixed into various request fields
-        """
-        if request.is_json:
-            # If request is application/json: all args are in JSON
-            args = json.loads(request.get_data(parse_form_data=True, as_text=True))
-        else:
-            if "json" in request.form:
-                # If request is multipart/form-data:
-                # some args are in JSON and some are part of form
-                args = json.loads(request.form["json"])
-            else:
-                args = {}
-            if request.form.get("metakeys"):
-                args["metakeys"] = request.form["metakeys"]
-            if request.form.get("upload_as"):
-                args["upload_as"] = request.form["upload_as"]
-        args["parent"] = parent_identifier if parent_identifier != "root" else None
-        return args
-
-    @requires_authorization
-    def post(self, identifier):
-        if self.ObjectType is Object:
-            raise MethodNotAllowed()
-
-        schema = self.CreateRequestSchema()
-        obj = load_schema(self._get_upload_args(identifier), schema)
-
-        return self.create_object(obj)
-
-    @requires_authorization
-    def put(self, identifier):
-        return self.post(identifier)
 
     @requires_authorization
     @requires_capabilities(Capabilities.removing_objects)

--- a/mwdb/schema/blob.py
+++ b/mwdb/schema/blob.py
@@ -4,7 +4,6 @@ from .config import ConfigItemResponseSchema
 from .object import (
     ObjectCreateRequestSchemaBase,
     ObjectItemResponseSchema,
-    ObjectLegacyMetakeysMixin,
     ObjectListItemResponseSchema,
     ObjectListResponseSchemaBase,
 )
@@ -19,10 +18,6 @@ class BlobCreateSpecSchema(Schema):
 
 
 class BlobCreateRequestSchema(ObjectCreateRequestSchemaBase, BlobCreateSpecSchema):
-    pass
-
-
-class BlobLegacyCreateRequestSchema(BlobCreateRequestSchema, ObjectLegacyMetakeysMixin):
     pass
 
 

--- a/mwdb/schema/config.py
+++ b/mwdb/schema/config.py
@@ -3,7 +3,6 @@ from marshmallow import Schema, fields
 from .object import (
     ObjectCreateRequestSchemaBase,
     ObjectItemResponseSchema,
-    ObjectLegacyMetakeysMixin,
     ObjectListItemResponseSchema,
     ObjectListResponseSchemaBase,
 )
@@ -13,21 +12,10 @@ class ConfigStatsRequestSchema(Schema):
     range = fields.Str(missing="*", allow_none=False)
 
 
-# Merge it with ConfigCreateRequestSchema during legacy upload remove
-class ConfigCreateSpecSchema(Schema):
+class ConfigCreateRequestSchema(ObjectCreateRequestSchemaBase):
     family = fields.Str(required=True, allow_none=False)
     config_type = fields.Str(missing="static", allow_none=False)
     cfg = fields.Dict(required=True, allow_none=False)
-
-
-class ConfigCreateRequestSchema(ObjectCreateRequestSchemaBase, ConfigCreateSpecSchema):
-    pass
-
-
-class ConfigLegacyCreateRequestSchema(
-    ConfigCreateRequestSchema, ObjectLegacyMetakeysMixin
-):
-    pass
 
 
 class ConfigListItemResponseSchema(ObjectListItemResponseSchema):

--- a/mwdb/schema/file.py
+++ b/mwdb/schema/file.py
@@ -6,7 +6,6 @@ from .config import ConfigItemResponseSchema
 from .object import (
     ObjectCreateRequestSchemaBase,
     ObjectItemResponseSchema,
-    ObjectLegacyMetakeysMixin,
     ObjectListItemResponseSchema,
     ObjectListResponseSchemaBase,
 )
@@ -31,12 +30,6 @@ class FileCreateRequestSchema(Schema):
             else:
                 del params["options"]
         return params
-
-
-class FileLegacyCreateRequestSchema(
-    ObjectCreateRequestSchemaBase, ObjectLegacyMetakeysMixin
-):
-    pass
 
 
 class FileListItemResponseSchema(ObjectListItemResponseSchema):

--- a/mwdb/schema/object.py
+++ b/mwdb/schema/object.py
@@ -1,13 +1,4 @@
-import json
-
-from marshmallow import (
-    Schema,
-    ValidationError,
-    fields,
-    post_dump,
-    pre_load,
-    validates_schema,
-)
+from marshmallow import Schema, ValidationError, fields, post_dump, validates_schema
 
 from .metakey import MetakeyItemRequestSchema
 from .tag import TagItemResponseSchema
@@ -38,30 +29,6 @@ class ObjectCreateRequestSchemaBase(Schema):
     upload_as = fields.Str(missing="*", allow_none=False)
     karton_id = fields.UUID(missing=None)
     karton_arguments = fields.Dict(missing={}, keys=fields.Str(), values=fields.Str())
-
-
-class ObjectLegacyMetakeysMixin(Schema):
-    @pre_load
-    def unpack_metakeys(self, params, **kwargs):
-        """
-        Metakeys are packed into JSON string that need to be deserialized first.
-        Empty string in 'metakeys' field is treated like missing key.
-        Request providing metakeys looks like this:
-        `curl ... -F="metakeys='{"metakeys": [...]}'"`
-        """
-        params = dict(params)
-        if "metakeys" in params:
-            if params["metakeys"]:
-                metakeys_json = json.loads(params["metakeys"])
-                if "metakeys" not in metakeys_json:
-                    raise ValidationError(
-                        "Object provided to 'metakeys' field "
-                        "must contain 'metakeys' key"
-                    )
-                params["metakeys"] = metakeys_json["metakeys"]
-            else:
-                del params["metakeys"]
-        return params
 
 
 class ObjectListItemResponseSchema(Schema):

--- a/tests/backend/test_api.py
+++ b/tests/backend/test_api.py
@@ -34,23 +34,6 @@ def test_add_sample():
     parse(res['upload_time'])
 
 
-def test_add_sample_legacy():
-    test = MwdbTest()
-    test.login()
-
-    filename = 'filename'
-    file_content = 'content'
-
-    res = test.add_sample_legacy(filename, file_content)
-
-    assert res['file_name'] == filename
-    assert res['file_size'] == len(file_content)
-    assert res['parents'] == []
-    assert res['children'] == []
-    assert res['tags'] == []
-    parse(res['upload_time'])
-
-
 def test_get_sample():
     test = MwdbTest()
     test.login()


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
See https://github.com/CERT-Polska/mwdb-core/issues/304 (`Use POST /api/file for uploading objects instead of deprecated POST/PUT /api/file/<parent>`)

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
This PR removes legacy `POST/PUT /api/<type>/<parent>` endpoints

Minimum supported mwdblib version: https://github.com/CERT-Polska/mwdblib/releases/tag/v3.3.0
