### PR TITLE
Rename metakeys to attributes

### DIFF
--- a/mwdb/app.py
+++ b/mwdb/app.py
@@ -286,7 +286,7 @@ api.add_resource(
 )
 api.add_resource(QuickQueryItemResource, "/quick_query/<int:id>")
 
-# Metakey endpoints
+# Attribute endpoints
 api.add_resource(MetakeyListDefinitionResource, "/meta/list/<any(read, set):access>")
 api.add_resource(
     MetakeyResource, "/<any(file, config, blob, object):type>/<hash64:identifier>/meta"

--- a/mwdb/core/karton.py
+++ b/mwdb/core/karton.py
@@ -48,7 +48,9 @@ def send_file_to_karton(file) -> str:
             headers={"type": "sample", "kind": "raw", "quality": feed_quality},
             payload={
                 "sample": Resource(file.file_name, path=path, sha256=file.sha256),
-                "attributes": file.get_metakeys(as_dict=True, check_permissions=False),
+                "attributes": file.get_attributes(
+                    as_dict=True, check_permissions=False
+                ),
             },
             priority=task_priority,
         )
@@ -68,7 +70,7 @@ def send_config_to_karton(config) -> str:
         payload={
             "config": config.cfg,
             "dhash": config.dhash,
-            "attributes": config.get_metakeys(as_dict=True, check_permissions=False),
+            "attributes": config.get_attributes(as_dict=True, check_permissions=False),
         },
     )
     producer.send_task(task)
@@ -84,7 +86,7 @@ def send_blob_to_karton(blob) -> str:
         payload={
             "content": blob.content,
             "dhash": blob.dhash,
-            "attributes": blob.get_metakeys(as_dict=True, check_permissions=False),
+            "attributes": blob.get_attributes(as_dict=True, check_permissions=False),
         },
     )
     producer.send_task(task)

