### PR TITLE
Feature/lazy parents children display

### DIFF
--- a/mwdb/model/object.py
+++ b/mwdb/model/object.py
@@ -622,6 +622,7 @@ class Object(db.Model):
         # In that case we want only those parents to which requestor has access.
         stmtp = (
             db.session.query(Object)
+            .join(relation, relation.c.parent_id == Object.id)
             .filter(
                 Object.id.in_(
                     db.session.query(relation.c.parent_id).filter(
@@ -629,6 +630,7 @@ class Object(db.Model):
                     )
                 )
             )
+            .order_by(relation.c.creation_time.desc())
             .filter(requestor.has_access_to_object(Object.id))
         )
         stmtp = stmtp.subquery()

--- a/mwdb/resources/relations.py
+++ b/mwdb/resources/relations.py
@@ -1,5 +1,5 @@
 from flask_restful import Resource
-from werkzeug.exceptions import Conflict, NotFound
+from werkzeug.exceptions import NotFound
 
 from mwdb.core.capabilities import Capabilities
 from mwdb.model import Object, db
@@ -99,8 +99,6 @@ class ObjectChildResource(Resource):
                 description: |
                     When one of objects doesn't exist or user
                     doesn't have access to object.
-            409:
-                description: Relation already exists.
             503:
                 description: |
                     Request canceled due to database statement timeout.
@@ -113,9 +111,7 @@ class ObjectChildResource(Resource):
         if child_object is None:
             raise NotFound("Child object not found")
 
