### PR TITLE
Added AWS IAM Authentication for Minio

### DIFF
--- a/docs/setup-and-configuration.rst
+++ b/docs/setup-and-configuration.rst
@@ -211,6 +211,8 @@ If you want to store files using object storage, open the ``mwdb.ini`` file and 
     s3_storage_region_name = <AWS S3 region name>
     # optional (for TLS)
     s3_storage_secure = 1
+    # optional (for AWS IAM role authentication)
+    s3_storage_iam_auth = 1
 
 
 If you use Docker-based setup, all the configuration can be set using environment variables (e.g. ``MWDB_STORAGE_PROVIDER=s3``).
@@ -263,6 +265,7 @@ Storage settings:
 * ``s3_storage_bucket_name`` (string) - S3 API bucket name for object storage. Required if you use S3-compatible storage.
 * ``s3_storage_region_name`` (string, optional) - S3 API storage region name. Used mainly with AWS S3 storage (default is None).
 * ``s3_storage_secure`` (0 or 1) - Use TLS for S3 API connection (default is ``0``).
+* ``s3_storage_iam_auth`` (0 or 1) - Use AWS IAM role for S3 authentication (default is ``0``). If ``1``, then ``s3_storage_access_key`` and ``s3_storage_secret_key`` aren't required.
 
 Extra features:
 

--- a/mwdb/core/config.py
+++ b/mwdb/core/config.py
@@ -80,6 +80,8 @@ class MWDBConfig(Config):
     s3_storage_region_name = key(cast=str, required=False)
     # S3 storage Bucket Name
     s3_storage_bucket_name = key(cast=str, required=False)
+    # S3 storage Authorize through IAM role (No credentials)
+    s3_storage_iam_auth = key(cast=intbool, required=False)
 
     # Administrator account login
     admin_login = key(cast=str, required=False, default="admin")

--- a/mwdb/core/util.py
+++ b/mwdb/core/util.py
@@ -18,6 +18,7 @@ import ssdeep
 from flask_restful import abort
 from flask_sqlalchemy import Pagination
 from minio import Minio
+from minio.credentials import IamAwsProvider
 
 
 def config_dhash(obj):
@@ -154,12 +155,20 @@ def is_subdir(parent, child):
 
 
 def get_minio_client(
-    endpoint: str, access_key: str, secret_key: str, region: str, secure: bool
+    endpoint: str,
+    access_key: str,
+    secret_key: str,
+    region: str,
+    secure: bool,
+    iam_auth: bool,
 ) -> Minio:
-    if endpoint is None or access_key is None or secret_key is None:
+    if endpoint is None:
+        raise RuntimeError("Attempting to get Minio client without an endpoint set")
+    if iam_auth:
+        return Minio(endpoint=endpoint, region=region, credentials=IamAwsProvider())
+    if access_key is None or secret_key is None:
         raise RuntimeError(
-            "Attempting to get Minio client without an "
-            "endpoint/access_key/secret_key set"
+            "Attempting to get Minio client without an access_key/secret_key set"
         )
     return Minio(
         endpoint=endpoint,

--- a/mwdb/model/file.py
+++ b/mwdb/model/file.py
@@ -120,6 +120,7 @@ class File(Object):
                     app_config.mwdb.s3_storage_secret_key,
                     app_config.mwdb.s3_storage_region_name,
                     app_config.mwdb.s3_storage_secure,
+                    app_config.mwdb.s3_storage_iam_auth,
                 ).put_object(
                     app_config.mwdb.s3_storage_bucket_name,
                     file_obj._calculate_path(),
@@ -207,6 +208,7 @@ class File(Object):
                 app_config.mwdb.s3_storage_secret_key,
                 app_config.mwdb.s3_storage_region_name,
                 app_config.mwdb.s3_storage_secure,
+                app_config.mwdb.s3_storage_iam_auth,
             ).get_object(app_config.mwdb.s3_storage_bucket_name, self._calculate_path())
         elif app_config.mwdb.storage_provider == StorageProviderType.DISK:
             return open(self._calculate_path(), "rb")

--- a/mwdb/templates/mwdb.ini.tmpl
+++ b/mwdb/templates/mwdb.ini.tmpl
@@ -72,6 +72,9 @@ base_url = {{ base_url }}
 ## Use TLS with S3 API (default: 0)
 # s3_storage_secure = 1
 
+## Use AWS IAM role authentication (deafult: 0)
+# s3_storage_iam_auth = 1
+
 ### Extra features
 
 # Set enable_rate_limit to 1 to turn on rate limiting (default: 0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ click==7.1.2
 click-default-group==1.2.2
 PyYAML==5.4
 redis==3.2.1
-minio==6.0.0
+minio==7.1.0
 typed-config==0.2.1
 karton-core==4.2.0
 prance==0.21.8.0  # apispec unpinned dependency


### PR DESCRIPTION
**Your checklist for this pull request**
- [X] I've read the [contributing guideline](CONTRIBUTING.md).
- [X] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [X] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**

The only possible authentication to S3 based bucket is by using credentials.

**What is the new behaviour?**

We can supply a new boolean environment variable `MWDB_S3_STORAGE_IAM_AUTH` or `s3_storage_iam_auth` in `mwdb.ini`. By setting this variable to `1`, Minio will return a different client based on AWS IAM role, which means we don't need to supply credentials - `MWDB_S3_STORAGE_ACCESS_KEY` and `MWDB_S3_STORAGE_SECRET_KEY`.
I also bumped Minio python client from `6.0.0` to `7.1.0` because the old version didn't support the `IamAwsProvider`.

**Test plan**

- Create S3 bucket on AWS.
- Attach to your AWS machine IAM role with the correct policy for accessing that bucket.
- Run `docker-compose-dev.yml` build with the next environment variables:
  - `MWDB_STORAGE_PROVIDER: s3`
  - `MWDB_HASH_PATHING: 0`
  - `MWDB_S3_STORAGE_ENDPOINT: "s3.<region-name>.amazonaws.com"`
  - `MWDB_S3_STORAGE_BUCKET_NAME: "<bucket-name>"`
  - `MWDB_S3_STORAGE_IAM_AUTH: 1`
- Upload a file to MWDB, and try to access it from the system (Preview for example).
- Check the bucket manually for the uploaded file.
- Test old parameters (supplied in `docker-compose-dev.yml` without the `MWDB_S3_STORAGE_IAM_AUTH`) to see that credential-based authentication also works.

**Closing issues**

closes #433
