### PR TITLE
Remove debug prints in Object.uninherit_share

### DIFF
--- a/mwdb/model/object.py
+++ b/mwdb/model/object.py
@@ -392,11 +392,6 @@ class Object(db.Model):
         return new_devisor
 
     def uninherit_share(self, share_to_remove, new_devisor=None, visited=None):
-        print(
-            f"Uninheriting share for '{share_to_remove.group_name}' "
-            f"({share_to_remove.access_reason})",
-            flush=True,
-        )
         # Break the c-c-c-cycles
         visited = visited or set()
         if self in visited:
@@ -405,14 +400,12 @@ class Object(db.Model):
             visited.add(self)
         # Get our share for the same group as share_to_remove
         our_share = self.get_share_for_group(share_to_remove.group_id)
-        print("our_share", our_share, flush=True)
         # If it doesn't exist or it's unrelated: just return
         if not our_share or not our_share.inherits(share_to_remove):
             return
         # Find new devisor different than share_to_remove
         if new_devisor is None:
             new_devisor = self._find_another_devisor(share_to_remove)
-        print("new_devisor", new_devisor, flush=True)
         # If there's nothing to change (same share is given by another parent): return
         if new_devisor is share_to_remove:
             return


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- There are debug prints left after `uninherit_share` method development

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- Removed debug prints
