### PR TITLE
Fix Karton analysis assignment during object upload

### DIFF
--- a/mwdb/model/blob.py
+++ b/mwdb/model/blob.py
@@ -36,7 +36,7 @@ class TextBlob(Object):
         parent=None,
         metakeys=None,
         share_with=None,
-        analysis=None,
+        analysis_id=None,
     ):
         dhash = hashlib.sha256(content.encode("utf-8")).hexdigest()
 
@@ -53,7 +53,7 @@ class TextBlob(Object):
             parent=parent,
             metakeys=metakeys,
             share_with=share_with,
-            analysis=analysis,
+            analysis_id=analysis_id,
         )
         # If object exists yet: we need to refresh last_seen timestamp
         if not is_new:

--- a/mwdb/model/config.py
+++ b/mwdb/model/config.py
@@ -39,7 +39,7 @@ class Config(Object):
         parent=None,
         metakeys=None,
         share_with=None,
-        analysis=None,
+        analysis_id=None,
     ):
         dhash = config_dhash(cfg)
 
@@ -51,7 +51,7 @@ class Config(Object):
             parent=parent,
             metakeys=metakeys,
             share_with=share_with,
-            analysis=analysis,
+            analysis_id=analysis_id,
         )
 
     def _send_to_karton(self):

--- a/mwdb/model/file.py
+++ b/mwdb/model/file.py
@@ -82,7 +82,7 @@ class File(Object):
         parent=None,
         metakeys=None,
         share_with=None,
-        analysis=None,
+        analysis_id=None,
     ):
         file_stream.seek(0, os.SEEK_END)
         file_size = file_stream.tell()
@@ -108,7 +108,7 @@ class File(Object):
             parent=parent,
             metakeys=metakeys,
             share_with=share_with,
-            analysis=analysis,
+            analysis_id=analysis_id,
         )
 
         if is_new:

--- a/mwdb/model/karton.py
+++ b/mwdb/model/karton.py
@@ -87,17 +87,16 @@ class KartonAnalysis(db.Model):
         return db.session.query(KartonAnalysis).filter(KartonAnalysis.id == analysis_id)
 
     @classmethod
-    def get_or_create(cls, analysis_id, initial_object):
+    def get_or_create(cls, analysis_id, initial_object=None):
         analysis = cls.get(analysis_id).first()
 
         if analysis is not None:
             return analysis, False
 
         db.session.begin_nested()
-        analysis = KartonAnalysis(id=analysis_id, objects=[initial_object])
         is_new = False
         try:
-            db.session.add(analysis)
+            analysis = cls.create(analysis_id, initial_object=initial_object)
             db.session.commit()
             is_new = True
         except IntegrityError:
@@ -108,9 +107,10 @@ class KartonAnalysis(db.Model):
         return analysis, is_new
 
     @classmethod
-    def create(cls, analysis_id, initial_object, arguments=None):
+    def create(cls, analysis_id, initial_object=None, arguments=None):
+        objects = [initial_object] if initial_object is not None else []
         analysis = KartonAnalysis(
-            id=analysis_id, arguments=arguments or {}, objects=[initial_object]
+            id=analysis_id, arguments=arguments or {}, objects=objects
         )
         db.session.add(analysis)
         return analysis

--- a/mwdb/model/object.py
+++ b/mwdb/model/object.py
@@ -490,7 +490,7 @@ class Object(db.Model):
 
     @classmethod
     def _get_or_create(
-        cls, obj, parent=None, metakeys=None, share_with=None, analysis=None
+        cls, obj, parent=None, metakeys=None, share_with=None, analysis_id=None
     ):
         """
         Polymophic get or create pattern, useful in dealing with race condition
@@ -562,8 +562,8 @@ class Object(db.Model):
         if parent:
             new_cls.add_parent(parent, commit=False)
 
-        if analysis:
-            new_cls.assign_analysis(analysis)
+        if analysis_id:
+            new_cls.assign_analysis(analysis_id)
 
         return new_cls, is_new
 

--- a/mwdb/resources/blob.py
+++ b/mwdb/resources/blob.py
@@ -25,7 +25,7 @@ class TextBlobUploader(ObjectUploader):
         super().on_reuploaded(object, params)
         hooks.on_reuploaded_text_blob(object)
 
-    def _create_object(self, spec, parent, share_with, metakeys, analysis):
+    def _create_object(self, spec, parent, share_with, metakeys, analysis_id):
         try:
             return TextBlob.get_or_create(
                 spec["content"],
@@ -34,7 +34,7 @@ class TextBlobUploader(ObjectUploader):
                 parent=parent,
                 share_with=share_with,
                 metakeys=metakeys,
-                analysis=analysis,
+                analysis_id=analysis_id,
             )
         except ObjectTypeConflictError:
             raise Conflict("Object already exists and is not a blob")

--- a/mwdb/resources/config.py
+++ b/mwdb/resources/config.py
@@ -115,7 +115,7 @@ class ConfigUploader(ObjectUploader):
                 "'in-blob' key must be set to blob SHA256 hash or blob specification"
             )
 
-    def _create_object(self, spec, parent, share_with, metakeys, analysis):
+    def _create_object(self, spec, parent, share_with, metakeys, analysis_id):
         try:
             blobs = []
             config = dict(spec["cfg"])
@@ -139,7 +139,7 @@ class ConfigUploader(ObjectUploader):
                 parent=parent,
                 share_with=share_with,
                 metakeys=metakeys,
-                analysis=analysis,
+                analysis_id=analysis_id,
             )
 
             for blob in blobs:

--- a/mwdb/resources/file.py
+++ b/mwdb/resources/file.py
@@ -28,7 +28,7 @@ class FileUploader(ObjectUploader):
         super().on_reuploaded(object, params)
         hooks.on_reuploaded_file(object)
 
-    def _create_object(self, spec, parent, share_with, metakeys, analysis):
+    def _create_object(self, spec, parent, share_with, metakeys, analysis_id):
         try:
             return File.get_or_create(
                 request.files["file"].filename,
@@ -36,7 +36,7 @@ class FileUploader(ObjectUploader):
                 parent=parent,
                 share_with=share_with,
                 metakeys=metakeys,
-                analysis=analysis,
+                analysis_id=analysis_id,
             )
         except ObjectTypeConflictError:
             raise Conflict("Object already exists and is not a file")


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- Karton analysis can't be assigned during object upload

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- Uploading a file with a new `karton` metakey creates and assigns a new KartonAnalysis

**Test plan**
<!-- Explain how to test your changes -->
- Try to upload file with `karton` metakey set or `karton_id` parameter

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #431 