-        result = child_object.add_parent(parent_object, commit=False)
-        if not result:
-            raise Conflict("Relation alredy exists")
+        child_object.add_parent(parent_object, commit=False)
 
         db.session.commit()
         logger.info(

--- a/mwdb/resources/relations.py
+++ b/mwdb/resources/relations.py
@@ -163,7 +163,7 @@ class ObjectChildResource(Resource):
                 description: When user doesn't have `removing_parents` capability.
             404:
                 description: |
-                    When one of objects doesn't exist or user
+                    When relation or one of objects doesn't exist or user
                     doesn't have access to object.
             409:
                 description: Relation does not exist.
@@ -181,7 +181,7 @@ class ObjectChildResource(Resource):
 
         result = child_object.remove_parent(parent_object)
         if not result:
-            raise Conflict("Relation does not exist")
+            raise NotFound("Relation not found")
 
         logger.info(
             "Child removed",

--- a/mwdb/resources/relations.py
+++ b/mwdb/resources/relations.py
@@ -159,10 +159,8 @@ class ObjectChildResource(Resource):
                 description: When user doesn't have `removing_parents` capability.
             404:
                 description: |
-                    When relation or one of objects doesn't exist or user
+                    When one of objects doesn't exist or user
                     doesn't have access to object.
-            409:
-                description: Relation does not exist.
             503:
                 description: |
                     Request canceled due to database statement timeout.
@@ -177,7 +175,8 @@ class ObjectChildResource(Resource):
 
         result = child_object.remove_parent(parent_object)
         if not result:
-            raise NotFound("Relation not found")
+            # Relation already removed
+            return
 
         logger.info(
             "Child removed",

--- a/mwdb/web/src/commons/helpers/index.js
+++ b/mwdb/web/src/commons/helpers/index.js
@@ -3,6 +3,7 @@ import _ from "lodash";
 export { default as downloadData } from "./download";
 export * from "./search";
 export * from "./filesize";
+export * from "./paginate";
 
 export const capitalize = (s) => {
     if (typeof s !== "string") return "";

--- a/mwdb/web/src/commons/helpers/paginate.js
+++ b/mwdb/web/src/commons/helpers/paginate.js
@@ -1,0 +1,10 @@
+export function updateActivePage(
+    activePage,
+    itemsCount,
+    itemsCountPerPage,
+    changeActivePage
+) {
+    // if removed item is last on page
+    if (activePage !== 1 && (itemsCount - 1) % itemsCountPerPage === 0)
+        changeActivePage((p) => p - 1);
+}

--- a/mwdb/web/src/components/ShowObject/Views/RelationsBox.js
+++ b/mwdb/web/src/components/ShowObject/Views/RelationsBox.js
@@ -58,7 +58,7 @@ function RelationsBox(props) {
     const [disabledModalButton, setDisabledModalButton] = useState(false);
     const [relationToRemove, setRelationToRemove] = useState({});
     const [modalError, setModalError] = useState("");
-    let updateRelationsActivePage = props.updateRelationsActivePage;
+    const updateRelationsActivePage = props.updateRelationsActivePage;
 
     async function addObjectRelations(relation, value) {
         try {

--- a/mwdb/web/src/components/ShowObject/Views/RelationsBox.js
+++ b/mwdb/web/src/components/ShowObject/Views/RelationsBox.js
@@ -280,7 +280,7 @@ function TypedRelationsBox(props) {
         return (
             <div>
                 <RelationsBox
-                    header={props.header}
+                    header={`${props.header}: ${typedRelationsCount}`}
                     updateRelationsActivePage={() =>
                         updateActivePage(
                             activePage,

--- a/mwdb/web/src/components/ShowObject/Views/RelationsBox.js
+++ b/mwdb/web/src/components/ShowObject/Views/RelationsBox.js
@@ -1,5 +1,6 @@
 import React, { useState, useContext } from "react";
 import { Link } from "react-router-dom";
+import Pagination from "react-js-pagination";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 import { APIContext } from "@mwdb-web/commons/api/context";
@@ -14,6 +15,36 @@ import {
 } from "@mwdb-web/commons/ui";
 import { useRemotePath } from "@mwdb-web/commons/remotes";
 import RelationsAddModal from "../Actions/RelationsAddModal";
+
+function paginateParentChildren(
+    parents,
+    children,
+    activePage,
+    itemsCountPerPage
+) {
+    const elementFrom = (activePage - 1) * itemsCountPerPage;
+    const elementTo = activePage * itemsCountPerPage;
+    const parentsFrom = elementFrom;
+    const parentsTo = elementTo;
+    let childrenFrom;
+    let childrenTo;
+
+    if (parents.length < elementTo) {
+        childrenFrom = elementFrom - parents.length;
+        if (childrenFrom < 0) {
+            childrenFrom = 0;
+        }
+        childrenTo = elementTo - parents.length;
+    } else {
+        childrenFrom = 0;
+        childrenTo = 0;
+    }
+
+    const selectedParents = parents.slice(parentsFrom, parentsTo);
+    const selectedChildren = children.slice(childrenFrom, childrenTo);
+
+    return [selectedParents, selectedChildren];
+}
 
 function RelationsBox(props) {
     const api = useContext(APIContext);
@@ -225,11 +256,43 @@ function RelationsBox(props) {
 }
 
 function TypedRelationsBox(props) {
-    const parents = props.parents.filter((e) => e.type === props.type);
-    const children = props.children.filter((e) => e.type === props.type);
-    if (parents.length + children.length > 0)
+    const parentsFiltered = props.parents.filter((e) => e.type === props.type);
+    const childrenFiltered = props.children.filter(
+        (e) => e.type === props.type
+    );
+
+    const itemsCountPerPage = props.itemsCountPerPage;
+    const [activePage, setActivePage] = useState(1);
+
+    let [parents, children] = paginateParentChildren(
+        parentsFiltered,
+        childrenFiltered,
+        activePage,
+        itemsCountPerPage
+    );
+
+    if (parentsFiltered.length + childrenFiltered.length > 0)
         return (
-            <RelationsBox header={props.header} {...{ parents, children }} />
+            <div>
+                <RelationsBox
+                    header={props.header}
+                    {...{ parents, children }}
+                />
+                {parentsFiltered.length + childrenFiltered.length >
+                    itemsCountPerPage && (
+                    <Pagination
+                        activePage={activePage}
+                        itemsCountPerPage={itemsCountPerPage}
+                        totalItemsCount={
+                            parentsFiltered.length + childrenFiltered.length
+                        }
+                        pageRangeDisplayed={5}
+                        onChange={setActivePage}
+                        itemClass="page-item"
+                        linkClass="page-link"
+                    />
+                )}
+            </div>
         );
     else return <div />;
 }
@@ -238,21 +301,26 @@ export default function MultiRelationsBox() {
     const context = useContext(ObjectContext);
     let parents = context.object.parents;
     let children = context.object.children;
+    const itemsCountPerPage = 5;
+
     return parents && children && parents.length + children.length > 0 ? (
         <div>
             <TypedRelationsBox
                 header="Related samples"
                 type="file"
+                itemsCountPerPage={itemsCountPerPage}
                 {...{ parents, children }}
             />
             <TypedRelationsBox
                 header="Related configs"
                 type="static_config"
+                itemsCountPerPage={itemsCountPerPage}
                 {...{ parents, children }}
             />
             <TypedRelationsBox
                 header="Related blobs"
                 type="text_blob"
+                itemsCountPerPage={itemsCountPerPage}
                 {...{ parents, children }}
             />
         </div>

--- a/mwdb/web/src/components/ShowObject/Views/RelationsBox.js
+++ b/mwdb/web/src/components/ShowObject/Views/RelationsBox.js
@@ -15,6 +15,7 @@ import {
 } from "@mwdb-web/commons/ui";
 import { useRemotePath } from "@mwdb-web/commons/remotes";
 import RelationsAddModal from "../Actions/RelationsAddModal";
+import { updateActivePage } from "@mwdb-web/commons/helpers";
 
 function paginateParentChildren(
     parents,
@@ -57,6 +58,7 @@ function RelationsBox(props) {
     const [disabledModalButton, setDisabledModalButton] = useState(false);
     const [relationToRemove, setRelationToRemove] = useState({});
     const [modalError, setModalError] = useState("");
+    let updateRelationsActivePage = props.updateRelationsActivePage;
 
     async function addObjectRelations(relation, value) {
         try {
@@ -240,12 +242,13 @@ function RelationsBox(props) {
                 isOpen={isAttributeDeleteModalOpen}
                 disabled={disabledModalButton}
                 onRequestClose={() => setAttributeDeleteModalOpen(false)}
-                onConfirm={() =>
+                onConfirm={() => {
                     removeObjectRelations(
                         relationToRemove.relation,
                         relationToRemove.id
-                    )
-                }
+                    );
+                    updateRelationsActivePage();
+                }}
                 message="Are you sure you want to delete this relation?"
                 buttonStyle="btn btn-danger"
                 confirmText="yes"
@@ -271,21 +274,28 @@ function TypedRelationsBox(props) {
         itemsCountPerPage
     );
 
-    if (parentsFiltered.length + childrenFiltered.length > 0)
+    let typedRelationsCount = parentsFiltered.length + childrenFiltered.length;
+
+    if (typedRelationsCount > 0)
         return (
             <div>
                 <RelationsBox
                     header={props.header}
+                    updateRelationsActivePage={() =>
+                        updateActivePage(
+                            activePage,
+                            typedRelationsCount,
+                            itemsCountPerPage,
+                            setActivePage
+                        )
+                    }
                     {...{ parents, children }}
                 />
-                {parentsFiltered.length + childrenFiltered.length >
-                    itemsCountPerPage && (
+                {typedRelationsCount > itemsCountPerPage && (
                     <Pagination
                         activePage={activePage}
                         itemsCountPerPage={itemsCountPerPage}
-                        totalItemsCount={
-                            parentsFiltered.length + childrenFiltered.length
-                        }
+                        totalItemsCount={typedRelationsCount}
                         pageRangeDisplayed={5}
                         onChange={setActivePage}
                         itemClass="page-item"

--- a/tests/backend/test_relations.py
+++ b/tests/backend/test_relations.py
@@ -481,20 +481,3 @@ def test_removing_not_existing_relation(admin_session):
     
     with ShouldRaise(status_code=404):
         test.remove_parent(sample_1['sha256'], sample_2['sha256'])
-
-
-def test_add_existing_relation(admin_session):
-    test = admin_session
-    
-    filename_1 = base62uuid()
-    file_content_1 = base62uuid()
-    sample_1 = test.add_sample(filename_1, file_content_1)
-    
-    filename_2 = base62uuid()
-    file_content_2 = base62uuid()
-    sample_2 = test.add_sample(filename_2, file_content_2)
-    
-    test.add_xref(sample_1['sha256'], sample_2['sha256'])
-    
-    with ShouldRaise(status_code=409):
-        test.add_xref(sample_1['sha256'], sample_2['sha256'])

--- a/tests/backend/test_relations.py
+++ b/tests/backend/test_relations.py
@@ -466,18 +466,3 @@ def test_removing_relations(admin_session):
         should_access=[Alice],
         should_not_access=[Bob],
     ).test()
-
-
-def test_removing_not_existing_relation(admin_session):
-    test = admin_session
-    
-    filename_1 = base62uuid()
-    file_content_1 = base62uuid()
-    sample_1 = test.add_sample(filename_1, file_content_1)
-    
-    filename_2 = base62uuid()
-    file_content_2 = base62uuid()
-    sample_2 = test.add_sample(filename_2, file_content_2)
-    
-    with ShouldRaise(status_code=404):
-        test.remove_parent(sample_1['sha256'], sample_2['sha256'])

--- a/tests/backend/test_relations.py
+++ b/tests/backend/test_relations.py
@@ -479,7 +479,7 @@ def test_removing_not_existing_relation(admin_session):
     file_content_2 = base62uuid()
     sample_2 = test.add_sample(filename_2, file_content_2)
     
-    with ShouldRaise(status_code=409):
+    with ShouldRaise(status_code=404):
         test.remove_parent(sample_1['sha256'], sample_2['sha256'])
 
 

--- a/tests/backend/test_relations.py
+++ b/tests/backend/test_relations.py
@@ -1,4 +1,5 @@
 from .relations import *
+from .utils import ShouldRaise, base62uuid
 
 
 def test_inheritance(admin_session):
@@ -465,3 +466,35 @@ def test_removing_relations(admin_session):
         should_access=[Alice],
         should_not_access=[Bob],
     ).test()
+
+
+def test_removing_not_existing_relation(admin_session):
+    test = admin_session
+    
+    filename_1 = base62uuid()
+    file_content_1 = base62uuid()
+    sample_1 = test.add_sample(filename_1, file_content_1)
+    
+    filename_2 = base62uuid()
+    file_content_2 = base62uuid()
+    sample_2 = test.add_sample(filename_2, file_content_2)
+    
+    with ShouldRaise(status_code=409):
+        test.remove_parent(sample_1['sha256'], sample_2['sha256'])
+
+
+def test_add_existing_relation(admin_session):
+    test = admin_session
+    
+    filename_1 = base62uuid()
+    file_content_1 = base62uuid()
+    sample_1 = test.add_sample(filename_1, file_content_1)
+    
+    filename_2 = base62uuid()
+    file_content_2 = base62uuid()
+    sample_2 = test.add_sample(filename_2, file_content_2)
+    
+    test.add_xref(sample_1['sha256'], sample_2['sha256'])
+    
+    with ShouldRaise(status_code=409):
+        test.add_xref(sample_1['sha256'], sample_2['sha256'])


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
All children and parents are showed on object detail view. When number of relatives is huge, it cause efficiency problems in UI.
Also for object, parents and children orders are different. Children are sorted relation creation_time descending, parents are sorted relation creation_time ascending.

**What is the new behaviour?**
In UI we have pagination for relations. Parents and children order is the same (relation creation_time descending).

**Test plan**
<!-- Explain how to test your changes -->

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #492 
