### PR TITLE
Feature/files commented by particular user

### DIFF
--- a/docs/user-guide/7-Lucene-search.rst
+++ b/docs/user-guide/7-Lucene-search.rst
@@ -293,6 +293,23 @@ The above query returns the favorite objects of specific user.
 
     Only system administrator with "manage_users" capabilities can search for other users favorites.
 
+Commentator field (\ ``commentator:``\ )
+------------------------------------------------------------
+
+Typing the field ``commentator:`` you can search for objects commented by selected user.
+
+.. code-block::
+
+   commentator:<user login>
+
+The above query returns the objects commented by user <user login>.
+
+.. warning::
+
+    Remember that you can only search using logins for users registered in mwdb.
+    Otherwise you receive error massage: ``No such user: <login>``.
+
+    Wildcards are not allowed for field ``commentator:``.
 
 Group access queries (\ ``shared:`` and ``uploader:``\ )
 ------------------------------------------------------------

--- a/docs/user-guide/7-Lucene-search.rst
+++ b/docs/user-guide/7-Lucene-search.rst
@@ -306,8 +306,7 @@ The above query returns the objects commented by user <user login>.
 
 .. warning::
 
-    Remember that you can only search using logins for users registered in mwdb.
-    Otherwise you receive error massage: ``No such user: <login>``.
+    Comment authors are kept only for existing users, so you can't search for comments from deleted accounts.
 
     Wildcards are not allowed for field ``comment_author:``.
 

--- a/docs/user-guide/7-Lucene-search.rst
+++ b/docs/user-guide/7-Lucene-search.rst
@@ -293,14 +293,14 @@ The above query returns the favorite objects of specific user.
 
     Only system administrator with "manage_users" capabilities can search for other users favorites.
 
-Commentator field (\ ``commentator:``\ )
+Comment author field (\ ``comment_author:``\ )
 ------------------------------------------------------------
 
-Typing the field ``commentator:`` you can search for objects commented by selected user.
+Typing the field ``comment_author:`` you can search for objects commented by selected user.
 
 .. code-block::
 
-   commentator:<user login>
+   comment_author:<user login>
 
 The above query returns the objects commented by user <user login>.
 
@@ -309,7 +309,7 @@ The above query returns the objects commented by user <user login>.
     Remember that you can only search using logins for users registered in mwdb.
     Otherwise you receive error massage: ``No such user: <login>``.
 
-    Wildcards are not allowed for field ``commentator:``.
+    Wildcards are not allowed for field ``comment_author:``.
 
 Group access queries (\ ``shared:`` and ``uploader:``\ )
 ------------------------------------------------------------

--- a/mwdb/core/search/fields.py
+++ b/mwdb/core/search/fields.py
@@ -451,7 +451,7 @@ class RelationField(BaseField):
         return self.column.any(Object.id.in_(expression.subquery))
 
 
-class CommentatorField(BaseField):
+class CommentAuthorField(BaseField):
     def __init__(self, column, value_column):
         super().__init__(column)
         self.value_column = value_column
@@ -463,7 +463,7 @@ class CommentatorField(BaseField):
             )
         if expression.has_wildcard():
             raise UnsupportedGrammarException(
-                "Wildcards are not allowed for commentator field"
+                "Wildcards are not allowed for comment_author field"
             )
 
         value = get_term_value(expression)

