### PR TITLE
CI: Tagging Docker image with version tag on release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Build and push mwdb-core image
+      - name: Build and push mwdb-core web image
         uses: docker/build-push-action@v2
         with:
           file: ./deploy/docker/Dockerfile-web

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,11 @@
 name: Release new mwdb-core version
 
 on:
-  push:
-    tags: 'v*.*.*'
+  release:
+    types: [published]
 
 jobs:
-  release:
+  release_pypi:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -27,3 +27,36 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}
+  release_docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build and push mwdb-core image
+        uses: docker/build-push-action@v2
+        with:
+          file: ./deploy/docker/Dockerfile
+          tags: |
+            certpl/mwdb:${{ github.event.release.tag_name }}
+          cache-from: |
+            type=registry,ref=certpl/mwdb:master
+            type=gha,scope=${{github.ref_name}}-mwdb
+          push: true
+      - name: Build and push mwdb-core web image
+        uses: docker/build-push-action@v2
+        with:
+          file: ./deploy/docker/Dockerfile-web
+          tags: |
+            certpl/mwdb-web:${{ github.event.release.tag_name }}
+          cache-from: |
+            type=registry,ref=certpl/mwdb-web:master
+            type=gha,scope=${{github.ref_name}}-mwdb-web
+          push: true

--- a/dev/bump_version.json
+++ b/dev/bump_version.json
@@ -2,10 +2,11 @@
     "files": {
         "setup.py": "version=\"$VERSION\"",
         "mwdb/version.py": "app_version = \"$VERSION\"",
-        "mwdb/web/package.json": "\"version\": \"$VERSION\"",
-        "mwdb/web/package-lock.json": "\"version\": \"$VERSION\"",
+        "mwdb/web/package.json": "\"name\": \"mwdb-web\",\\s+\"version\": \"$VERSION\"",
+        "mwdb/web/package-lock.json": "\"name\": \"mwdb-web\",\\s+\"version\": \"$VERSION\"",
         "mwdb/web/src/commons/package.json": "\"version\": \"$VERSION\"",
-        "docs/conf.py": "release = '$VERSION'"
+        "docs/conf.py": "release = '$VERSION'",
+        "docker-compose.yml": "image: certpl/mwdb(?:-web)?\\:v$VERSION"
     },
     "regex": "(\\d+[.]\\d+[.]\\d+(?:-(post|dev|alpha|beta|rc)[0-9])?)"
 }

--- a/dev/bump_version.py
+++ b/dev/bump_version.py
@@ -40,13 +40,14 @@ def main(new_version):
 
         pattern = VERSION_FILES[path].replace("$VERSION", VERSION_REGEX)
         version = next(re.finditer(pattern, content)).group(1)
-        output_files[path] = re.sub(pattern, subst_version, content, count=1)
+        output_files[path] = re.sub(pattern, subst_version, content)
 
         if old_version is not None and version != old_version:
             print(
                 f"[!] {str(path)} contains different version than other files "
                 f"({version} != {old_version})"
             )
+            return
         old_version = version
 
     for path in VERSION_FILES.keys():

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     depends_on:
       - postgres
       - redis
-    image: certpl/mwdb
+    image: certpl/mwdb:v2.6.0
     restart: on-failure
     env_file:
       # NOTE: use gen_vars.sh in order to generate this file
@@ -22,7 +22,7 @@ services:
     build:
       context: .
       dockerfile: deploy/docker/Dockerfile-web
-    image: certpl/mwdb-web
+    image: certpl/mwdb-web:v2.6.0
     ports:
       - "80:80"
     restart: on-failure


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [ ] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- Docker images on Docker Hub are not tagged against the version

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- Added proper version tagging to release workflow (building with cache should be faster than pulling the images)
- Pinned image version in `docker-compose.yml`
- Improved `dev/bump_version.py` script

**Test plan**
<!-- Explain how to test your changes -->

- `dev` release will be generated to check if workflow works correctly before stable `2.6.0` release.

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #465 
