### PR TITLE
UI: Moved React.lazy out of render() functions

### DIFF
--- a/mwdb/web/src/components/Docs.js
+++ b/mwdb/web/src/components/Docs.js
@@ -4,10 +4,11 @@ import api from "@mwdb-web/commons/api";
 import { AuthContext } from "@mwdb-web/commons/auth";
 import { View } from "@mwdb-web/commons/ui";
 
+const SwaggerUI = React.lazy(() => import("swagger-ui-react"));
+
 export default function Docs() {
     const auth = useContext(AuthContext);
     const [apiSpec, setApiSpec] = useState({});
-    const SwaggerUI = React.lazy(() => import("swagger-ui-react"));
 
     async function updateSpec() {
         const spec = await api.getServerDocs();

--- a/mwdb/web/src/components/RelationsPlot.js
+++ b/mwdb/web/src/components/RelationsPlot.js
@@ -8,6 +8,8 @@ import { capitalize } from "@mwdb-web/commons/helpers";
 
 import { Tag } from "@mwdb-web/commons/ui";
 
+const DagreD3Plot = React.lazy(() => import("./DagreD3Plot"));
+
 function RelationsNode(props) {
     const typeMapping = {
         file: "file",
@@ -189,8 +191,6 @@ function RelationsPlot(props) {
         for (let node of expandedNodes) expandNode(node);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
-
-    const DagreD3Plot = React.lazy(() => import("./DagreD3Plot"));
 
     return (
         <Suspense fallback={<div />}>


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
All lazy components are reloaded after each re-render of parent component

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
Moved `React.lazy` calls out of render function
