### PR TITLE
Fix permalink to Docker section in docs

### DIFF
--- a/docs/setup-and-configuration.rst
+++ b/docs/setup-and-configuration.rst
@@ -31,7 +31,7 @@ It's highly recommended to create a fresh `virtualenv <https://docs.python.org/3
    (venv) ~/mwdb$
 
 .. note::
-   If you are a bit overwhelmed by setting up PostgreSQL database and you are looking for quick setup method just for testing: first make sure you have Docker and Docker-Compose installed and go to the `Alternative setup using Docker-Compose <#Alternative-setup-using-Docker-Compose>`_.
+   If you are a bit overwhelmed by setting up PostgreSQL database and you are looking for quick setup method just for testing: first make sure you have Docker and Docker-Compose installed and go to the `Alternative setup with Docker-Compose <#Alternative-setup-with-Docker-Compose>`_.
 
    You can also setup temporary PostgreSQL database container using Docker image:
 

--- a/docs/setup-and-configuration.rst
+++ b/docs/setup-and-configuration.rst
@@ -141,7 +141,7 @@ Your MWDB instance will be available on port 5000 (use ``--port`` to change that
    Remember to run ``mwdb-core configure`` after each version upgrade to apply database migrations
 
 
-Alternative setup using Docker Compose
+Alternative setup with Docker Compose
 --------------------------------------
 
 The quickest way setup MWDB is to just clone the repository and use Docker-Compose. We recommend this method **only for testing** because it can be a bit more difficult to install extensions and integrate with other services.


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [x] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
Invalid permalink for ``Alternative setup with Docker Compose`` for that documentation section.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
Change title from ``Alternative setup using Docker Compose`` to ``Alternative setup with Docker Compose``.

**Test plan**
<!-- Explain how to test your changes -->
Local build docs environment and check if permalink works fine.

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #483 
