### PR TITLE
CI: Introduce layer caching with GH Actions Cache and registry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,8 +50,10 @@ jobs:
           tags: |
             certpl/mwdb:${{ github.sha }}
             certpl/mwdb:master
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: |
+            type=registry,ref=certpl/mwdb:master
+            type=gha,scope=mwdb
+          cache-to: type=gha,scope=mwdb,mode=max
           outputs: type=docker,dest=./mwdb-image
       - name: Upload mwdb-core image
         uses: actions/upload-artifact@v2 
@@ -78,8 +80,10 @@ jobs:
           tags: |
             certpl/mwdb-web:${{ github.sha }}
             certpl/mwdb-web:master
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: |
+            type=registry,ref=certpl/mwdb-web:master
+            type=gha,scope=mwdb-web
+          cache-to: type=gha,scope=mwdb-web,mode=max
           outputs: type=docker,dest=./mwdb-web-image
       - name: Upload mwdb-core web image
         uses: actions/upload-artifact@v2 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
     name: Build mwdb-core core image
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository
+      - name: Check out repository for ${{github.ref_name}}
         uses: actions/checkout@v2
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -52,8 +52,8 @@ jobs:
             certpl/mwdb:master
           cache-from: |
             type=registry,ref=certpl/mwdb:master
-            type=gha,scope=mwdb
-          cache-to: type=gha,scope=mwdb,mode=max
+            type=gha,scope=${{github.ref_name}}-mwdb
+          cache-to: type=gha,scope=${{github.ref_name}}-mwdb,mode=max
           outputs: type=docker,dest=./mwdb-image
       - name: Upload mwdb-core image
         uses: actions/upload-artifact@v2 
@@ -82,8 +82,8 @@ jobs:
             certpl/mwdb-web:master
           cache-from: |
             type=registry,ref=certpl/mwdb-web:master
-            type=gha,scope=mwdb-web
-          cache-to: type=gha,scope=mwdb-web,mode=max
+            type=gha,scope=${{github.ref_name}}-mwdb-web
+          cache-to: type=gha,scope=${{github.ref_name}}-mwdb-web,mode=max
           outputs: type=docker,dest=./mwdb-web-image
       - name: Upload mwdb-core web image
         uses: actions/upload-artifact@v2 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,9 +50,7 @@ jobs:
           tags: |
             certpl/mwdb:${{ github.sha }}
             certpl/mwdb:master
-          cache-from: |
-            type=registry,ref=certpl/mwdb:master
-            type=gha
+          cache-from: type=gha
           cache-to: type=gha,mode=max
           outputs: type=docker,dest=./mwdb-image
       - name: Upload mwdb-core image
@@ -80,9 +78,7 @@ jobs:
           tags: |
             certpl/mwdb-web:${{ github.sha }}
             certpl/mwdb-web:master
-          cache-from: |
-            type=registry,ref=certpl/mwdb-web:master
-            type=gha
+          cache-from: type=gha
           cache-to: type=gha,mode=max
           outputs: type=docker,dest=./mwdb-web-image
       - name: Upload mwdb-core web image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,10 @@ jobs:
           tags: |
             certpl/mwdb:${{ github.sha }}
             certpl/mwdb:master
+          cache-from: |
+            type=registry,ref=certpl/mwdb:master
+            type=gha
+          cache-to: type=gha,mode=max
           outputs: type=docker,dest=./mwdb-image
       - name: Upload mwdb-core image
         uses: actions/upload-artifact@v2 
@@ -76,6 +80,10 @@ jobs:
           tags: |
             certpl/mwdb-web:${{ github.sha }}
             certpl/mwdb-web:master
+          cache-from: |
+            type=registry,ref=certpl/mwdb-web:master
+            type=gha
+          cache-to: type=gha,mode=max
           outputs: type=docker,dest=./mwdb-web-image
       - name: Upload mwdb-core web image
         uses: actions/upload-artifact@v2 
@@ -221,7 +229,5 @@ jobs:
           docker load --input ./mwdb-web-image/mwdb-web-image
           docker tag certpl/mwdb:$GITHUB_SHA certpl/mwdb:master
           docker tag certpl/mwdb-web:$GITHUB_SHA certpl/mwdb-web:master
-          docker push certpl/mwdb:$GITHUB_SHA
-          docker push certpl/mwdb-web:$GITHUB_SHA
-          docker push certpl/mwdb:master
-          docker push certpl/mwdb-web:master
+          docker push --all-tags certpl/mwdb
+          docker push --all-tags certpl/mwdb-web

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
     name: Build mwdb-core core image
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository for ${{github.ref_name}}
+      - name: Check out repository
         uses: actions/checkout@v2
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -109,6 +109,10 @@ jobs:
           context: tests/backend
           tags: |
             certpl/mwdb-tests:${{ github.sha }}
+          cache-from: |
+            type=registry,ref=certpl/mwdb-tests:master
+            type=gha,scope=${{github.ref_name}}-mwdb-tests
+          cache-to: type=gha,scope=${{github.ref_name}}-mwdb-tests,mode=max
           outputs: type=docker,dest=./mwdb-tests-image
       - name: Upload test image
         uses: actions/upload-artifact@v2 
@@ -134,6 +138,10 @@ jobs:
           context: tests/frontend
           tags: |
             certpl/mwdb-web-tests:${{ github.sha }}
+          cache-from: |
+            type=registry,ref=certpl/mwdb-web-tests:master
+            type=gha,scope=${{github.ref_name}}-mwdb-web-tests
+          cache-to: type=gha,scope=${{github.ref_name}}-mwdb-web-tests,mode=max
           outputs: type=docker,dest=./mwdb-web-tests-image
       - name: Upload test image
         uses: actions/upload-artifact@v2
@@ -227,7 +235,13 @@ jobs:
         run: |
           docker load --input ./mwdb-image/mwdb-image
           docker load --input ./mwdb-web-image/mwdb-web-image
+          docker load --input ./mwdb-tests-image/mwdb-tests-image
+          docker load --input ./mwdb-web-tests-image/mwdb-web-tests-image
           docker tag certpl/mwdb:$GITHUB_SHA certpl/mwdb:master
           docker tag certpl/mwdb-web:$GITHUB_SHA certpl/mwdb-web:master
+          docker tag certpl/mwdb-tests:$GITHUB_SHA certpl/mwdb-tests:master
+          docker tag certpl/mwdb-web-tests:$GITHUB_SHA certpl/mwdb-web-tests:master
           docker push --all-tags certpl/mwdb
           docker push --all-tags certpl/mwdb-web
+          docker push --all-tags certpl/mwdb-tests
+          docker push --all-tags certpl/mwdb-web-tests


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- Current CI workflow doesn't use any caching

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- CI workflow tries to use `master` image from registry and GHA cache to speed up image build time
- Added correct `push --all-tags`
