### PR TITLE
Fix: Ignore refreshSession call when user is not authenticated

### DIFF
--- a/mwdb/web/src/commons/auth/provider.js
+++ b/mwdb/web/src/commons/auth/provider.js
@@ -101,6 +101,9 @@ export function AuthProvider(props) {
 
     async function refreshSession() {
         try {
+            // If not authenticated: just ignore that call
+            // refreshSession is called by 403 Forbidden interceptor
+            if (!isAuthenticated) return;
             const response = await api.authRefresh();
             updateSession(response.data);
         } catch (e) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- `refreshSession` is fire-and-forget call that refreshes the session token and capabilities. It's called periodically and by 403 Forbidden interceptor in case of capabilities changes that are not yet known by client.
- Unfortunately, when `refreshSession` is called when user is not authenticated: user is immediately redirected to `/login` page with "Session expired." message, so the actual error is not correctly handled.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- `refreshSession` checks authentication state before it calls `/auth/refresh`

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #450 