--- a/mwdb/core/search/mappings.py
+++ b/mwdb/core/search/mappings.py
@@ -17,7 +17,7 @@ from .exceptions import FieldNotQueryableException, MultipleObjectsQueryExceptio
 from .fields import (
     AttributeField,
     BaseField,
-    CommentatorField,
+    CommentAuthorField,
     DatetimeField,
     FavoritesField,
     JSONField,
@@ -51,7 +51,7 @@ field_mapping: Dict[str, Dict[str, BaseField]] = {
         "child": RelationField(Object.children),
         "favorites": FavoritesField(Object.followers),
         "karton": UUIDField(Object.analyses, KartonAnalysis.id),
-        "commentator": CommentatorField(Object.commentators, User.login),
+        "comment_author": CommentAuthorField(Object.comment_authors, User.login),
     },
     File.__name__: {
         "name": StringField(File.file_name),

--- a/mwdb/core/search/mappings.py
+++ b/mwdb/core/search/mappings.py
@@ -2,12 +2,22 @@ from typing import Dict, List, Tuple, Type
 
 import regex
 
-from mwdb.model import Comment, Config, File, KartonAnalysis, Object, Tag, TextBlob
+from mwdb.model import (
+    Comment,
+    Config,
+    File,
+    KartonAnalysis,
+    Object,
+    Tag,
+    TextBlob,
+    User,
+)
 
 from .exceptions import FieldNotQueryableException, MultipleObjectsQueryException
 from .fields import (
     AttributeField,
     BaseField,
+    CommentatorField,
     DatetimeField,
     FavoritesField,
     JSONField,
@@ -41,6 +51,7 @@ field_mapping: Dict[str, Dict[str, BaseField]] = {
         "child": RelationField(Object.children),
         "favorites": FavoritesField(Object.followers),
         "karton": UUIDField(Object.analyses, KartonAnalysis.id),
+        "commentator": CommentatorField(Object.commentators, User.login),
     },
     File.__name__: {
         "name": StringField(File.file_name),

--- a/mwdb/model/object.py
+++ b/mwdb/model/object.py
@@ -252,7 +252,7 @@ class Object(db.Model):
         "User", secondary=favorites, back_populates="favorites", lazy="joined"
     )
 
-    commentators = db.relationship(
+    comment_authors = db.relationship(
         "User", secondary="comment", back_populates="commented_objects", lazy="selectin"
     )
 

--- a/mwdb/model/object.py
+++ b/mwdb/model/object.py
@@ -253,7 +253,7 @@ class Object(db.Model):
     )
 
     comment_authors = db.relationship(
-        "User", secondary="comment", back_populates="commented_objects", lazy="selectin"
+        "User", secondary="comment", back_populates="commented_objects"
     )
 
     shares = db.relationship(

--- a/mwdb/model/object.py
+++ b/mwdb/model/object.py
@@ -252,6 +252,10 @@ class Object(db.Model):
         "User", secondary=favorites, back_populates="favorites", lazy="joined"
     )
 
+    commentators = db.relationship(
+        "User", secondary="comment", back_populates="commented_objects", lazy="selectin"
+    )
+
     shares = db.relationship(
         "ObjectPermission",
         lazy="dynamic",

--- a/mwdb/model/user.py
+++ b/mwdb/model/user.py
@@ -64,7 +64,7 @@ class User(db.Model):
     )
 
     commented_objects = db.relationship(
-        "Object", secondary="comment", back_populates="comment_authors", lazy="selectin"
+        "Object", secondary="comment", back_populates="comment_authors"
     )
 
     comments = db.relationship(

--- a/mwdb/model/user.py
+++ b/mwdb/model/user.py
@@ -63,6 +63,10 @@ class User(db.Model):
         "Object", secondary=favorites, back_populates="followers", lazy="joined"
     )
 
+    commented_objects = db.relationship(
+        "Object", secondary="comment", back_populates="commentators", lazy="selectin"
+    )
+
     comments = db.relationship(
         "Comment",
         back_populates="author",

--- a/mwdb/model/user.py
+++ b/mwdb/model/user.py
@@ -64,7 +64,7 @@ class User(db.Model):
     )
 
     commented_objects = db.relationship(
-        "Object", secondary="comment", back_populates="commentators", lazy="selectin"
+        "Object", secondary="comment", back_populates="comment_authors", lazy="selectin"
     )
 
     comments = db.relationship(


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [x] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
It is impossible to search objects commented by selected user.

**What is the new behaviour?**
New search field: ```comentator:<user_login>``` was added to lucine search functionality. Now searching objects commented by selected user is possible.

**Closing issues**
Implementation covers issue 292
<!-- Add in issue numbers related to this PR, if applicable -->

closes #292
