### PR TITLE
Fix: Better handling of missing API endpoint when static files are served

### DIFF
--- a/mwdb/core/static.py
+++ b/mwdb/core/static.py
@@ -1,6 +1,6 @@
 import os
 
-from flask import Blueprint, safe_join, send_from_directory
+from flask import Blueprint, jsonify, safe_join, send_from_directory
 
 from mwdb.paths import web_bundle_dir
 
@@ -13,7 +13,15 @@ static_blueprint = Blueprint("static", __name__)
 @static_blueprint.route("/", defaults={"path": ""})
 @static_blueprint.route("/<path:path>")
 def serve_static(path):
+    if path.startswith("api/"):
+        return (
+            jsonify(
+                message="The requested URL was not found on the server. "
+                "If you entered the URL manually please check your spelling "
+                "and try again."
+            ),
+            404,
+        )
     if path != "" and os.path.exists(safe_join(web_folder, path)):
         return send_from_directory(web_folder, path)
-    elif not path.startswith("api"):
-        return send_from_directory(web_folder, "index.html")
+    return send_from_directory(web_folder, "index.html")


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
When `serve_web = 1` (Flask serves static files via additional blueprint), requests to missing `api/` endpoints are not correctly handled and server returns ISE 500

```
[ERROR] Thread-36 - service.error_router:72 - Unhandled exception occurred
Traceback (most recent call last):
  File "/home/aurelien/mwdb/mwdb/venv/lib/python3.8/site-packages/flask/app.py", line 2447, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/aurelien/mwdb/mwdb/venv/lib/python3.8/site-packages/flask/app.py", line 1953, in full_dispatch_request
    return self.finalize_request(rv)
  File "/home/aurelien/mwdb/mwdb/venv/lib/python3.8/site-packages/flask/app.py", line 1968, in finalize_request
    response = self.make_response(rv)
  File "/home/aurelien/mwdb/mwdb/venv/lib/python3.8/site-packages/flask/app.py", line 2097, in make_response
    raise TypeError(
TypeError: The view function did not return a valid response. The function either returned None or ended without a return statement.
127.0.0.1 - - [27/Oct/2021 09:06:42] "GET /api/file/ HTTP/1.1" 500 -
```

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- Improved handling in static blueprint, so it correctly handles missing `api/` endpoint

**Test plan**
<!-- Explain how to test your changes -->
- Go to the `/api/missing` when `serve_web = 1`. Server should respond with HTTP 404.
<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

