### PR TITLE
Fix dependency conflict: prance requires requests >= 2.25.0, but 2.24.0 is pinned

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ SQLAlchemy==1.3.18
 marshmallow==3.7.1
 ssdeep==3.4
 psycopg2-binary==2.8.5
-requests==2.24.0
+requests==2.26.0
 apispec[yaml,validation]==3.3.1
 bcrypt==3.1.4
 python-magic==0.4.18
@@ -22,3 +22,4 @@ redis==3.2.1
 minio==6.0.0
 typed-config==0.2.1
 karton-core==4.2.0
+prance==0.21.8.0  # apispec unpinned dependency


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
```
pkg_resources.ContextualVersionConflict: (requests 2.25.0 (/opt/mwdb-core-v2.4.0/venv_local/lib/python3.8/site-packages), Requirement.parse('requests==2.24.0'), {'mwdb-core'})
```

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- There are no dependency conflicts of `requests` package
