### PR TITLE
Web: use new Attribute API instead of legacy Metakey API

### DIFF
--- a/mwdb/model/attribute.py
+++ b/mwdb/model/attribute.py
@@ -37,6 +37,7 @@ class Attribute(db.Model):
 
     @property
     def url(self):
+        # deprecated, left for metakey compatibility
         if self.template.url_template:
             s = Template(self.template.url_template)
             return s.safe_substitute(value=self.value)

--- a/mwdb/model/object.py
+++ b/mwdb/model/object.py
@@ -838,7 +838,9 @@ class Object(db.Model):
     def remove_attribute_by_id(self, attribute_id, check_permissions=True):
         attribute_query = Attribute.get_by_id(self.id, attribute_id)
 
-        if check_permissions:
+        if check_permissions and not g.auth_user.has_rights(
+            Capabilities.adding_all_attributes
+        ):
             attribute_query = attribute_query.filter(
                 Attribute.key.in_(
                     db.session.query(AttributePermission.key)

--- a/mwdb/resources/attribute.py
+++ b/mwdb/resources/attribute.py
@@ -454,7 +454,7 @@ class AttributeDefinitionResource(Resource):
         if description is not None:
             attribute_definition.description = description
 
-        url_template = obj["template"]
+        url_template = obj["url_template"]
         if url_template is not None:
             attribute_definition.url_template = url_template
 

--- a/mwdb/web/src/commons/api/index.js
+++ b/mwdb/web/src/commons/api/index.js
@@ -186,8 +186,8 @@ function getObjectShares(id) {
     return axios.get(`/object/${id}/share`);
 }
 
-function getObjectMetakeys(id) {
-    return axios.get(`/object/${id}/meta`);
+function getObjectAttributes(id) {
+    return axios.get(`/object/${id}/attribute`);
 }
 
 function removeObject(id) {
@@ -212,14 +212,12 @@ function removeObjectComment(id, comment_id) {
     return axios.delete(`/object/${id}/comment/${comment_id}`);
 }
 
-function addObjectMetakey(id, key, value) {
-    return axios.post(`/object/${id}/meta`, { key, value });
+function addObjectAttribute(object_id, key, value) {
+    return axios.post(`/object/${object_id}/attribute`, { key, value });
 }
 
-function removeObjectMetakey(type, id, key, value) {
-    return axios.delete(`/${type}/${id}/meta`, {
-        params: { key: key, value: value },
-    });
+function removeObjectAttribute(object_id, attribute_id) {
+    return axios.delete(`/object/${object_id}/attribute/${attribute_id}`);
 }
 
 function addObjectFavorite(id) {
@@ -361,6 +359,63 @@ function getReadableMetakeyDefinitions() {
     return axios.get("/meta/list/read");
 }
 
+function getAttributeDefinitions(access) {
+    return axios.get("/attribute", {
+        params: { access },
+    });
+}
+
+function getAttributeDefinition(key) {
+    return axios.get(`/attribute/${key}`);
+}
+
+function addAttributeDefinition(key, label, description, url_template, hidden) {
+    return axios.post("/attribute", {
+        key,
+        label,
+        description,
+        url_template,
+        hidden,
+    });
+}
+
+function updateAttributeDefinition(
+    key,
+    label,
+    description,
+    url_template,
+    hidden
+) {
+    return axios.post(`/attribute/${key}`, {
+        label,
+        description,
+        url_template,
+        hidden,
+    });
+}
+
+function removeAttributeDefinition(key) {
+    return axios.delete(`/attribute/${key}`);
+}
+
+function getAttributePermissions(key) {
+    return axios.get(`/attribute/${key}/permissions`);
+}
+
+function setAttributePermission(key, group_name, can_read, can_set) {
+    return axios.put(`/attribute/${key}/permissions`, {
+        group_name,
+        can_read,
+        can_set,
+    });
+}
+
+function deleteAttributePermission(key, group_name) {
+    return axios.delete(`/attribute/${key}/permissions/`, {
+        params: { group_name },
+    });
+}
+
 function getSettableMetakeyDefinitions() {
     return axios.get("/meta/list/set");
 }
@@ -498,8 +553,8 @@ function getRemoteObjectShares(remote, id) {
     return axios.get(`/remote/${remote}/api/object/${id}/share`);
 }
 
-function getRemoteObjectMetakeys(remote, id) {
-    return axios.get(`/remote/${remote}/api/object/${id}/meta`);
+function getRemoteObjectAttributes(remote, id) {
+    return axios.get(`/remote/${remote}/api/object/${id}/attribute`);
 }
 
 function downloadRemoteFile(remote, id) {
@@ -560,14 +615,11 @@ const api = {
     getObjectTags,
     getObjectComments,
     getObjectShares,
-    getObjectMetakeys,
     removeObject,
     addObjectTag,
     removeObjectTag,
     addObjectComment,
     removeObjectComment,
-    addObjectMetakey,
-    removeObjectMetakey,
     addObjectFavorite,
     removeObjectFavorite,
     shareObjectWith,
@@ -606,6 +658,17 @@ const api = {
     updateMetakeyDefinition,
     setMetakeyPermission,
     deleteMetakeyPermission,
+    getObjectAttributes,
+    addObjectAttribute,
+    removeObjectAttribute,
+    getAttributeDefinitions,
+    getAttributeDefinition,
+    addAttributeDefinition,
+    updateAttributeDefinition,
+    removeAttributeDefinition,
+    getAttributePermissions,
+    setAttributePermission,
+    deleteAttributePermission,
     downloadFile,
     requestFileDownloadLink,
     uploadFile,
@@ -624,7 +687,7 @@ const api = {
     getRemoteObjectComments,
     getRemoteObjectRelations,
     getRemoteObjectShares,
-    getRemoteObjectMetakeys,
+    getRemoteObjectAttributes,
     downloadRemoteFile,
     requestRemoteFileDownloadLink,
     getKartonAnalysesList,

--- a/mwdb/web/src/commons/api/index.js
+++ b/mwdb/web/src/commons/api/index.js
@@ -355,10 +355,6 @@ function removeUser(login) {
     return axios.delete(`/user/${login}`);
 }
 
-function getReadableMetakeyDefinitions() {
-    return axios.get("/meta/list/read");
-}
-
 function getAttributeDefinitions(access) {
     return axios.get("/attribute", {
         params: { access },
@@ -386,7 +382,7 @@ function updateAttributeDefinition(
     url_template,
     hidden
 ) {
-    return axios.post(`/attribute/${key}`, {
+    return axios.put(`/attribute/${key}`, {
         label,
         description,
         url_template,
@@ -410,60 +406,10 @@ function setAttributePermission(key, group_name, can_read, can_set) {
     });
 }
 
-function deleteAttributePermission(key, group_name) {
-    return axios.delete(`/attribute/${key}/permissions/`, {
+function removeAttributePermission(key, group_name) {
+    return axios.delete(`/attribute/${key}/permissions`, {
         params: { group_name },
     });
-}
-
-function getSettableMetakeyDefinitions() {
-    return axios.get("/meta/list/set");
-}
-
-function getMetakeyDefinitions() {
-    return axios.get(`/meta/manage`);
-}
-
-function getMetakeyDefinition(key) {
-    return axios.get(`/meta/manage/${key}`);
-}
-
-function removeMetakeyDefinition(key) {
-    return axios.delete(`/meta/manage/${key}`);
-}
-
-function addMetakeyDefinition(key, label, description, template, hidden) {
-    return axios.post(`/meta/manage/${key}`, {
-        key,
-        label,
-        description,
-        template,
-        hidden,
-    });
-}
-
-function updateMetakeyDefinition(
-    key,
-    { label, description, template, hidden }
-) {
-    return axios.put(`/meta/manage/${key}`, {
-        label,
-        description,
-        template,
-        hidden,
-    });
-}
-
-function setMetakeyPermission(key, group_name, can_read, can_set) {
-    return axios.put(`/meta/manage/${key}/permissions/${group_name}`, {
-        group_name,
-        can_read,
-        can_set,
-    });
-}
-
-function deleteMetakeyPermission(key, group_name) {
-    return axios.delete(`/meta/manage/${key}/permissions/${group_name}`);
 }
 
 function downloadFile(id) {
@@ -479,7 +425,7 @@ async function requestFileDownloadLink(id) {
     return `${baseURL}/file/${id}/download?token=${response.data.token}`;
 }
 
-function uploadFile(file, parent, upload_as, metakeys) {
+function uploadFile(file, parent, upload_as, attributes) {
     let formData = new FormData();
     formData.append("file", file);
     formData.append(
@@ -487,7 +433,7 @@ function uploadFile(file, parent, upload_as, metakeys) {
         JSON.stringify({
             parent: parent || null,
             upload_as: upload_as,
-            metakeys: metakeys,
+            attributes: attributes,
         })
     );
     return axios.post(`/file`, formData, { timeout: 60 * 1000 });
@@ -649,15 +595,6 @@ const api = {
     registerUser,
     updateUser,
     removeUser,
-    getReadableMetakeyDefinitions,
-    getSettableMetakeyDefinitions,
-    getMetakeyDefinitions,
-    getMetakeyDefinition,
-    removeMetakeyDefinition,
-    addMetakeyDefinition,
-    updateMetakeyDefinition,
-    setMetakeyPermission,
-    deleteMetakeyPermission,
     getObjectAttributes,
     addObjectAttribute,
     removeObjectAttribute,
@@ -668,7 +605,7 @@ const api = {
     removeAttributeDefinition,
     getAttributePermissions,
     setAttributePermission,
-    deleteAttributePermission,
+    removeAttributePermission,
     downloadFile,
     requestFileDownloadLink,
     uploadFile,

--- a/mwdb/web/src/components/AttributeKarton.js
+++ b/mwdb/web/src/components/AttributeKarton.js
@@ -190,7 +190,11 @@ function KartonAttributeRow(props) {
     );
 }
 
-export function FirstAnalysisBanner(props) {
+export function FirstAnalysisBanner({
+    attributes,
+    onUpdateAttributes,
+    object,
+}) {
     const [submitted, setSubmitted] = useState(false);
     const auth = useContext(AuthContext);
     const context = useContext(ObjectContext);
@@ -198,11 +202,11 @@ export function FirstAnalysisBanner(props) {
         Capability.kartonReanalyze
     );
 
-    if (!isReanalysisAvailable || !props.attributes) return [];
+    if (!isReanalysisAvailable || !attributes) return [];
 
     if (
-        Object.keys(props.attributes).some((label) =>
-            props.attributes[label].some((attr) => attr.key === "karton")
+        Object.keys(attributes).some((label) =>
+            attributes[label].some((attr) => attr.key === "karton")
         )
     )
         return [];
@@ -211,9 +215,9 @@ export function FirstAnalysisBanner(props) {
         ev.preventDefault();
         setSubmitted(true);
         try {
-            await api.resubmitKartonAnalysis(props.object.id);
+            await api.resubmitKartonAnalysis(object.id);
             // Update attributes
-            props.onUpdateAttributes();
+            onUpdateAttributes();
         } catch (error) {
             context.setObjectError(error);
         }
@@ -234,7 +238,7 @@ export function FirstAnalysisBanner(props) {
     );
 }
 
-export function KartonAttributeRenderer(props) {
+export function KartonAttributeRenderer({ values, onUpdateAttributes }) {
     const [maxItems, setMaxItems] = useState(3);
     const [completedItems, setCompletedItems] = useState([]);
     const [visibleItems, setVisibleItems] = useState([]);
@@ -247,10 +251,8 @@ export function KartonAttributeRenderer(props) {
     );
 
     useEffect(() => {
-        setVisibleItems(
-            props.values.slice(0, maxItems).map((attr) => attr.value)
-        );
-    }, [maxItems, props.values]);
+        setVisibleItems(values.slice(0, maxItems).map((attr) => attr.value));
+    }, [maxItems, values]);
 
     useEffect(() => {
         // User can reanalyze if all visible items are completed
@@ -267,9 +269,9 @@ export function KartonAttributeRenderer(props) {
         setCanReanalyze(false);
         // Trigger reanalysis
         try {
-            await api.resubmitKartonAnalysis(props.object.id);
+            await api.resubmitKartonAnalysis(context.object.id);
             // Update attributes
-            props.onUpdateAttributes();
+            onUpdateAttributes();
         } catch (error) {
             context.setObjectError(error);
         }
@@ -299,7 +301,7 @@ export function KartonAttributeRenderer(props) {
         <KartonAttributeRow
             key={item}
             uid={item}
-            object={props.object}
+            object={context.object}
             onCompleted={(uid) => {
                 setCompletedItems((completed) => completed.concat([uid]));
             }}
@@ -307,11 +309,11 @@ export function KartonAttributeRenderer(props) {
     ));
 
     return (
-        <tr key={props.label}>
+        <tr key="Karton analysis">
             <th>Karton analysis</th>
             <td>
                 {attributesRows}
-                {maxItems < props.values.length ? (
+                {maxItems < values.length ? (
                     <Link to="#" onClick={showMore}>
                         <span className="badge badge-primary">more...</span>
                     </Link>

--- a/mwdb/web/src/components/Attributes.js
+++ b/mwdb/web/src/components/Attributes.js
@@ -62,7 +62,7 @@ function AttributeRenderer({
     const attributeLabel = attributeDefinition.label || attributeKey;
 
     const attributeValues = visibleValues.map((attribute) => {
-        let value;
+        let valueRender, valueRaw;
         if (typeof attribute.value === "string") {
             // URL templates are supported only for string values
             const url = attributeDefinition["url_template"]
@@ -72,19 +72,21 @@ function AttributeRenderer({
                   )
                 : null;
             if (url) {
-                value = <a href={url}>{attribute.value}</a>;
+                valueRender = <a href={url}>{attribute.value}</a>;
             } else {
-                value = <span>{attribute.value}</span>;
+                valueRender = <span>{attribute.value}</span>;
             }
+            valueRaw = attribute.value;
         } else {
-            value = <pre>{JSON.stringify(attribute.value, null, 4)}</pre>;
+            valueRender = <pre>{JSON.stringify(attribute.value, null, 4)}</pre>;
+            valueRaw = JSON.stringify(attribute.value);
         }
         return (
             <div key={attribute.id}>
-                {value}
+                {valueRender}
                 <span className="ml-2">
                     <ActionCopyToClipboard
-                        text={String(attribute.value)}
+                        text={valueRaw}
                         tooltipMessage="Copy value to clipboard"
                     />
                 </span>
@@ -97,7 +99,7 @@ function AttributeRenderer({
                         history.push(
                             makeSearchLink(
                                 `attribute.${attributeKey}`,
-                                String(attribute.value),
+                                valueRaw,
                                 false
                             )
                         );

--- a/mwdb/web/src/components/Attributes.js
+++ b/mwdb/web/src/components/Attributes.js
@@ -27,7 +27,12 @@ for (let extraRenderers of fromPlugin("attributeRenderers")) {
     attributeRenderers = { ...attributeRenderers, ...extraRenderers };
 }
 
-function DefaultAttributeRenderer(props) {
+function AttributeRenderer({
+    attributeKey,
+    attributeDefinition,
+    values,
+    onUpdateAttributes,
+}) {
     const api = useContext(APIContext);
     const auth = useContext(AuthContext);
     const context = useContext(ObjectContext);
@@ -35,29 +40,113 @@ function DefaultAttributeRenderer(props) {
 
     const [collapsed, setCollapsed] = useState(true);
     const [isOpenDeleteModal, setOpenDeleteModal] = useState(false);
-    const [attributeToRemove, setAttributeToRemote] = useState(null);
+    const [attributeIdToRemove, setAttributeIdToRemove] = useState(null);
 
-    const isCollapsible = props.values.length > 3;
+    const isCollapsible = values.length > 3;
 
     async function deleteAttribute() {
         try {
-            await api.removeObjectMetakey(
-                context.object.type,
+            await api.removeObjectAttribute(
                 context.object.id,
-                attributeToRemove.key,
-                attributeToRemove.value
+                attributeIdToRemove
             );
-            props.onUpdateAttributes();
+            onUpdateAttributes();
             setOpenDeleteModal(false);
-            setAttributeToRemote(null);
+            setAttributeIdToRemove(null);
         } catch (error) {
             context.setObjectError(error);
         }
     }
 
-    const visibleValues = collapsed ? props.values.slice(0, 3) : props.values;
+    const visibleValues = collapsed ? values.slice(0, 3) : values;
+    const attributeLabel = attributeDefinition.label || attributeKey;
+
+    const attributeValues = visibleValues.map((attribute) => {
+        let value;
+        if (typeof attribute.value === "string") {
+            // URL templates are supported only for string values
+            const url = attributeDefinition["url_template"]
+                ? attributeDefinition["url_template"].replace(
+                      "$value",
+                      attribute.value
+                  )
+                : null;
+            if (url) {
+                value = <a href={url}>{attribute.value}</a>;
+            } else {
+                value = <span>{attribute.value}</span>;
+            }
+        } else {
+            value = <pre>{JSON.stringify(attribute.value, null, 4)}</pre>;
+        }
+        return (
+            <div key={attribute.id}>
+                {value}
+                <span className="ml-2">
+                    <ActionCopyToClipboard
+                        text={String(attribute.value)}
+                        tooltipMessage="Copy value to clipboard"
+                    />
+                </span>
+                <span
+                    className="ml-2"
+                    data-toggle="tooltip"
+                    title="Search for that attribute values"
+                    onClick={(ev) => {
+                        ev.preventDefault();
+                        history.push(
+                            makeSearchLink(
+                                `attribute.${attributeKey}`,
+                                String(attribute.value),
+                                false
+                            )
+                        );
+                    }}
+                >
+                    <i>
+                        <FontAwesomeIcon
+                            icon="search"
+                            size="sm"
+                            style={{ cursor: "pointer" }}
+                        />
+                    </i>
+                </span>
+                {auth.hasCapability(Capability.removingAttributes) && (
+                    <span
+                        className="ml-2"
+                        data-toggle="tooltip"
+                        title="Remove attribute value from this object"
+                        onClick={() => {
+                            setAttributeIdToRemove(attribute.id);
+                            setOpenDeleteModal(true);
+                        }}
+                    >
+                        <i>
+                            <FontAwesomeIcon
+                                icon={"trash"}
+                                size="sm"
+                                style={{ cursor: "pointer" }}
+                            />
+                        </i>
+                    </span>
+                )}
+                <ConfirmationModal
+                    buttonStyle="btn-danger"
+                    confirmText="Yes"
+                    cancelText="No"
+                    message="Are you sure you want to remove this attribute from the object?"
+                    isOpen={isOpenDeleteModal}
+                    onRequestClose={() => setOpenDeleteModal(false)}
+                    onConfirm={(ev) => {
+                        ev.preventDefault();
+                        deleteAttribute();
+                    }}
+                />
+            </div>
+        );
+    });
     return (
-        <tr key={props.label}>
+        <tr key={attributeKey}>
             <th
                 onClick={(ev) => {
                     ev.preventDefault();
@@ -74,85 +163,14 @@ function DefaultAttributeRenderer(props) {
                 )}{" "}
                 <span
                     data-toggle="tooltip"
-                    title={props.name}
+                    title={attributeKey}
                     style={{ cursor: "pointer" }}
                 >
-                    {props.label}
+                    {attributeLabel}
                 </span>
             </th>
             <td className="flickerable">
-                {visibleValues.map((attr) => (
-                    <div key={attr.value}>
-                        {attr.url ? (
-                            <a href={attr.url}>{attr.value}</a>
-                        ) : (
-                            <span>{attr.value}</span>
-                        )}
-                        <span className="ml-2">
-                            <ActionCopyToClipboard
-                                text={attr.value}
-                                tooltipMessage="Copy value to clipboard"
-                            />
-                        </span>
-                        <span
-                            className="ml-2"
-                            data-toggle="tooltip"
-                            title="Search for that attribute values"
-                            onClick={(ev) => {
-                                ev.preventDefault();
-                                history.push(
-                                    makeSearchLink(
-                                        `meta.${props.name}`,
-                                        attr.value,
-                                        false
-                                    )
-                                );
-                            }}
-                        >
-                            <i>
-                                <FontAwesomeIcon
-                                    icon="search"
-                                    size="sm"
-                                    style={{ cursor: "pointer" }}
-                                />
-                            </i>
-                        </span>
-                        {auth.hasCapability(Capability.removingAttributes) && (
-                            <span
-                                className="ml-2"
-                                data-toggle="tooltip"
-                                title="Remove attribute value from this object"
-                                onClick={() => {
-                                    setAttributeToRemote({
-                                        key: attr.key,
-                                        value: attr.value,
-                                    });
-                                    setOpenDeleteModal(true);
-                                }}
-                            >
-                                <i>
-                                    <FontAwesomeIcon
-                                        icon={"trash"}
-                                        size="sm"
-                                        style={{ cursor: "pointer" }}
-                                    />
-                                </i>
-                            </span>
-                        )}
-                        <ConfirmationModal
-                            buttonStyle="btn-danger"
-                            confirmText="Yes"
-                            cancelText="No"
-                            message="Are you sure you want to remove this attribute from the object?"
-                            isOpen={isOpenDeleteModal}
-                            onRequestClose={() => setOpenDeleteModal(false)}
-                            onConfirm={(ev) => {
-                                ev.preventDefault();
-                                deleteAttribute();
-                            }}
-                        />
-                    </div>
-                ))}
+                {attributeValues}
                 {isCollapsible && collapsed ? (
                     <span style={{ color: "gray", fontWeight: "bold" }}>
                         ...
@@ -170,22 +188,46 @@ function ObjectAttributes(props) {
     const config = useContext(ConfigContext);
     const context = useContext(ObjectContext);
 
+    const [attributeDefinitions, setAttributeDefinitions] = useState({});
     const [attributes, setAttributes] = useState([]);
     const objectId = context.object.id;
     const setObjectError = context.setObjectError;
 
+    async function updateAttributeDefinitions() {
+        try {
+            const response = await api.getAttributeDefinitions("read");
+            const keyDefinitions = response.data[
+                "attribute_definitions"
+            ].reduce(
+                (agg, definition) => ({
+                    ...agg,
+                    [definition.key]: definition,
+                }),
+                {}
+            );
+            setAttributeDefinitions(keyDefinitions);
+        } catch (error) {
+            setObjectError(error);
+        }
+    }
+
     async function updateAttributes() {
         if (typeof objectId === "undefined") return;
         try {
-            let response = await api.getObjectMetakeys(objectId);
-            let aggregated = response.data.metakeys.reduce((agg, m) => {
-                let label = m.label || m.key;
-                return {
+            const response = await api.getObjectAttributes(objectId);
+            const attributes = response.data.attributes.reduce(
+                (agg, attribute) => ({
                     ...agg,
-                    [label]: [m].concat(agg[label] || []),
-                };
-            }, {});
-            setAttributes(aggregated);
+                    [attribute.key]: [
+                        {
+                            id: attribute.id,
+                            value: attribute.value,
+                        },
+                    ].concat(agg[attribute.key] || []),
+                }),
+                {}
+            );
+            setAttributes(attributes);
         } catch (error) {
             setObjectError(error);
         }
@@ -193,13 +235,22 @@ function ObjectAttributes(props) {
 
     async function addAttribute(key, value) {
         try {
-            await api.addObjectMetakey(objectId, key, value);
+            await api.addObjectAttribute(objectId, key, value);
             await updateAttributes();
             props.onRequestModalClose();
         } catch (error) {
             setObjectError(error);
         }
     }
+
+    const getAttributeDefinitions = useCallback(updateAttributeDefinitions, [
+        api,
+        setObjectError,
+    ]);
+
+    useEffect(() => {
+        getAttributeDefinitions();
+    }, [getAttributeDefinitions]);
 
     const getAttributes = useCallback(updateAttributes, [
         objectId,
@@ -232,19 +283,17 @@ function ObjectAttributes(props) {
                 <DataTable>
                     {Object.keys(attributes)
                         .sort()
-                        .map((label) => {
-                            let values = attributes[label];
-                            let key = values[0] && values[0].key;
+                        .map((key) => {
+                            const definition = attributeDefinitions[key];
+                            const values = attributes[key];
                             let Attribute =
-                                attributeRenderers[key] ||
-                                DefaultAttributeRenderer;
+                                attributeRenderers[key] || AttributeRenderer;
                             return (
                                 <Attribute
                                     key={key}
-                                    name={key}
-                                    label={label}
+                                    attributeKey={key}
+                                    attributeDefinition={definition}
                                     values={values}
-                                    object={context.object}
                                     onUpdateAttributes={updateAttributes}
                                 />
                             );

--- a/mwdb/web/src/components/AttributesAddModal.js
+++ b/mwdb/web/src/components/AttributesAddModal.js
@@ -79,7 +79,9 @@ export default function AttributesAddModal({ isOpen, onAdd, onRequestClose }) {
                                 .map((attr) => (
                                     <option key={attr} value={attr}>
                                         {attributeDefinitions[attr].label ||
-                                            attributeDefinitions[attr].key}
+                                            attributeDefinitions[attr].key}{" "}
+                                        {attributeDefinitions[attr].label &&
+                                            `(${attributeDefinitions[attr].key})`}
                                     </option>
                                 ))}
                         </select>

--- a/mwdb/web/src/components/AttributesAddModal.js
+++ b/mwdb/web/src/components/AttributesAddModal.js
@@ -1,133 +1,109 @@
-import React, { Component } from "react";
+import React, { useRef, useState, useEffect, useCallback } from "react";
 
 import api from "@mwdb-web/commons/api";
-import { AuthContext, Capability } from "@mwdb-web/commons/auth";
 import { ConfirmationModal } from "@mwdb-web/commons/ui";
 
-export default class AttributesAddModal extends Component {
-    state = {
-        attributes: [],
-        attributeKey: "",
-        attributeValue: "",
-    };
+export default function AttributesAddModal({ isOpen, onAdd, onRequestClose }) {
+    const [attributeDefinitions, setAttributeDefinitions] = useState({});
+    const [attributeKey, setAttributeKey] = useState("");
+    const [attributeValue, setAttributeValue] = useState("");
+    const attributeForm = useRef(null);
 
-    attributesForm = React.createRef();
+    function handleSubmit(ev) {
+        if (ev) ev.preventDefault();
+        if (!attributeForm.current.reportValidity()) return;
+        onAdd(attributeKey, attributeValue);
+    }
 
-    static contextType = AuthContext;
+    function handleKeyChange(ev) {
+        setAttributeKey(ev.target.value);
+    }
 
-    handleSubmit = (event) => {
-        if (event) event.preventDefault();
-        if (
-            !this.attributesForm.current ||
-            !this.attributesForm.current.reportValidity()
-        )
-            return;
-        this.props.onAdd(
-            this.state.attributeKey.toLowerCase(),
-            this.state.attributeValue
-        );
-    };
+    function handleValueChange(ev) {
+        setAttributeValue(ev.target.value);
+    }
 
-    async updateAttributesList() {
+    async function updateAttributeDefinitions() {
         try {
-            let response = await api.getSettableMetakeyDefinitions();
-            let attributes = {};
-            for (let attribute of response.data.metakeys) {
-                attributes[attribute.label || attribute.key] = attribute;
-            }
-            this.setState({ attributes });
+            const response = await api.getAttributeDefinitions("set");
+            const keyDefinitions = response.data[
+                "attribute_definitions"
+            ].reduce(
+                (agg, definition) => ({
+                    ...agg,
+                    [definition.key]: definition,
+                }),
+                {}
+            );
+            console.log(keyDefinitions);
+            setAttributeDefinitions(keyDefinitions);
         } catch (error) {
-            console.error(error);
-            this.setState({ error });
+            console.log(error);
         }
     }
 
-    handleAttributeChange = (ev) => {
-        let chosenAttribute = ev.target.value;
-        this.setState({
-            chosenAttribute,
-            attributeKey: this.state.attributes[chosenAttribute].key,
-        });
-    };
+    const getAttributeDefinitions = useCallback(updateAttributeDefinitions, []);
 
-    handleValueChange = (ev) => {
-        this.setState({ attributeValue: ev.target.value });
-    };
+    useEffect(() => {
+        getAttributeDefinitions();
+    }, [getAttributeDefinitions]);
 
-    get attributeHint() {
-        if (!this.state.chosenAttribute) return undefined;
-        return this.state.attributes[this.state.chosenAttribute].description;
-    }
-
-    componentDidMount() {
-        this.updateAttributesList();
-    }
-
-    componentDidUpdate(prevProps) {
-        if (prevProps.isOpen !== this.props.isOpen) this.updateAttributesList();
-    }
-
-    render() {
-        return (
-            <ConfirmationModal
-                buttonStyle="btn-success"
-                confirmText="Add"
-                message="Add attribute"
-                isOpen={this.props.isOpen}
-                onRequestClose={this.props.onRequestClose}
-                onConfirm={this.handleSubmit}
-            >
-                {!this.context.hasCapability(Capability.addingAllAttributes) &&
-                !Object.keys(this.state.attributes).length ? (
-                    <div>
-                        Sorry, there are no attributes you can set at this
-                        moment.
+    return (
+        <ConfirmationModal
+            buttonStyle="btn-success"
+            confirmText="Add"
+            message="Add attribute"
+            isOpen={isOpen}
+            onRequestClose={onRequestClose}
+            onConfirm={handleSubmit}
+        >
+            {!Object.keys(attributeDefinitions).length ? (
+                <div>
+                    Sorry, there are no attributes you can set at this moment.
+                </div>
+            ) : (
+                <form onSubmit={handleSubmit} ref={attributeForm}>
+                    <div className="form-group">
+                        <label>Attribute</label>
+                        <select
+                            className="form-control"
+                            onChange={handleKeyChange}
+                            value={attributeKey}
+                            required
+                        >
+                            <option key="" value="">
+                                &nbsp;
+                            </option>
+                            {Object.keys(attributeDefinitions)
+                                .sort()
+                                .map((attr) => (
+                                    <option key={attr} value={attr}>
+                                        {attributeDefinitions[attr].label ||
+                                            attributeDefinitions[attr].key}
+                                    </option>
+                                ))}
+                        </select>
+                        {attributeDefinitions[attributeKey] &&
+                        attributeDefinitions[attributeKey].description ? (
+                            <div className="form-hint">
+                                {attributeDefinitions[attributeKey].description}
+                            </div>
+                        ) : (
+                            []
+                        )}
                     </div>
-                ) : (
-                    <form
-                        ref={this.attributesForm}
-                        onSubmit={this.handleSubmit}
-                    >
-                        <div className="form-group">
-                            <label>Attribute</label>
-                            <select
-                                className="form-control"
-                                onChange={this.handleAttributeChange}
-                                value={this.state.chosenAttribute}
-                                required
-                            >
-                                <option key="" value="">
-                                    &nbsp;
-                                </option>
-                                {Object.keys(this.state.attributes)
-                                    .sort()
-                                    .map((attr) => (
-                                        <option key={attr} value={attr}>
-                                            {attr}
-                                        </option>
-                                    ))}
-                            </select>
-                            {this.attributeHint ? (
-                                <div class="form-hint">
-                                    {this.attributeHint}
-                                </div>
-                            ) : (
-                                []
-                            )}
-                        </div>
-                        <div className="form-group">
-                            <label>Value</label>
-                            <input
-                                type="text"
-                                className="form-control"
-                                onChange={this.handleValueChange}
-                                value={this.state.attributeValue}
-                                required
-                            />
-                        </div>
-                    </form>
-                )}
-            </ConfirmationModal>
-        );
-    }
+                    <div className="form-group">
+                        <label>Value</label>
+                        <input
+                            type="text"
+                            className="form-control"
+                            onChange={handleValueChange}
+                            value={attributeValue}
+                            required
+                        />
+                    </div>
+                </form>
+            )}
+        </ConfirmationModal>
+    );
 }

--- a/mwdb/web/src/components/Remote/RemoteAPI.js
+++ b/mwdb/web/src/components/Remote/RemoteAPI.js
@@ -19,7 +19,8 @@ export default function RemoteAPI({ children }) {
             getObjectRelations: (id) =>
                 api.getRemoteObjectRelations(remote, id),
             getObjectShares: (id) => api.getRemoteObjectShares(remote, id),
-            getObjectMetakeys: (id) => api.getRemoteObjectMetakeys(remote, id),
+            getObjectAttributes: (id) =>
+                api.getRemoteObjectAttributes(remote, id),
             downloadFile: (id) => api.downloadRemoteFile(remote, id),
             requestFileDownloadLink: (id) =>
                 api.requestRemoteFileDownloadLink(remote, id),

--- a/mwdb/web/src/components/Settings/SettingsView.js
+++ b/mwdb/web/src/components/Settings/SettingsView.js
@@ -190,8 +190,8 @@ export default function SettingsView() {
                             <AdministrativeRoute
                                 exact
                                 path={[
-                                    "/settings/attribute/:metakey",
-                                    "/settings/attribute/:metakey/permissions",
+                                    "/settings/attribute/:attributeKey",
+                                    "/settings/attribute/:attributeKey/permissions",
                                 ]}
                             >
                                 <AttributeView />

--- a/mwdb/web/src/components/Settings/Views/AttributeCreate.js
+++ b/mwdb/web/src/components/Settings/Views/AttributeCreate.js
@@ -6,10 +6,10 @@ import { useViewAlert } from "@mwdb-web/commons/ui";
 export default function AttributeCreate() {
     const viewAlert = useViewAlert();
     const [values, setValues] = useState({
-        metakey: "",
+        attributeKey: "",
         label: "",
         description: "",
-        template: "",
+        url_template: "",
         hidden: false,
     });
 
@@ -27,15 +27,15 @@ export default function AttributeCreate() {
 
     async function createAttribute() {
         try {
-            await api.addMetakeyDefinition(
-                values.metakey,
+            await api.addAttributeDefinition(
+                values.attributeKey,
                 values.label,
                 values.description,
-                values.template,
+                values["url_template"],
                 values.hidden
             );
             viewAlert.redirectToAlert({
-                target: `/settings/attribute/${values.metakey}`,
+                target: `/settings/attribute/${values.attributeKey}`,
                 success: "Attribute created successfully.",
             });
         } catch (error) {
@@ -56,8 +56,8 @@ export default function AttributeCreate() {
                     <label>Key</label>
                     <input
                         type="text"
-                        name="metakey"
-                        value={values.metakey}
+                        name="attributeKey"
+                        value={values.attributeKey}
                         onChange={handleInputChange}
                         className="form-control"
                         required
@@ -98,8 +98,8 @@ export default function AttributeCreate() {
                     <label>URL template</label>
                     <input
                         type="text"
-                        name="template"
-                        value={values.template}
+                        name="url_template"
+                        value={values["url_template"]}
                         onChange={handleInputChange}
                         className="form-control"
                     />

--- a/mwdb/web/src/components/Settings/Views/AttributeDetails.js
+++ b/mwdb/web/src/components/Settings/Views/AttributeDetails.js
@@ -33,7 +33,13 @@ export function AttributeDetails({ attribute, getAttribute }) {
             newValue.hidden = false;
         }
         try {
-            await api.updateMetakeyDefinition(attribute.key, newValue);
+            await api.updateAttributeDefinition(
+                attribute.key,
+                newValue.label,
+                newValue.description,
+                newValue["url_template"],
+                newValue.hidden
+            );
         } catch (error) {
             viewAlert.setAlert({ error });
         } finally {
@@ -44,7 +50,7 @@ export function AttributeDetails({ attribute, getAttribute }) {
     async function handleRemoveAttribute() {
         try {
             setDeleteModalDisabled(true);
-            await api.removeMetakeyDefinition(attribute.key);
+            await api.removeAttributeDefinition(attribute.key);
             viewAlert.redirectToAlert({
                 target: "/settings/attributes",
                 success: `Attribute '${attribute.key}' successfully removed.`,
@@ -74,8 +80,8 @@ export function AttributeDetails({ attribute, getAttribute }) {
                     </AttributeItem>
                     <AttributeItem label="URL Template">
                         <EditableItem
-                            name="template"
-                            defaultValue={attribute.template}
+                            name="url_template"
+                            defaultValue={attribute["url_template"]}
                             onSubmit={handleSubmit}
                         />
                     </AttributeItem>

--- a/mwdb/web/src/components/Settings/Views/AttributePermissions.js
+++ b/mwdb/web/src/components/Settings/Views/AttributePermissions.js
@@ -1,4 +1,4 @@
-import React, { Component, useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 
 import api from "@mwdb-web/commons/api";
 import {
@@ -8,248 +8,215 @@ import {
 } from "@mwdb-web/commons/ui";
 import { Link, useParams } from "react-router-dom";
 
-class AttributePermissionsBox extends Component {
-    state = {
-        changedPermissions: {},
-        newMember: "",
-    };
+function AttributePermissionsItem({
+    group,
+    permission,
+    updateGroup,
+    removeGroup,
+}) {
+    const [changedPermission, setChangedPermission] = useState({
+        read: permission.read,
+        set: permission.set,
+    });
 
-    isPermissionChanged(groupName, permission) {
-        let permset = this.state.changedPermissions[groupName];
-        return (
-            permset &&
-            permset[permission] !==
-                this.props.permissions[groupName][permission]
-        );
+    function switchPermission(access) {
+        setChangedPermission((prevState) => {
+            const state = { ...prevState };
+            state[access] = !state[access];
+            return state;
+        });
     }
 
-    getPermission(groupName, permission) {
-        let permset =
-            this.state.changedPermissions[groupName] ||
-            this.props.permissions[groupName];
-        return permset[permission];
+    function isChanged(access) {
+        return changedPermission[access] !== permission[access];
     }
 
-    switchPermission(groupName, permission) {
-        let changedPermissions = { ...this.state.changedPermissions };
-        if (!changedPermissions[groupName])
-            changedPermissions[groupName] = {
-                read: this.props.permissions[groupName].read,
-                set: this.props.permissions[groupName].set,
-            };
-        changedPermissions[groupName][permission] =
-            !changedPermissions[groupName][permission];
-        this.setState({ changedPermissions });
-    }
-
-    render() {
-        return (
-            <div>
-                <table className="table table-striped table-bordered wrap-table">
-                    <thead>
-                        <tr>
-                            <th>Group name</th>
-                            <th>Permissions</th>
-                            <th>Actions</th>
-                        </tr>
-                    </thead>
+    return (
+        <tr key={group}>
+            <td>
+                <Link to={`/settings/group/${group}`}>{group}</Link>
+            </td>
+            <td>
+                <table className="float-left">
                     <tbody>
-                        {Object.keys(this.props.permissions)
-                            .sort()
-                            .map((permGroup) => (
-                                <tr key={permGroup}>
-                                    <td>
-                                        <Link
-                                            to={`/settings/group/${permGroup}`}
-                                        >
-                                            {permGroup}
-                                        </Link>
-                                    </td>
-                                    <td>
-                                        <table className="float-left">
-                                            <tr>
-                                                <td>
-                                                    <div className="material-switch">
-                                                        <input
-                                                            type="checkbox"
-                                                            className="custom-control-input"
-                                                            id={`${permGroup}-readSwitch`}
-                                                            onChange={(ev) => {
-                                                                this.switchPermission(
-                                                                    permGroup,
-                                                                    "read"
-                                                                );
-                                                            }}
-                                                            checked={this.getPermission(
-                                                                permGroup,
-                                                                "read"
-                                                            )}
-                                                        />
-                                                        <label
-                                                            className="bg-primary"
-                                                            htmlFor={`${permGroup}-readSwitch`}
-                                                        />
-                                                    </div>
-                                                    <div>
-                                                        {this.isPermissionChanged(
-                                                            permGroup,
-                                                            "read"
-                                                        ) ? (
-                                                            <span
-                                                                style={{
-                                                                    color: "red",
-                                                                }}
-                                                            >
-                                                                *
-                                                            </span>
-                                                        ) : (
-                                                            []
-                                                        )}
-                                                        Can read
-                                                    </div>
-                                                </td>
-                                                <td>
-                                                    <div className="material-switch">
-                                                        <input
-                                                            type="checkbox"
-                                                            className="custom-control-input"
-                                                            id={`${permGroup}-setSwitch`}
-                                                            onChange={(ev) => {
-                                                                this.switchPermission(
-                                                                    permGroup,
-                                                                    "set"
-                                                                );
-                                                            }}
-                                                            checked={this.getPermission(
-                                                                permGroup,
-                                                                "set"
-                                                            )}
-                                                        />
-                                                        <label
-                                                            className="bg-primary"
-                                                            htmlFor={`${permGroup}-setSwitch`}
-                                                        />
-                                                    </div>
-                                                    <div>
-                                                        {this.isPermissionChanged(
-                                                            permGroup,
-                                                            "set"
-                                                        ) ? (
-                                                            <span
-                                                                style={{
-                                                                    color: "red",
-                                                                }}
-                                                            >
-                                                                *
-                                                            </span>
-                                                        ) : (
-                                                            []
-                                                        )}
-                                                        Can set
-                                                    </div>
-                                                </td>
-                                            </tr>
-                                        </table>
-                                    </td>
-                                    <td>
-                                        <button
-                                            type="button"
-                                            className="btn btn-primary"
-                                            disabled={
-                                                !this.isPermissionChanged(
-                                                    permGroup,
-                                                    "read"
-                                                ) &&
-                                                !this.isPermissionChanged(
-                                                    permGroup,
-                                                    "set"
-                                                )
-                                            }
-                                            onClick={() =>
-                                                this.props.updateGroup(
-                                                    permGroup,
-                                                    this.getPermission(
-                                                        permGroup,
-                                                        "read"
-                                                    ),
-                                                    this.getPermission(
-                                                        permGroup,
-                                                        "set"
-                                                    )
-                                                )
-                                            }
-                                        >
-                                            Update
-                                        </button>
-                                        <button
-                                            type="button"
-                                            className="btn btn-danger"
-                                            onClick={() =>
-                                                this.props.removeGroup(
-                                                    permGroup
-                                                )
-                                            }
-                                        >
-                                            Remove group
-                                        </button>
-                                    </td>
-                                </tr>
-                            ))}
                         <tr>
                             <td>
-                                <Autocomplete
-                                    value={this.state.newMember}
-                                    items={this.props.groupItems.filter(
-                                        (item) =>
-                                            item.name
-                                                .toLowerCase()
-                                                .indexOf(
-                                                    this.state.newMember.toLowerCase()
-                                                ) !== -1
+                                <div className="material-switch">
+                                    <input
+                                        type="checkbox"
+                                        className="custom-control-input"
+                                        id={`${group}-readSwitch`}
+                                        onChange={() => {
+                                            switchPermission("read");
+                                        }}
+                                        checked={changedPermission["read"]}
+                                    />
+                                    <label
+                                        className="bg-primary"
+                                        htmlFor={`${group}-readSwitch`}
+                                    />
+                                </div>
+                                <div>
+                                    {isChanged("read") ? (
+                                        <span style={{ color: "red" }}>*</span>
+                                    ) : (
+                                        []
                                     )}
-                                    getItemValue={(item) => item.name}
-                                    onChange={(value) =>
-                                        this.setState({ newMember: value })
-                                    }
-                                    className="form-control"
-                                />
+                                    Can read
+                                </div>
                             </td>
-                            <td />
                             <td>
-                                <button
-                                    type="button"
-                                    className="btn btn-success"
-                                    onClick={() =>
-                                        this.state.newMember &&
-                                        this.props.addGroup(
-                                            this.state.newMember
-                                        )
-                                    }
-                                    disabled={!this.state.newMember}
-                                >
-                                    Add group
-                                </button>
+                                <div className="material-switch">
+                                    <input
+                                        type="checkbox"
+                                        className="custom-control-input"
+                                        id={`${group}-setSwitch`}
+                                        onChange={() => {
+                                            switchPermission("set");
+                                        }}
+                                        checked={changedPermission["set"]}
+                                    />
+                                    <label
+                                        className="bg-primary"
+                                        htmlFor={`${group}-setSwitch`}
+                                    />
+                                </div>
+                                <div>
+                                    {isChanged("set") ? (
+                                        <span
+                                            style={{
+                                                color: "red",
+                                            }}
+                                        >
+                                            *
+                                        </span>
+                                    ) : (
+                                        []
+                                    )}
+                                    Can set
+                                </div>
                             </td>
                         </tr>
                     </tbody>
                 </table>
-            </div>
-        );
-    }
+            </td>
+            <td>
+                <button
+                    type="button"
+                    className="btn btn-primary"
+                    disabled={!isChanged("read") && !isChanged("set")}
+                    onClick={() =>
+                        updateGroup(
+                            group,
+                            changedPermission["read"],
+                            changedPermission["set"]
+                        )
+                    }
+                >
+                    Update
+                </button>
+                <button
+                    type="button"
+                    className="btn btn-danger"
+                    onClick={() => removeGroup(group)}
+                >
+                    Remove group
+                </button>
+            </td>
+        </tr>
+    );
+}
+
+function AttributePermissionsBox({
+    permissions,
+    groups,
+    addGroup,
+    updateGroup,
+    removeGroup,
+}) {
+    const [newMember, setNewMember] = useState("");
+
+    return (
+        <table className="table table-striped table-bordered wrap-table">
+            <thead>
+                <tr>
+                    <th>Group name</th>
+                    <th>Permissions</th>
+                    <th>Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                {Object.keys(permissions)
+                    .sort()
+                    .map((group) => (
+                        <AttributePermissionsItem
+                            key={group}
+                            group={group}
+                            permission={permissions[group]}
+                            updateGroup={updateGroup}
+                            removeGroup={removeGroup}
+                        />
+                    ))}
+                <tr>
+                    <td>
+                        <Autocomplete
+                            value={newMember}
+                            items={groups.filter(
+                                (item) =>
+                                    item.name
+                                        .toLowerCase()
+                                        .indexOf(newMember.toLowerCase()) !== -1
+                            )}
+                            getItemValue={(item) => item.name}
+                            onChange={(value) => setNewMember(value)}
+                            className="form-control"
+                        />
+                    </td>
+                    <td />
+                    <td>
+                        <button
+                            type="button"
+                            className="btn btn-success"
+                            onClick={() => newMember && addGroup(newMember)}
+                            disabled={!newMember}
+                        >
+                            Add group
+                        </button>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    );
 }
 
 export function AttributesPermissions({ attribute, getAttribute }) {
-    const { metakey } = useParams();
+    const { attributeKey } = useParams();
     const { setAlert } = useViewAlert();
     const [allGroups, setAllGroups] = useState([]);
     const [permissions, setPermissions] = useState({});
     const [modalSpec, setModalSpec] = useState({});
     const [isModalOpen, setModalOpen] = useState(false);
 
+    const updateAttributePermissions = useCallback(async () => {
+        let response = await api.getAttributePermissions(attributeKey);
+        let attributePermissions = {};
+        for (let permission of response.data["attribute_permissions"])
+            attributePermissions[permission["group_name"]] = {
+                read: permission["can_read"],
+                set: permission["can_set"],
+            };
+        setPermissions(attributePermissions);
+    }, [attributeKey]);
+
     async function addGroup(group) {
         try {
-            await api.setMetakeyPermission(attribute.key, group, false, false);
-            getAttribute();
+            await api.setAttributePermission(
+                attribute.key,
+                group,
+                false,
+                false
+            );
+            await updateAttributePermissions();
         } catch (error) {
             setAlert({ error });
         }
@@ -257,13 +224,13 @@ export function AttributesPermissions({ attribute, getAttribute }) {
 
     async function updateGroup(group, can_read, can_set) {
         try {
-            await api.setMetakeyPermission(
+            await api.setAttributePermission(
                 attribute.key,
                 group,
                 can_read,
                 can_set
             );
-            getAttribute();
+            await updateAttributePermissions();
             setModalOpen(false);
         } catch (error) {
             setAlert({ error });
@@ -282,8 +249,8 @@ export function AttributesPermissions({ attribute, getAttribute }) {
 
     async function removeGroup(group) {
         try {
-            await api.deleteMetakeyPermission(attribute.key, group);
-            getAttribute();
+            await api.removeAttributePermission(attribute.key, group);
+            await updateAttributePermissions();
             setModalOpen(false);
         } catch (error) {
             setAlert({ error });
@@ -309,17 +276,6 @@ export function AttributesPermissions({ attribute, getAttribute }) {
         }
     }, [setAlert]);
 
-    const updateAttributePermissions = useCallback(async () => {
-        let response = await api.getMetakeyDefinition(metakey);
-        let attributePermissions = {};
-        for (let permission of response.data.permissions)
-            attributePermissions[permission["group_name"]] = {
-                read: permission["can_read"],
-                set: permission["can_set"],
-            };
-        setPermissions(attributePermissions);
-    }, [metakey]);
-
     function handleUpdate() {
         updateAllGroups();
         updateAttributePermissions();
@@ -340,7 +296,7 @@ export function AttributesPermissions({ attribute, getAttribute }) {
         <React.Fragment>
             <AttributePermissionsBox
                 permissions={permissions}
-                groupItems={allGroups}
+                groups={allGroups}
                 addGroup={addGroup}
                 updateGroup={handleUpdateGroup}
                 removeGroup={handleRemoveGroup}

--- a/mwdb/web/src/components/Settings/Views/AttributeView.js
+++ b/mwdb/web/src/components/Settings/Views/AttributeView.js
@@ -8,19 +8,19 @@ import { AttributesPermissions } from "./AttributePermissions";
 export default function AttributeView() {
     const location = useLocation();
     const { setAlert } = useViewAlert();
-    const { metakey } = useParams();
+    const { attributeKey } = useParams();
     const [attribute, setAttribute] = useState({});
 
     async function updateAttribute() {
         try {
-            let response = await api.getMetakeyDefinition(metakey);
+            let response = await api.getAttributeDefinition(attributeKey);
             setAttribute(response.data);
         } catch (error) {
             setAlert({ error });
         }
     }
 
-    const getAttribute = useCallback(updateAttribute, [metakey, setAlert]);
+    const getAttribute = useCallback(updateAttribute, [attributeKey, setAlert]);
 
     useEffect(() => {
         getAttribute();
@@ -44,7 +44,7 @@ export default function AttributeView() {
                     {location.pathname.split("/").length > 4 && (
                         <li className="breadcrumb-item active">
                             <Switch>
-                                <AdministrativeRoute path="/settings/attribute/:metakey/permissions">
+                                <AdministrativeRoute path="/settings/attribute/:attributeKey/permissions">
                                     Permissions
                                 </AdministrativeRoute>
                             </Switch>
@@ -53,7 +53,10 @@ export default function AttributeView() {
                 </ol>
             </nav>
             <Switch>
-                <AdministrativeRoute exact path="/settings/attribute/:metakey">
+                <AdministrativeRoute
+                    exact
+                    path="/settings/attribute/:attributeKey"
+                >
                     <AttributeDetails
                         attribute={attribute}
                         getAttribute={updateAttribute}
@@ -61,7 +64,7 @@ export default function AttributeView() {
                 </AdministrativeRoute>
                 <AdministrativeRoute
                     exact
-                    path="/settings/attribute/:metakey/permissions"
+                    path="/settings/attribute/:attributeKey/permissions"
                 >
                     <AttributesPermissions
                         attribute={attribute}

--- a/mwdb/web/src/components/Settings/Views/AttributesList.js
+++ b/mwdb/web/src/components/Settings/Views/AttributesList.js
@@ -4,19 +4,25 @@ import { Link } from "react-router-dom";
 import api from "@mwdb-web/commons/api";
 import { PagedList, useViewAlert } from "@mwdb-web/commons/ui";
 
-function AttributeItem({ name, label, description, template }) {
+function AttributeItem({ attribute }) {
     return (
         <tr>
             <td>
-                <Link to={`/settings/attribute/${name}`}>{name}</Link>
+                <Link to={`/settings/attribute/${attribute.key}`}>
+                    {attribute.key}
+                </Link>
                 &nbsp;
-                {label && <span>({label})</span>}
+                {attribute.label && <span>({attribute.label})</span>}
             </td>
             <td>
-                {description || <div className="text-muted">(Not defined)</div>}
+                {attribute.description || (
+                    <div className="text-muted">(Not defined)</div>
+                )}
             </td>
             <td>
-                {template || <div className="text-muted">(Not defined)</div>}
+                {attribute["url_template"] || (
+                    <div className="text-muted">(Not defined)</div>
+                )}
             </td>
         </tr>
     );
@@ -30,11 +36,10 @@ export default function AttributesList() {
 
     async function updateAttributes() {
         try {
-            const response = await api.getMetakeyDefinitions();
+            const response = await api.getAttributeDefinitions("manage");
             setAttributes(
-                response.data["metakeys"].map((attribute) => ({
+                response.data["attribute_definitions"].map((attribute) => ({
                     ...attribute,
-                    name: attribute.key,
                 }))
             );
         } catch (error) {
@@ -63,7 +68,9 @@ export default function AttributesList() {
             <PagedList
                 listItem={AttributeItem}
                 columnNames={["Key (Label)", "Description", "URL Template"]}
-                items={items.slice((activePage - 1) * 10, activePage * 10)}
+                items={items
+                    .slice((activePage - 1) * 10, activePage * 10)
+                    .map((attribute) => ({ attribute }))}
                 itemCount={items.length}
                 activePage={activePage}
                 filterValue={attributeFilter}


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
Web client still uses old Metakey API

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

Web client uses new Attribute API and properly renders non-string values.

Additional bugfixes:
- fixed `remove_attribute_by_id` that disallowed to remove attributes without explicit ACLs when `adding_all_attributes` capability is set
- fixed attribute definition update endpoint throwing ISE 500

**Test plan**
<!-- Explain how to test your changes -->
- Check if all attribute-related functions still work
<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->
