### PR TITLE
Web: Adding JSON attributes from Web

### DIFF
--- a/mwdb/web/src/components/Attributes.js
+++ b/mwdb/web/src/components/Attributes.js
@@ -78,60 +78,70 @@ function AttributeRenderer({
             }
             valueRaw = attribute.value;
         } else {
-            valueRender = <pre>{JSON.stringify(attribute.value, null, 4)}</pre>;
+            valueRender = (
+                <pre className="attribute-object">
+                    {"(object)"} {JSON.stringify(attribute.value, null, 4)}
+                </pre>
+            );
             valueRaw = JSON.stringify(attribute.value);
         }
         return (
-            <div key={attribute.id}>
+            <div key={attribute.id} className="d-flex">
                 {valueRender}
-                <span className="ml-2">
-                    <ActionCopyToClipboard
-                        text={valueRaw}
-                        tooltipMessage="Copy value to clipboard"
-                    />
-                </span>
-                <span
-                    className="ml-2"
-                    data-toggle="tooltip"
-                    title="Search for that attribute values"
-                    onClick={(ev) => {
-                        ev.preventDefault();
-                        history.push(
-                            makeSearchLink(
-                                `attribute.${attributeKey}`,
-                                valueRaw,
-                                false
-                            )
-                        );
-                    }}
-                >
-                    <i>
-                        <FontAwesomeIcon
-                            icon="search"
-                            size="sm"
-                            style={{ cursor: "pointer" }}
+                <div className="d-flex align-items-center">
+                    <span className="ml-2">
+                        <ActionCopyToClipboard
+                            text={valueRaw}
+                            tooltipMessage="Copy value to clipboard"
                         />
-                    </i>
-                </span>
-                {auth.hasCapability(Capability.removingAttributes) && (
-                    <span
-                        className="ml-2"
-                        data-toggle="tooltip"
-                        title="Remove attribute value from this object"
-                        onClick={() => {
-                            setAttributeIdToRemove(attribute.id);
-                            setOpenDeleteModal(true);
-                        }}
-                    >
-                        <i>
-                            <FontAwesomeIcon
-                                icon={"trash"}
-                                size="sm"
-                                style={{ cursor: "pointer" }}
-                            />
-                        </i>
                     </span>
-                )}
+                    {typeof attribute.value === "string" ? (
+                        <span
+                            className="ml-2"
+                            data-toggle="tooltip"
+                            title="Search for that attribute values"
+                            onClick={(ev) => {
+                                ev.preventDefault();
+                                history.push(
+                                    makeSearchLink(
+                                        `attribute.${attributeKey}`,
+                                        valueRaw,
+                                        false
+                                    )
+                                );
+                            }}
+                        >
+                            <i>
+                                <FontAwesomeIcon
+                                    icon="search"
+                                    size="sm"
+                                    style={{ cursor: "pointer" }}
+                                />
+                            </i>
+                        </span>
+                    ) : (
+                        []
+                    )}
+                    {auth.hasCapability(Capability.removingAttributes) && (
+                        <span
+                            className="ml-2"
+                            data-toggle="tooltip"
+                            title="Remove attribute value from this object"
+                            onClick={() => {
+                                setAttributeIdToRemove(attribute.id);
+                                setOpenDeleteModal(true);
+                            }}
+                        >
+                            <i>
+                                <FontAwesomeIcon
+                                    icon={"trash"}
+                                    size="sm"
+                                    style={{ cursor: "pointer" }}
+                                />
+                            </i>
+                        </span>
+                    )}
+                </div>
                 <ConfirmationModal
                     buttonStyle="btn-danger"
                     confirmText="Yes"

--- a/mwdb/web/src/components/Attributes.js
+++ b/mwdb/web/src/components/Attributes.js
@@ -297,6 +297,9 @@ function ObjectAttributes(props) {
                         .sort()
                         .map((key) => {
                             const definition = attributeDefinitions[key];
+                            if (!definition)
+                                // definition not yet loaded
+                                return [];
                             const values = attributes[key];
                             let Attribute =
                                 attributeRenderers[key] || AttributeRenderer;

--- a/mwdb/web/src/components/AttributesAddModal.js
+++ b/mwdb/web/src/components/AttributesAddModal.js
@@ -3,24 +3,49 @@ import React, { useRef, useState, useEffect, useCallback } from "react";
 import api from "@mwdb-web/commons/api";
 import { ConfirmationModal } from "@mwdb-web/commons/ui";
 
+import AceEditor from "react-ace";
+
+import "ace-builds/src-noconflict/mode-text";
+import "ace-builds/src-noconflict/mode-json";
+import "ace-builds/src-noconflict/theme-github";
+import "ace-builds/src-noconflict/ext-searchbox";
+
 export default function AttributesAddModal({ isOpen, onAdd, onRequestClose }) {
     const [attributeDefinitions, setAttributeDefinitions] = useState({});
     const [attributeKey, setAttributeKey] = useState("");
     const [attributeValue, setAttributeValue] = useState("");
+    const [attributeType, setAttributeType] = useState("string");
+    const [error, setError] = useState(null);
     const attributeForm = useRef(null);
 
     function handleSubmit(ev) {
         if (ev) ev.preventDefault();
         if (!attributeForm.current.reportValidity()) return;
-        onAdd(attributeKey, attributeValue);
+        let value = attributeValue;
+        if (attributeType === "object") {
+            try {
+                value = JSON.parse(attributeValue);
+            } catch (e) {
+                setError(e.toString());
+                return;
+            }
+        }
+        onAdd(attributeKey, value);
     }
 
     function handleKeyChange(ev) {
         setAttributeKey(ev.target.value);
+        setError(null);
     }
 
     function handleValueChange(ev) {
         setAttributeValue(ev.target.value);
+        setError(null);
+    }
+
+    function handleTypeChange(ev) {
+        setAttributeType(ev.target.value);
+        setError(null);
     }
 
     async function updateAttributeDefinitions() {
@@ -35,10 +60,9 @@ export default function AttributesAddModal({ isOpen, onAdd, onRequestClose }) {
                 }),
                 {}
             );
-            console.log(keyDefinitions);
             setAttributeDefinitions(keyDefinitions);
         } catch (error) {
-            console.log(error);
+            setError(error.toString());
         }
     }
 
@@ -57,6 +81,16 @@ export default function AttributesAddModal({ isOpen, onAdd, onRequestClose }) {
             onRequestClose={onRequestClose}
             onConfirm={handleSubmit}
         >
+            {error ? (
+                <div
+                    className="alert alert-danger"
+                    style={{ "max-width": "300px" }}
+                >
+                    {error}
+                </div>
+            ) : (
+                []
+            )}
             {!Object.keys(attributeDefinitions).length ? (
                 <div>
                     Sorry, there are no attributes you can set at this moment.
@@ -95,14 +129,65 @@ export default function AttributesAddModal({ isOpen, onAdd, onRequestClose }) {
                         )}
                     </div>
                     <div className="form-group">
+                        <div className="form-check form-check-inline">
+                            <input
+                                className="form-check-input"
+                                type="radio"
+                                id="value-string"
+                                name="value-type"
+                                checked={attributeType === "string"}
+                                value="string"
+                                onClick={handleTypeChange}
+                            />
+                            <label
+                                className="form-check-label"
+                                htmlFor="value-string"
+                            >
+                                String
+                            </label>
+                        </div>
+                        <div className="form-check form-check-inline">
+                            <input
+                                className="form-check-input"
+                                type="radio"
+                                id="value-object"
+                                name="value-type"
+                                checked={attributeType === "object"}
+                                value="object"
+                                onClick={handleTypeChange}
+                            />
+                            <label
+                                className="form-check-label"
+                                htmlFor="value-object"
+                            >
+                                Object
+                            </label>
+                        </div>
+                    </div>
+                    <div className="form-group">
                         <label>Value</label>
-                        <input
-                            type="text"
-                            className="form-control"
-                            onChange={handleValueChange}
-                            value={attributeValue}
-                            required
-                        />
+                        {attributeType === "string" ? (
+                            <input
+                                type="text"
+                                className="form-control"
+                                onChange={handleValueChange}
+                                value={attributeValue}
+                                required
+                            />
+                        ) : (
+                            <AceEditor
+                                mode="json"
+                                theme="github"
+                                wrapEnabled
+                                onChange={(input) => setAttributeValue(input)}
+                                value={attributeValue}
+                                width="300px"
+                                height="150px"
+                                setOptions={{
+                                    useWorker: false,
+                                }}
+                            />
+                        )}
                     </div>
                 </form>
             )}

--- a/mwdb/web/src/components/Upload.js
+++ b/mwdb/web/src/components/Upload.js
@@ -285,7 +285,21 @@ class Upload extends Component {
                                     {this.state.attributes.map((attr, idx) => (
                                         <tr key={idx} className="centered">
                                             <th>{attr.key}</th>
-                                            <td>{attr.value}</td>
+                                            <td>
+                                                {typeof attr.value ===
+                                                "string" ? (
+                                                    attr.value
+                                                ) : (
+                                                    <pre className="attribute-object">
+                                                        {"(object)"}{" "}
+                                                        {JSON.stringify(
+                                                            attr.value,
+                                                            null,
+                                                            4
+                                                        )}
+                                                    </pre>
+                                                )}
+                                            </td>
                                             <td>
                                                 <input
                                                     value="Dismiss"

--- a/mwdb/web/src/styles/index.css
+++ b/mwdb/web/src/styles/index.css
@@ -163,6 +163,11 @@ div.quick-query-bar {
     border-left-color: var(--info);
 }
 
+pre.attribute-object {
+    margin-bottom: 0;
+    display: inline-block;
+}
+
 /***
 	Material Design Switches for Bootstrap 4 and Material Design Bootstrap (MDB)
 	by djibe


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- JSON attributes can't be added directly from Web
- Rendering of JSON attributes should be improved a bit

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- Added option to add JSON attributes from Web
- Improved button rendering for JSON attribute options

<img width="436" alt="image" src="https://user-images.githubusercontent.com/8720367/145041658-40c51f2d-b462-49c1-877a-ada6fe1c35d7.png">
<img width="347" alt="image" src="https://user-images.githubusercontent.com/8720367/145041720-e1331182-ac8a-4be9-a6de-84bedbb003a5.png">

