### PR TITLE
Revert #442: Use 'npm ci' instead of 'npm install'

### DIFF
--- a/deploy/docker/Dockerfile-web
+++ b/deploy/docker/Dockerfile-web
@@ -4,7 +4,7 @@ COPY ./mwdb/web /app
 COPY ./docker/plugins /plugins
 
 RUN cd /app \
-    && npm ci --unsafe-perm . $(find /plugins -name 'package.json' -printf "%h\n" | sort -u) \
+    && npm install --unsafe-perm . $(find /plugins -name 'package.json' -printf "%h\n" | sort -u) \
     && CI=true npm run build \
     && npm cache clean --force
 

--- a/deploy/docker/Dockerfile-web-dev
+++ b/deploy/docker/Dockerfile-web-dev
@@ -4,7 +4,7 @@ COPY ./mwdb/web /app
 COPY ./docker/plugins /plugins
 
 RUN cd /app \
-    && npm ci --unsafe-perm . $(find /plugins -name 'package.json' -printf "%h\n" | sort -u) \
+    && npm install --unsafe-perm . $(find /plugins -name 'package.json' -printf "%h\n" | sort -u) \
     && CI=true npm run build \
     && npm cache clean --force
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ copyright = '2021, CERT Polska'
 author = 'CERT Polska'
 
 # The full version, including alpha/beta/rc tags
-release = '2.5.0'
+release = '2.5.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/mwdb/version.py
+++ b/mwdb/version.py
@@ -4,5 +4,5 @@ try:
 except IOError:
     git_revision = ""
 
-app_version = "2.5.0"
+app_version = "2.5.1"
 app_build_version = f"{app_version}+{git_revision}" if git_revision else app_version

--- a/mwdb/web/package-lock.json
+++ b/mwdb/web/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mwdb-web",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/mwdb/web/package.json
+++ b/mwdb/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mwdb-web",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.0-14",

--- a/mwdb/web/src/commons/package.json
+++ b/mwdb/web/src/commons/package.json
@@ -2,7 +2,7 @@
     "name": "@mwdb-web/commons",
     "main": "index.js",
     "private": true,
-    "version": "2.5.0",
+    "version": "2.5.1",
     "peerDependencies": {
         "@fortawesome/react-fontawesome": "*",
         "bootstrap-select": "*",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ Under the hood of mwdb.cert.pl service hosted by CERT.pl.
 """
 
 setup(name="mwdb-core",
-      version="2.5.0",
+      version="2.5.1",
       description="MWDB Core malware database",
       long_description=LONG_DESCRIPTION,
       author="CERT Polska",


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- `npm ci` introduced in #442 was meant to improve building time of Docker-based environment, but plugins are not installed correctly.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- Reverted to `npm install`

This branch is intentionally based on v2.5.0 and doesn't include changes from current master.

