### PR TITLE
Add mouseover text for attributes and search button for its values

### DIFF
--- a/mwdb/web/src/components/Attributes.js
+++ b/mwdb/web/src/components/Attributes.js
@@ -240,6 +240,7 @@ function ObjectAttributes(props) {
                                 DefaultAttributeRenderer;
                             return (
                                 <Attribute
+                                    key={key}
                                     name={key}
                                     label={label}
                                     values={values}

--- a/mwdb/web/src/components/Attributes.js
+++ b/mwdb/web/src/components/Attributes.js
@@ -12,10 +12,12 @@ import {
     ConfirmationModal,
     ActionCopyToClipboard,
 } from "@mwdb-web/commons/ui";
+import { makeSearchLink } from "@mwdb-web/commons/helpers";
 import {
     FirstAnalysisBanner,
     KartonAttributeRenderer,
 } from "./AttributeKarton";
+import { useHistory } from "react-router-dom";
 
 let attributeRenderers = {
     karton: KartonAttributeRenderer,
@@ -29,6 +31,7 @@ function DefaultAttributeRenderer(props) {
     const api = useContext(APIContext);
     const auth = useContext(AuthContext);
     const context = useContext(ObjectContext);
+    const history = useHistory();
 
     const [collapsed, setCollapsed] = useState(true);
     const [isOpenDeleteModal, setOpenDeleteModal] = useState(false);
@@ -53,7 +56,6 @@ function DefaultAttributeRenderer(props) {
     }
 
     const visibleValues = collapsed ? props.values.slice(0, 3) : props.values;
-
     return (
         <tr key={props.label}>
             <th
@@ -70,7 +72,13 @@ function DefaultAttributeRenderer(props) {
                 ) : (
                     []
                 )}{" "}
-                {props.label}
+                <span
+                    data-toggle="tooltip"
+                    title={props.name}
+                    style={{ cursor: "pointer" }}
+                >
+                    {props.label}
+                </span>
             </th>
             <td className="flickerable">
                 {visibleValues.map((attr) => (
@@ -86,11 +94,34 @@ function DefaultAttributeRenderer(props) {
                                 tooltipMessage="Copy value to clipboard"
                             />
                         </span>
+                        <span
+                            className="ml-2"
+                            data-toggle="tooltip"
+                            title="Search for that attribute values"
+                            onClick={(ev) => {
+                                ev.preventDefault();
+                                history.push(
+                                    makeSearchLink(
+                                        `meta.${props.name}`,
+                                        attr.value,
+                                        false
+                                    )
+                                );
+                            }}
+                        >
+                            <i>
+                                <FontAwesomeIcon
+                                    icon="search"
+                                    size="sm"
+                                    style={{ cursor: "pointer" }}
+                                />
+                            </i>
+                        </span>
                         {auth.hasCapability(Capability.removingAttributes) && (
                             <span
                                 className="ml-2"
                                 data-toggle="tooltip"
-                                title="Remove attribute value from this object."
+                                title="Remove attribute value from this object"
                                 onClick={() => {
                                     setAttributeToRemote({
                                         key: attr.key,
@@ -181,7 +212,6 @@ function ObjectAttributes(props) {
     }, [getAttributes]);
 
     if (!attributes) return [];
-
     return (
         <Extendable
             ident="attributesList"
@@ -210,7 +240,7 @@ function ObjectAttributes(props) {
                                 DefaultAttributeRenderer;
                             return (
                                 <Attribute
-                                    key={key}
+                                    name={key}
                                     label={label}
                                     values={values}
                                     object={context.object}


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
Can't display the name of attribute in show object view.

**What is the new behaviour?**
Maouseover text for attributes that show real name of the attribute and new button near attribute value that redirects to search with field: "meta.attribute-name:current_value".

**Test plan**
<!-- Explain how to test your changes -->
Add attributes to some objects and check if everything works properly.

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #359 
