### PR TITLE
add search wildcard to UUIDField

### DIFF
--- a/mwdb/core/search/fields.py
+++ b/mwdb/core/search/fields.py
@@ -171,7 +171,7 @@ class UUIDField(BaseField):
         value = get_term_value(expression)
 
         if expression.has_wildcard():
-            return self.column.any(cast(self.value_column, String()).like(value))
+            return self.column.any(cast(self.value_column, String).like(value))
 
         try:
             uuid_value = uuid.UUID(value)

--- a/mwdb/core/search/fields.py
+++ b/mwdb/core/search/fields.py
@@ -6,7 +6,7 @@ from typing import Any, List, Type, Union
 import regex
 from flask import g
 from luqum.tree import Range, Term
-from sqlalchemy import Text, and_, column, exists, func, or_, select
+from sqlalchemy import Text, String, and_, column, exists, func, or_, select, cast
 from sqlalchemy.dialects.postgresql.json import JSONPATH_ASTEXT
 
 from mwdb.core.capabilities import Capabilities
@@ -171,7 +171,7 @@ class UUIDField(BaseField):
         value = get_term_value(expression)
 
         if expression.has_wildcard():
-            raise UnsupportedGrammarException("Wildcards are not allowed here")
+            return self.column.any(cast(self.value_column, String()).like(value))
 
         try:
             uuid_value = uuid.UUID(value)

--- a/mwdb/core/search/fields.py
+++ b/mwdb/core/search/fields.py
@@ -6,7 +6,7 @@ from typing import Any, List, Type, Union
 import regex
 from flask import g
 from luqum.tree import Range, Term
-from sqlalchemy import Text, String, and_, column, exists, func, or_, select, cast
+from sqlalchemy import String, Text, and_, cast, column, exists, func, or_, select
 from sqlalchemy.dialects.postgresql.json import JSONPATH_ASTEXT
 
 from mwdb.core.capabilities import Capabilities


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
It is impossible to search files using wildcard in `karton `search field.

**What is the new behaviour?**
Single wildcard in `karton `search field is allowed. Using Lucene query `karton:*` -  returns samples for which karton analyses are attached. Using query `NOT karton:*` - gives samples without karton analysis.

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #395 
