### PR TITLE
CI: Push Docker images for master branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,6 +114,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           file: ./tests/backend/Dockerfile
+          context: tests/backend
           tags: |
             certpl/mwdb-tests:${{ github.sha }}
           push: false
@@ -140,6 +141,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           file: ./tests/frontend/Dockerfile
+          context: tests/frontend
           tags: |
             certpl/mwdb-web-tests:${{ github.sha }}
           push: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,9 +56,10 @@ jobs:
           tags: |
             certpl/mwdb:${{ github.sha }}
             certpl/mwdb:master
+          outputs: type=docker,dest=./docker-images
           push: ${{ github.event_name == 'push' }}
-      - name: Store mwdb-core image
-        run: docker save -o ./mwdb-image certpl/mwdb:${{ github.sha }}
+      - name: ls
+        run: ls ./docker-images/
       - name: Upload mwdb-core image
         uses: actions/upload-artifact@v2 
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,20 +36,27 @@ jobs:
     needs: [lint_core]
     name: Build mwdb-core core image
     runs-on: ubuntu-latest
-    env:
-      DOCKER_BUILDKIT: 1
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
-      - name: Build and push mwdb-core image
-        uses: docker/build-push-action@v1.1.0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        if: ${{ github.event_name == 'push' }}
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          dockerfile: ./deploy/docker/Dockerfile
-          repository: certpl/mwdb
-          tags: ${{ github.sha }}
-          push: ${{ github.event == 'push' }}
+      - name: Build and push mwdb-core image
+        uses: docker/build-push-action@v2
+        with:
+          file: ./deploy/docker/Dockerfile
+          tags: |
+            certpl/mwdb:${{ github.sha }}
+            certpl/mwdb:master
+          push: ${{ github.event_name == 'push' }}
       - name: Store mwdb-core image
         run: docker save -o ./mwdb-image certpl/mwdb:${{ github.sha }}
       - name: Upload mwdb-core image
@@ -66,15 +73,24 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
-      - name: Build and push mwdb-core web image
-        uses: docker/build-push-action@v1.1.0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        if: ${{ github.event_name == 'push' }}
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          dockerfile: ./deploy/docker/Dockerfile-web
-          repository: certpl/mwdb-web
-          tags: ${{ github.sha }}
-          push: ${{ github.event == 'push' }} 
+      - name: Build and push mwdb-core image
+        uses: docker/build-push-action@v2
+        with:
+          file: ./deploy/docker/Dockerfile-web
+          tags: |
+            certpl/mwdb-web:${{ github.sha }}
+            certpl/mwdb-web:master
+          push: ${{ github.event_name == 'push' }}
       - name: Store mwdb-core web image
         run: docker save -o ./mwdb-web-image certpl/mwdb-web:${{ github.sha }}
       - name: Upload mwdb-core web image
@@ -90,17 +106,18 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
-      - name: Build and push test image
-        uses: docker/build-push-action@v1.1.0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Build and push mwdb-core image
+        uses: docker/build-push-action@v2
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          dockerfile: ./tests/backend/Dockerfile
-          repository: certpl/mwdb-tests
-          path: tests/backend
-          tags: ${{ github.sha }}
-          push: ${{ github.event == 'push' }} 
-      - name: Store test image 
+          file: ./tests/backend/Dockerfile
+          tags: |
+            certpl/mwdb-tests:${{ github.sha }}
+          push: false
+      - name: Store test image
         run: docker save -o ./mwdb-tests-image certpl/mwdb-tests:${{ github.sha }}
       - name: Upload test image
         uses: actions/upload-artifact@v2 
@@ -115,16 +132,17 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
-      - name: Build and push test image
-        uses: docker/build-push-action@v1.1.0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Build and push mwdb-core image
+        uses: docker/build-push-action@v2
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          dockerfile: ./tests/frontend/Dockerfile
-          repository: certpl/mwdb-web-tests
-          path: tests/frontend
-          tags: ${{ github.sha }}
-          push: ${{ github.event == 'push' }}
+          file: ./tests/frontend/Dockerfile
+          tags: |
+            certpl/mwdb-web-tests:${{ github.sha }}
+          push: false
       - name: Store test image
         run: docker save -o ./mwdb-web-tests-image certpl/mwdb-web-tests:${{ github.sha }}
       - name: Upload test image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,10 +56,8 @@ jobs:
           tags: |
             certpl/mwdb:${{ github.sha }}
             certpl/mwdb:master
-          outputs: type=docker,dest=./docker-images
+          outputs: type=docker,dest=./mwdb-image
           push: ${{ github.event_name == 'push' }}
-      - name: ls
-        run: ls ./docker-images/
       - name: Upload mwdb-core image
         uses: actions/upload-artifact@v2 
         with:
@@ -91,9 +89,8 @@ jobs:
           tags: |
             certpl/mwdb-web:${{ github.sha }}
             certpl/mwdb-web:master
+          outputs: type=docker,dest=./mwdb-web-image
           push: ${{ github.event_name == 'push' }}
-      - name: Store mwdb-core web image
-        run: docker save -o ./mwdb-web-image certpl/mwdb-web:${{ github.sha }}
       - name: Upload mwdb-core web image
         uses: actions/upload-artifact@v2 
         with:
@@ -118,9 +115,8 @@ jobs:
           context: tests/backend
           tags: |
             certpl/mwdb-tests:${{ github.sha }}
+          outputs: type=docker,dest=./mwdb-tests-image
           push: false
-      - name: Store test image
-        run: docker save -o ./mwdb-tests-image certpl/mwdb-tests:${{ github.sha }}
       - name: Upload test image
         uses: actions/upload-artifact@v2 
         with:
@@ -145,9 +141,8 @@ jobs:
           context: tests/frontend
           tags: |
             certpl/mwdb-web-tests:${{ github.sha }}
+          outputs: type=docker,dest=./mwdb-web-tests-image
           push: false
-      - name: Store test image
-        run: docker save -o ./mwdb-web-tests-image certpl/mwdb-web-tests:${{ github.sha }}
       - name: Upload test image
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- Well... Docker images are not pushed at all (due to `event` => `event_name` typo)

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- Tried to adapt workflow to similar version as in https://github.com/CERT-Polska/karton-classifier/blob/master/.github/workflows/publish.yml

**Test plan**
<!-- Explain how to test your changes -->
- Check if CI correctly builds images and pushes them when branch is merged with master
<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->
