### PR TITLE
Fix: zero-pad CRC32 to 8 bytes

### DIFF
--- a/mwdb/core/util.py
+++ b/mwdb/core/util.py
@@ -120,7 +120,7 @@ def calc_crc32(stream):
     if csum is not None:
         csum = csum & 0xFFFFFFFF
 
-    return "{:x}".format(csum)
+    return "{:08x}".format(csum)
 
 
 def paginate_fast(q, page, per_page):

--- a/mwdb/model/migrations/versions/574bce4bac6f_zero_pad_crc32_to_8_characters.py
+++ b/mwdb/model/migrations/versions/574bce4bac6f_zero_pad_crc32_to_8_characters.py
@@ -5,9 +5,8 @@ Revises: 373e4d6322eb
 Create Date: 2021-12-02 16:11:21.579604
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "574bce4bac6f"

--- a/mwdb/model/migrations/versions/574bce4bac6f_zero_pad_crc32_to_8_characters.py
+++ b/mwdb/model/migrations/versions/574bce4bac6f_zero_pad_crc32_to_8_characters.py
@@ -1,0 +1,24 @@
+"""Zero-pad CRC32 to 8 characters
+
+Revision ID: 574bce4bac6f
+Revises: 373e4d6322eb
+Create Date: 2021-12-02 16:11:21.579604
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "574bce4bac6f"
+down_revision = "373e4d6322eb"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("UPDATE file SET crc32=LPAD(crc32, 8, '0') WHERE char_length(crc32) < 8")
+
+
+def downgrade():
+    pass

--- a/tests/backend/test_api.py
+++ b/tests/backend/test_api.py
@@ -201,8 +201,8 @@ def test_object_conflict(admin_session):
         admin_session.add_blob(None, name, name, content)
 
 
-def test_zero_crc32(admin_session):
+def test_zero_starting_crc32(admin_session):
     name = rand_string()
-    content = b"DYB|O"
+    content = b'\xf7\xb8\xb4\xab\x6b\x35\x31\x8a'
     sample = admin_session.add_sample(name, content)
-    assert sample["crc32"] == "00000000"
+    assert sample["crc32"] == "000d06ec"

--- a/tests/backend/test_api.py
+++ b/tests/backend/test_api.py
@@ -199,3 +199,10 @@ def test_object_conflict(admin_session):
     admin_session.add_sample(name, content)
     with ShouldRaise(status_code=409):
         admin_session.add_blob(None, name, name, content)
+
+
+def test_zero_crc32(admin_session):
+    name = rand_string()
+    content = b"DYB|O"
+    sample = admin_session.add_sample(name, content)
+    assert sample["crc32"] == "00000000"


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- CRC32 is not zero-padded to 8 bytes, which conflicts with some internal assumptions (including new `multi` feature)

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- Added migration that pads CRC32 into full length as other sums and hashes

**Test plan**
<!-- Explain how to test your changes -->
- Tested migration on production-alike data whether low CRC32 are zero-padded
- Added test `test_zero_starting_crc32`
<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #493 
