### PR TITLE
Allow to bind unknown Karton analyses to the objects

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ copyright = '2021, CERT Polska'
 author = 'CERT Polska'
 
 # The full version, including alpha/beta/rc tags
-release = '2.4.0'
+release = '2.4.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/mwdb/model/karton.py
+++ b/mwdb/model/karton.py
@@ -102,7 +102,7 @@ class KartonAnalysis(db.Model):
             is_new = True
         except IntegrityError:
             db.session.rollback()
-            analysis = cls.get(analysis_id).first()
+            analysis = cls.get(analysis_id).first()  # Avoid TOCTOU exceptions
             if analysis is None:
                 raise
         return analysis, is_new

--- a/mwdb/resources/karton.py
+++ b/mwdb/resources/karton.py
@@ -200,17 +200,11 @@ class KartonAnalysisResource(Resource):
                 description: |
                     When object doesn't exist or user doesn't have access
                     to this object.
-
-                    When analysis doesn't exist.
         """
         db_object = access_object(type, identifier)
         if db_object is None:
             raise NotFound("Object not found")
 
-        analysis = KartonAnalysis.get(analysis_id).first()
-        if analysis is None:
-            raise NotFound("Analysis not found or not associated with the object")
-
-        db_object.assign_analysis(analysis)
+        analysis, _ = db_object.assign_analysis(analysis_id)
         schema = KartonItemResponseSchema()
         return schema.dump(analysis)

--- a/mwdb/version.py
+++ b/mwdb/version.py
@@ -4,5 +4,5 @@ try:
 except IOError:
     git_revision = ""
 
-app_version = "2.4.0"
+app_version = "2.4.1"
 app_build_version = f"{app_version}+{git_revision}" if git_revision else app_version

--- a/mwdb/web/package-lock.json
+++ b/mwdb/web/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mwdb-web",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/mwdb/web/package.json
+++ b/mwdb/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mwdb-web",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.0-14",

--- a/mwdb/web/src/commons/package.json
+++ b/mwdb/web/src/commons/package.json
@@ -2,7 +2,7 @@
     "name": "@mwdb-web/commons",
     "main": "index.js",
     "private": true,
-    "version": "2.4.0",
+    "version": "2.4.1",
     "peerDependencies": {
         "@fortawesome/react-fontawesome": "*",
         "bootstrap-select": "*",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ Under the hood of mwdb.cert.pl service hosted by CERT.pl.
 """
 
 setup(name="mwdb-core",
-      version="2.4.0",
+      version="2.4.1",
       description="MWDB Core malware database",
       long_description=LONG_DESCRIPTION,
       author="CERT Polska",


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
Karton integration added in 2.3.0 allowed only to bind Karton analysis identifiers that were already registered in MWDB by `ObjectUploader.on_created` hook. That was simple approach for initial implementation but wasn't a wise choice, because analyses can be still spawned by some external services. These analyses are currently rejected by MWDB and karton-reporter.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- MWDB creates KartonAnalysis during Karton analysis assignment when UUID was not already registered.

**Test plan**
<!-- Explain how to test your changes -->
Check if Karton integration still works correctly
<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->
