### PR TITLE
Fix/comment removing

### DIFF
--- a/mwdb/web/src/commons/helpers/index.js
+++ b/mwdb/web/src/commons/helpers/index.js
@@ -3,6 +3,7 @@ import _ from "lodash";
 export { default as downloadData } from "./download";
 export * from "./search";
 export * from "./filesize";
+export * from "./paginate";
 
 export const capitalize = (s) => {
     if (typeof s !== "string") return "";

--- a/mwdb/web/src/commons/helpers/paginate.js
+++ b/mwdb/web/src/commons/helpers/paginate.js
@@ -1,0 +1,10 @@
+export function updateActivePage(
+    activePage,
+    itemsCount,
+    itemsCountPerPage,
+    changeActivePage
+) {
+    // if removed item is last on page
+    if (activePage !== 1 && (itemsCount - 1) % itemsCountPerPage === 0)
+        changeActivePage((p) => p - 1);
+}

--- a/mwdb/web/src/components/ShowObject/Views/CommentBox.js
+++ b/mwdb/web/src/components/ShowObject/Views/CommentBox.js
@@ -177,6 +177,13 @@ function CommentBox() {
                 onRequestClose={() => setDeleteModalOpen(false)}
                 onConfirm={() => {
                     removeComment(commentToRemove);
+                    // if last comment on page is removed
+                    if (
+                        activePage !== 1 &&
+                        (comments.length - 1) % itemsCountPerPage === 0
+                    ) {
+                        setActivePage((p) => p - 1);
+                    }
                 }}
                 message="Remove the comment?"
                 confirmText="Remove"

--- a/mwdb/web/src/components/ShowObject/Views/CommentBox.js
+++ b/mwdb/web/src/components/ShowObject/Views/CommentBox.js
@@ -8,6 +8,7 @@ import { APIContext } from "@mwdb-web/commons/api/context";
 import { AuthContext, Capability } from "@mwdb-web/commons/auth";
 import { ObjectContext } from "@mwdb-web/commons/context";
 import { Identicon, ConfirmationModal } from "@mwdb-web/commons/ui";
+import { updateActivePage } from "@mwdb-web/commons/helpers";
 
 function Comment(props) {
     return (
@@ -160,17 +161,6 @@ function CommentBox() {
         setCommentToRemove(comment_id);
     }
 
-    function updateActivePage(
-        activePage,
-        comments,
-        itemsCountPerPage,
-        setActivePage
-    ) {
-        // if removed item is last on page
-        if (activePage !== 1 && (comments.length - 1) % itemsCountPerPage === 0)
-            setActivePage((p) => p - 1);
-    }
-
     const getComments = useCallback(updateComments, [
         api,
         objectId,
@@ -190,7 +180,7 @@ function CommentBox() {
                     removeComment(commentToRemove);
                     updateActivePage(
                         activePage,
-                        comments,
+                        comments.length,
                         itemsCountPerPage,
                         setActivePage
                     );

--- a/mwdb/web/src/components/ShowObject/Views/CommentBox.js
+++ b/mwdb/web/src/components/ShowObject/Views/CommentBox.js
@@ -160,6 +160,17 @@ function CommentBox() {
         setCommentToRemove(comment_id);
     }
 
+    function updateActivePage(
+        activePage,
+        comments,
+        itemsCountPerPage,
+        setActivePage
+    ) {
+        // if removed item is last on page
+        if (activePage !== 1 && (comments.length - 1) % itemsCountPerPage === 0)
+            setActivePage((p) => p - 1);
+    }
+
     const getComments = useCallback(updateComments, [
         api,
         objectId,
@@ -177,13 +188,12 @@ function CommentBox() {
                 onRequestClose={() => setDeleteModalOpen(false)}
                 onConfirm={() => {
                     removeComment(commentToRemove);
-                    // if last comment on page is removed
-                    if (
-                        activePage !== 1 &&
-                        (comments.length - 1) % itemsCountPerPage === 0
-                    ) {
-                        setActivePage((p) => p - 1);
-                    }
+                    updateActivePage(
+                        activePage,
+                        comments,
+                        itemsCountPerPage,
+                        setActivePage
+                    );
                 }}
                 message="Remove the comment?"
                 confirmText="Remove"


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
When last comment on page is removed, page isn't changed on previous. It is especially critical when last element is on page 2, because after comment removing we are not able to change active page because paginator is not visible.

**What is the new behaviour?**
After removing last comment on page, active page is changed on previous.

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #502
