### PR TITLE
CI: Store logs for failed e2e backend tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,6 +160,16 @@ jobs:
           docker-compose -f docker-compose-e2e.yml up -d mwdb-tests
           docker-compose -f docker-compose-e2e.yml logs -f -t mwdb-tests
           ([ $(docker wait mwdb-core_mwdb-tests_1) == 0 ])
+      - name: Job failed - storing application logs
+        if: ${{ failure() }}
+        run: |
+          docker-compose -f docker-compose-e2e.yml logs --no-color -t mwdb > ./mwdb-e2e-logs
+      - name: Job failed - upload application logs
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: mwdb-e2e-logs
+          path: mwdb-e2e-logs
   test_frontend_e2e:
     needs: [build_core, build_frontend, build_frontend_e2e]
     name: Perform frontend e2e tests


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- We don't have complete information when E2E tests for backend fail.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- CI job stores logs from `mwdb` container in artifacts after failed job
