### PR TITLE
Fix: wrong conflict check in Object._get_or_create

### DIFF
--- a/tests/backend/test_api.py
+++ b/tests/backend/test_api.py
@@ -2,7 +2,7 @@ import pytest
 import requests
 from dateutil.parser import parse
 
-from .utils import rand_string
+from .utils import rand_string, ShouldRaise
 
 
 def test_login(admin_session):
@@ -177,3 +177,11 @@ def test_download_sample_with_token(admin_session):
     downloaded = r.text
 
     assert downloaded == expected
+
+
+def test_object_conflict(admin_session):
+    name = rand_string()
+    content = rand_string()
+    admin_session.add_sample(name, content)
+    with ShouldRaise(status_code=409):
+        admin_session.add_blob(None, name, name, content)


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [x] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
Object type conflict condition is incorrectly checked:
```python
        # Ensure that existing object has the expected type
        if new_cls is not isinstance(obj, cls):
            # If Object has been fetched, fetch typed instance
            new_cls = cls.get(obj.dhash).first()
            if new_cls is None:
               raise ObjectTypeConflictError
```

`if new_cls is not isinstance(obj, cls)` is always true because we use `is not` operator for comparing Object and bool. Conflict is still correctly checked because `_get_or_create` always try to fetch typed instance. It's unnecessary when object was just created though.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- Added correct `if not is_new` condition
- Renamed `new_cls` to `created_object` and added more comments for readability
- Added test that checks for conflict

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #476 
