### PR TITLE
Revert #442: Use 'npm ci' instead of 'npm install' (on master branch)

### DIFF
--- a/deploy/docker/Dockerfile-web
+++ b/deploy/docker/Dockerfile-web
@@ -4,7 +4,7 @@ COPY ./mwdb/web /app
 COPY ./docker/plugins /plugins
 
 RUN cd /app \
-    && npm ci --unsafe-perm . $(find /plugins -name 'package.json' -printf "%h\n" | sort -u) \
+    && npm install --unsafe-perm . $(find /plugins -name 'package.json' -printf "%h\n" | sort -u) \
     && CI=true npm run build \
     && npm cache clean --force
 

--- a/deploy/docker/Dockerfile-web-dev
+++ b/deploy/docker/Dockerfile-web-dev
@@ -4,7 +4,7 @@ COPY ./mwdb/web /app
 COPY ./docker/plugins /plugins
 
 RUN cd /app \
-    && npm ci --unsafe-perm . $(find /plugins -name 'package.json' -printf "%h\n" | sort -u) \
+    && npm install --unsafe-perm . $(find /plugins -name 'package.json' -printf "%h\n" | sort -u) \
     && CI=true npm run build \
     && npm cache clean --force
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

Only `2.5.x` is reverted (https://github.com/CERT-Polska/mwdb-core/pull/449), now it's time to apply revert also on master branch.