--- a/mwdb/core/search/fields.py
+++ b/mwdb/core/search/fields.py
@@ -11,10 +11,10 @@ from sqlalchemy.dialects.postgresql.json import JSONPATH_ASTEXT
 
 from mwdb.core.capabilities import Capabilities
 from mwdb.model import (
-    Group,
-    Member,
     Attribute,
     AttributeDefinition,
+    Group,
+    Member,
     Object,
     ObjectPermission,
     User,

--- a/mwdb/core/search/fields.py
+++ b/mwdb/core/search/fields.py
@@ -225,15 +225,15 @@ class AttributeField(BaseField):
         else:
             raise UnsupportedGrammarException("Missing attribute key (meta.<key>:)")
 
-        metakey_definition = AttributeDefinition.query_for_read(
+        attribute_definition = AttributeDefinition.query_for_read(
             key=attribute_key, include_hidden=True
         ).first()
 
-        if metakey_definition is None:
+        if attribute_definition is None:
             raise ObjectNotFoundException(f"No such attribute: {attribute_key}")
 
         if (
-            metakey_definition.hidden
+            attribute_definition.hidden
             and expression.has_wildcard()
             and not g.auth_user.has_rights(Capabilities.reading_all_attributes)
         ):
@@ -242,11 +242,11 @@ class AttributeField(BaseField):
             )
 
         value = get_term_value(expression)
-        metakey_value = Attribute.value[()].astext
+        attribute_value = Attribute.value[()].astext
         if expression.has_wildcard():
-            value_condition = metakey_value.like(value)
+            value_condition = attribute_value.like(value)
         else:
-            value_condition = metakey_value == value
+            value_condition = attribute_value == value
 
         return self.column.any(and_(Attribute.key == attribute_key, value_condition))
 

--- a/mwdb/core/search/fields.py
+++ b/mwdb/core/search/fields.py
@@ -13,8 +13,8 @@ from mwdb.core.capabilities import Capabilities
 from mwdb.model import (
     Group,
     Member,
-    Metakey,
-    MetakeyDefinition,
+    Attribute,
+    AttributeDefinition,
     Object,
     ObjectPermission,
     User,
@@ -225,7 +225,7 @@ class AttributeField(BaseField):
         else:
             raise UnsupportedGrammarException("Missing attribute key (meta.<key>:)")
 
-        metakey_definition = MetakeyDefinition.query_for_read(
+        metakey_definition = AttributeDefinition.query_for_read(
             key=attribute_key, include_hidden=True
         ).first()
 
@@ -242,13 +242,13 @@ class AttributeField(BaseField):
             )
 
         value = get_term_value(expression)
-        metakey_value = Metakey.value[()].astext
+        metakey_value = Attribute.value[()].astext
         if expression.has_wildcard():
             value_condition = metakey_value.like(value)
         else:
             value_condition = metakey_value == value
 
-        return self.column.any(and_(Metakey.key == attribute_key, value_condition))
+        return self.column.any(and_(Attribute.key == attribute_key, value_condition))
 
 
 class ShareField(BaseField):

--- a/mwdb/core/search/mappings.py
+++ b/mwdb/core/search/mappings.py
@@ -33,7 +33,7 @@ field_mapping: Dict[str, Dict[str, BaseField]] = {
         "dhash": StringField(Object.dhash),
         "tag": ListField(Object.tags, Tag.tag),
         "comment": ListField(Object.comments, Comment.comment),
-        "meta": AttributeField(Object.meta),
+        "meta": AttributeField(Object.attributes),
         "shared": ShareField(Object.shares),
         "uploader": UploaderField(Object.related_shares),
         "upload_time": DatetimeField(Object.upload_time),

--- a/mwdb/model/__init__.py
+++ b/mwdb/model/__init__.py
@@ -5,13 +5,13 @@ db = SQLAlchemy()
 # These imports must appear after "db" declaration
 
 from .api_key import APIKey  # noqa: E402
+from .attribute import Attribute, AttributeDefinition, AttributePermission  # noqa: E402
 from .blob import TextBlob  # noqa: E402
 from .comment import Comment  # noqa: E402
 from .config import Config, StaticConfig  # noqa: E402
 from .file import File  # noqa: E402
 from .group import Group, Member  # noqa: E402
 from .karton import KartonAnalysis, karton_object  # noqa: E402
-from .metakey import Attribute, AttributeDefinition, AttributePermission  # noqa: E402
 from .object import Object, ObjectPermission, relation  # noqa: E402
 from .quick_query import QuickQuery  # noqa: E402
 from .tag import Tag, object_tag_table  # noqa: E402

--- a/mwdb/model/__init__.py
+++ b/mwdb/model/__init__.py
@@ -11,7 +11,7 @@ from .config import Config, StaticConfig  # noqa: E402
 from .file import File  # noqa: E402
 from .group import Group, Member  # noqa: E402
 from .karton import KartonAnalysis, karton_object  # noqa: E402
-from .metakey import Metakey, MetakeyDefinition, MetakeyPermission  # noqa: E402
+from .metakey import Attribute, AttributeDefinition, AttributePermission  # noqa: E402
 from .object import Object, ObjectPermission, relation  # noqa: E402
 from .quick_query import QuickQuery  # noqa: E402
 from .tag import Tag, object_tag_table  # noqa: E402
@@ -29,9 +29,9 @@ __all__ = [
     "KartonAnalysis",
     "karton_object",
     "Member",
-    "Metakey",
-    "MetakeyDefinition",
-    "MetakeyPermission",
+    "Attribute",
+    "AttributeDefinition",
+    "AttributePermission",
     "Object",
     "ObjectPermission",
     "relation",

--- a/mwdb/model/blob.py
+++ b/mwdb/model/blob.py
@@ -34,7 +34,7 @@ class TextBlob(Object):
         blob_name,
         blob_type,
         parent=None,
-        metakeys=None,
+        attributes=None,
         share_with=None,
         analysis_id=None,
     ):
@@ -51,7 +51,7 @@ class TextBlob(Object):
         blob_obj, is_new = cls._get_or_create(
             blob_obj,
             parent=parent,
-            metakeys=metakeys,
+            attributes=attributes,
             share_with=share_with,
             analysis_id=analysis_id,
         )

--- a/mwdb/model/config.py
+++ b/mwdb/model/config.py
@@ -37,7 +37,7 @@ class Config(Object):
         family,
         config_type,
         parent=None,
-        metakeys=None,
+        attributes=None,
         share_with=None,
         analysis_id=None,
     ):
@@ -49,7 +49,7 @@ class Config(Object):
         return cls._get_or_create(
             cfg_obj,
             parent=parent,
-            metakeys=metakeys,
+            attributes=attributes,
             share_with=share_with,
             analysis_id=analysis_id,
         )

--- a/mwdb/model/file.py
+++ b/mwdb/model/file.py
@@ -80,7 +80,7 @@ class File(Object):
         file_name,
         file_stream,
         parent=None,
-        metakeys=None,
+        attributes=None,
         share_with=None,
         analysis_id=None,
     ):
@@ -106,7 +106,7 @@ class File(Object):
         file_obj, is_new = cls._get_or_create(
             file_obj,
             parent=parent,
-            metakeys=metakeys,
+            attributes=attributes,
             share_with=share_with,
             analysis_id=analysis_id,
         )

--- a/mwdb/model/group.py
+++ b/mwdb/model/group.py
@@ -38,7 +38,7 @@ class Group(db.Model):
     )
 
     attributes = db.relationship(
-        "MetakeyPermission",
+        "AttributePermission",
         back_populates="group",
         cascade="all, delete",
         passive_deletes=True,

--- a/mwdb/model/migrations/versions/35916645cf47_rename_metakey_to_attribute.py
+++ b/mwdb/model/migrations/versions/35916645cf47_rename_metakey_to_attribute.py
@@ -1,0 +1,63 @@
+"""Rename metakey to attribute
+
+Revision ID: 35916645cf47
+Revises: 7054c09d10ac
+Create Date: 2021-08-30 15:32:57.160753
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "35916645cf47"
+down_revision = "7054c09d10ac"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.rename_table("metakey", "attribute")
+    op.execute("ALTER INDEX metakey_pkey RENAME TO attribute_pkey")
+    op.execute("ALTER INDEX ix_metakey_key RENAME TO ix_attribute_key")
+    op.execute("ALTER INDEX ix_metakey_value RENAME TO ix_attribute_value")
+    op.execute(
+        "ALTER INDEX metakey_object_id_key_value_key RENAME TO attribute_object_id_key_value_key"
+    )
+    op.execute("ALTER SEQUENCE metakey_id_seq RENAME TO attribute_id_seq")
+    op.execute(
+        'ALTER TABLE "attribute" RENAME CONSTRAINT metakey_key_fkey TO attribute_key_fkey'
+    )
+    op.execute(
+        'ALTER TABLE "attribute" RENAME CONSTRAINT metakey_object_id_fkey TO attribute_object_id_fkey'
+    )
+
+    op.rename_table("metakey_definition", "attribute_definition")
+    op.execute(
+        "ALTER INDEX metakey_definition_pkey RENAME TO attribute_definition_pkey"
+    )
+
+    op.rename_table("metakey_permission", "attribute_permission")
+    op.execute(
+        "ALTER INDEX metakey_permission_pkey RENAME TO attribute_permission_pkey"
+    )
+    op.execute(
+        "ALTER INDEX ix_metakey_permission_group_id RENAME TO ix_attribute_permission_group_id"
+    )
+    op.execute(
+        "ALTER INDEX ix_metakey_permission_key RENAME TO ix_attribute_permission_key"
+    )
+    op.execute(
+        "ALTER INDEX ix_metakey_permission_metakey_group RENAME TO ix_attribute_permission_attribute_group"
+    )
+    op.execute(
+        "ALTER TABLE attribute_permission RENAME CONSTRAINT metakey_permission_group_id_fkey "
+        "TO attribute_permission_group_id_fkey"
+    )
+    op.execute(
+        "ALTER TABLE attribute_permission RENAME CONSTRAINT metakey_permission_key_fkey "
+        "TO attribute_permission_key_fkey"
+    )
+
+
+def downgrade():
+    pass

--- a/mwdb/model/migrations/versions/35916645cf47_rename_metakey_to_attribute.py
+++ b/mwdb/model/migrations/versions/35916645cf47_rename_metakey_to_attribute.py
@@ -7,7 +7,6 @@ Create Date: 2021-08-30 15:32:57.160753
 """
 from alembic import op
 
-
 # revision identifiers, used by Alembic.
 revision = "35916645cf47"
 down_revision = "7054c09d10ac"

--- a/mwdb/model/object.py
+++ b/mwdb/model/object.py
@@ -54,7 +54,6 @@ class ObjectTypeConflictError(Exception):
 
 class ObjectPermission(db.Model):
     __tablename__ = "permission"
-    __mapper_args__ = {"polymorphic_identity": __tablename__, "polymorphic_on": type}
 
     object_id = db.Column(
         db.Integer,
@@ -216,6 +215,8 @@ class Object(db.Model):
     upload_time = db.Column(
         db.DateTime, nullable=False, index=True, default=datetime.datetime.utcnow
     )
+
+    __mapper_args__ = {"polymorphic_identity": __tablename__, "polymorphic_on": type}
 
     parents = db.relationship(
         "Object",

--- a/mwdb/model/object.py
+++ b/mwdb/model/object.py
@@ -13,8 +13,8 @@ from sqlalchemy.sql.expression import true
 from mwdb.core.capabilities import Capabilities
 
 from . import db
+from .attribute import Attribute, AttributeDefinition, AttributePermission
 from .karton import KartonAnalysis, karton_object
-from .metakey import Attribute, AttributeDefinition, AttributePermission
 from .tag import Tag, object_tag_table
 
 relation = db.Table(
@@ -233,7 +233,7 @@ class Object(db.Model):
         back_populates="parents",
     )
 
-    meta = db.relationship(
+    attributes = db.relationship(
         "Attribute", backref="object", lazy=True, cascade="save-update, merge, delete"
     )
     comments = db.relationship(

--- a/mwdb/resources/blob.py
+++ b/mwdb/resources/blob.py
@@ -25,7 +25,7 @@ class TextBlobUploader(ObjectUploader):
         super().on_reuploaded(object, params)
         hooks.on_reuploaded_text_blob(object)
 
-    def _create_object(self, spec, parent, share_with, metakeys, analysis_id):
+    def _create_object(self, spec, parent, share_with, attributes, analysis_id):
         try:
             return TextBlob.get_or_create(
                 spec["content"],
@@ -33,7 +33,7 @@ class TextBlobUploader(ObjectUploader):
                 spec["blob_type"],
                 parent=parent,
                 share_with=share_with,
-                metakeys=metakeys,
+                attributes=attributes,
                 analysis_id=analysis_id,
             )
         except ObjectTypeConflictError:

--- a/mwdb/resources/config.py
+++ b/mwdb/resources/config.py
@@ -88,7 +88,7 @@ class ConfigUploader(ObjectUploader):
         super().on_reuploaded(object, params)
         hooks.on_reuploaded_config(object)
 
-    def _get_embedded_blob(self, in_blob, share_with, metakeys):
+    def _get_embedded_blob(self, in_blob, share_with, attributes):
         if isinstance(in_blob, dict):
             schema = BlobCreateSpecSchema()
             blob_spec = load_schema(in_blob, schema)
@@ -100,7 +100,7 @@ class ConfigUploader(ObjectUploader):
                     blob_spec["blob_type"],
                     parent=None,
                     share_with=share_with,
-                    metakeys=metakeys,
+                    attributes=attributes,
                 )
             except ObjectTypeConflictError:
                 raise Conflict("Object already exists and is not a blob")
@@ -115,7 +115,7 @@ class ConfigUploader(ObjectUploader):
                 "'in-blob' key must be set to blob SHA256 hash or blob specification"
             )
 
-    def _create_object(self, spec, parent, share_with, metakeys, analysis_id):
+    def _create_object(self, spec, parent, share_with, attributes, analysis_id):
         try:
             blobs = []
             config = dict(spec["cfg"])
@@ -125,7 +125,7 @@ class ConfigUploader(ObjectUploader):
                     if not g.auth_user.has_rights(Capabilities.adding_blobs):
                         raise Forbidden("You are not permitted to add blob objects")
                     blob_obj = self._get_embedded_blob(
-                        second["in-blob"], share_with, metakeys
+                        second["in-blob"], share_with, attributes
                     )
                     config[first]["in-blob"] = blob_obj.dhash
                     blobs.append(blob_obj)
@@ -138,7 +138,7 @@ class ConfigUploader(ObjectUploader):
                 spec["config_type"],
                 parent=parent,
                 share_with=share_with,
-                metakeys=metakeys,
+                attributes=attributes,
                 analysis_id=analysis_id,
             )
 

--- a/mwdb/resources/file.py
+++ b/mwdb/resources/file.py
@@ -28,14 +28,14 @@ class FileUploader(ObjectUploader):
         super().on_reuploaded(object, params)
         hooks.on_reuploaded_file(object)
 
-    def _create_object(self, spec, parent, share_with, metakeys, analysis_id):
+    def _create_object(self, spec, parent, share_with, attributes, analysis_id):
         try:
             return File.get_or_create(
                 request.files["file"].filename,
                 request.files["file"].stream,
                 parent=parent,
                 share_with=share_with,
-                metakeys=metakeys,
+                attributes=attributes,
                 analysis_id=analysis_id,
             )
         except ObjectTypeConflictError:
@@ -147,7 +147,7 @@ class FileResource(ObjectResource, FileUploader):
             403:
                 description: |
                     No permissions to perform additional operations
-                    (e.g. adding parent, metakeys)
+                    (e.g. adding parent, attributes)
             404:
                 description: |
                     One of attribute keys doesn't exist
@@ -268,7 +268,7 @@ class FileItemResource(ObjectItemResource, FileUploader):
             403:
                 description: |
                     No permissions to perform additional operations
-                    (e.g. adding parent, metakeys)
+                    (e.g. adding parent, attributes)
             404:
                 description: |
                     One of attribute keys doesn't exist or user doesn't have

--- a/mwdb/resources/metakey.py
+++ b/mwdb/resources/metakey.py
@@ -91,7 +91,7 @@ class MetakeyResource(Resource):
         if db_object is None:
             raise NotFound("Object not found")
 
-        metakeys = db_object.get_metakeys(show_hidden=show_hidden)
+        metakeys = db_object.get_attributes(show_hidden=show_hidden)
         schema = MetakeyListResponseSchema()
         return schema.dump({"metakeys": metakeys})
 
@@ -149,7 +149,7 @@ class MetakeyResource(Resource):
 
         key = obj["key"]
         value = obj["value"]
-        is_new = db_object.add_metakey(key, value)
+        is_new = db_object.add_attribute(key, value)
         if is_new is None:
             raise NotFound(
                 f"Attribute '{key}' is not defined or you have "
@@ -158,7 +158,7 @@ class MetakeyResource(Resource):
 
         db.session.commit()
         db.session.refresh(db_object)
-        metakeys = db_object.get_metakeys()
+        metakeys = db_object.get_attributes()
         schema = MetakeyListResponseSchema()
         return schema.dump({"metakeys": metakeys})
 
@@ -223,7 +223,7 @@ class MetakeyResource(Resource):
         key = obj["key"]
         value = obj.get("value")
 
-        deleted_object = db_object.remove_metakey(key, value)
+        deleted_object = db_object.remove_attribute(key, value)
         if deleted_object is False:
             raise NotFound(
                 f"Attribute '{key}' is not defined or you have "

--- a/mwdb/resources/metakey.py
+++ b/mwdb/resources/metakey.py
@@ -3,7 +3,7 @@ from flask_restful import Resource
 from werkzeug.exceptions import BadRequest, Forbidden, NotFound
 
 from mwdb.core.capabilities import Capabilities
-from mwdb.model import Group, AttributeDefinition, AttributePermission, db
+from mwdb.model import AttributeDefinition, AttributePermission, Group, db
 from mwdb.schema.metakey import (
     MetakeyDefinitionItemRequestArgsSchema,
     MetakeyDefinitionItemRequestBodySchema,

--- a/mwdb/resources/object.py
+++ b/mwdb/resources/object.py
@@ -10,7 +10,7 @@ from mwdb.core.capabilities import Capabilities
 from mwdb.core.config import app_config
 from mwdb.core.plugins import hooks
 from mwdb.core.search import SQLQueryBuilder, SQLQueryBuilderBaseException
-from mwdb.model import MetakeyDefinition, Object, db
+from mwdb.model import AttributeDefinition, Object, db
 from mwdb.schema.object import (
     ObjectCountRequestSchema,
     ObjectCountResponseSchema,
@@ -82,9 +82,9 @@ class ObjectUploader:
                     analysis_id = UUID(metakey["value"])
                 except (ValueError, AttributeError):
                     raise BadRequest("'karton' attribute accepts only UUID values")
-            elif not MetakeyDefinition.query_for_set(key).first():
+            elif not AttributeDefinition.query_for_set(key).first():
                 raise NotFound(
-                    f"Metakey '{key}' not defined or insufficient "
+                    f"Attribute '{key}' not defined or insufficient "
                     "permissions to set that one"
                 )
 

--- a/mwdb/resources/object.py
+++ b/mwdb/resources/object.py
@@ -48,7 +48,7 @@ class ObjectUploader:
     def on_reuploaded(self, object, params):
         hooks.on_reuploaded_object(object)
 
-    def _create_object(self, spec, parent, share_with, metakeys, analysis_id):
+    def _create_object(self, spec, parent, share_with, attributes, analysis_id):
         # To be implemented by specialized uploaders (e.g. FileUploader)
         raise NotImplementedError
 
@@ -70,16 +70,16 @@ class ObjectUploader:
         # Validate metakeys and Karton assignment
         analysis_id = params.get("karton_id")
 
-        metakeys = params["metakeys"]
-        for metakey in params["metakeys"]:
-            key = metakey["key"]
+        attributes = params["metakeys"]
+        for attribute in params["metakeys"]:
+            key = attribute["key"]
             if key == "karton":
                 if analysis_id is not None:
                     raise BadRequest(
                         "You can't provide more than one Karton analysis identifier"
                     )
                 try:
-                    analysis_id = UUID(metakey["value"])
+                    analysis_id = UUID(attribute["value"])
                 except (ValueError, AttributeError):
                     raise BadRequest("'karton' attribute accepts only UUID values")
             elif not AttributeDefinition.query_for_set(key).first():
@@ -98,7 +98,7 @@ class ObjectUploader:
         share_with = get_shares_for_upload(params["upload_as"])
 
         item, is_new = self._create_object(
-            params, parent_object, share_with, metakeys, analysis_id
+            params, parent_object, share_with, attributes, analysis_id
         )
 
         try:

--- a/mwdb/resources/remotes.py
+++ b/mwdb/resources/remotes.py
@@ -253,7 +253,7 @@ class RemoteConfigPullResource(RemotePullResource):
             403:
                 description: |
                     No permissions to perform additional operations
-                    (e.g. adding parent, metakeys)
+                    (e.g. adding parent, attributes)
             404:
                 description: |
                     When the name of the remote instance is not figured


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

Naming problem described in https://github.com/CERT-Polska/mwdb-core/issues/301

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- Renamed internal model names from `Metakey` to `Attribute`
- `schema` and `resources` intentionally left without changes: Metakey part will represent the legacy, deprecated API. Attribute is reserved for new API endpoint set.
- Plugin breaking change: related db.Object methods (`get_metakeys`) are renamed (`get_attributes`). Plugins must be adapted to that change.

**Test plan**
<!-- Explain how to test your changes -->
- Check if attribute actions work as usual
<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->
