### PR TITLE
CI: Don't use GHA cache due to connection problems

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,6 @@ jobs:
           cache-from: |
             type=registry,ref=certpl/mwdb:master
             type=gha,scope=${{github.ref_name}}-mwdb
-          cache-to: type=gha,scope=${{github.ref_name}}-mwdb,mode=max
           outputs: type=docker,dest=./mwdb-image
       - name: Upload mwdb-core image
         uses: actions/upload-artifact@v2 
@@ -83,7 +82,6 @@ jobs:
           cache-from: |
             type=registry,ref=certpl/mwdb-web:master
             type=gha,scope=${{github.ref_name}}-mwdb-web
-          cache-to: type=gha,scope=${{github.ref_name}}-mwdb-web,mode=max
           outputs: type=docker,dest=./mwdb-web-image
       - name: Upload mwdb-core web image
         uses: actions/upload-artifact@v2 
@@ -112,7 +110,6 @@ jobs:
           cache-from: |
             type=registry,ref=certpl/mwdb-tests:master
             type=gha,scope=${{github.ref_name}}-mwdb-tests
-          cache-to: type=gha,scope=${{github.ref_name}}-mwdb-tests,mode=max
           outputs: type=docker,dest=./mwdb-tests-image
       - name: Upload test image
         uses: actions/upload-artifact@v2 
@@ -141,7 +138,6 @@ jobs:
           cache-from: |
             type=registry,ref=certpl/mwdb-web-tests:master
             type=gha,scope=${{github.ref_name}}-mwdb-web-tests
-          cache-to: type=gha,scope=${{github.ref_name}}-mwdb-web-tests,mode=max
           outputs: type=docker,dest=./mwdb-web-tests-image
       - name: Upload test image
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
We have problems with CI when docker/build-push-action tries to push cache artifacts to GHA cache
```
#17 exporting cache
#17 preparing build cache for export done
#17 writing layer sha256:2fcd866b2b28912fa0b8d82b36eab616af243785ee69bbc02ea865c5b103731a
#17 writing layer sha256:2fcd866b2b28912fa0b8d82b36eab616af243785ee69bbc02ea865c5b103731a 1.2s done
#17 ERROR: error writing layer blob: Patch "https://artifactcache.actions.githubusercontent.com/ZZykNmevxKcKtilmBliEZcTNHLY9TCICy4RK7vdM3fyFYHMRag/_apis/artifactcache/caches/730": http: read on closed response body
------
 > exporting cache:
------
error: failed to solve: error writing layer blob: Patch "https://artifactcache.actions.githubusercontent.com/ZZykNmevxKcKtilmBliEZcTNHLY9TCICy4RK7vdM3fyFYHMRag/_apis/artifactcache/caches/730": http: read on closed response body
Error: buildx failed with: error: failed to solve: error writing layer blob: Patch "https://artifactcache.actions.githubusercontent.com/ZZykNmevxKcKtilmBliEZcTNHLY9TCICy4RK7vdM3fyFYHMRag/_apis/artifactcache/caches/730": http: read on closed response body
```
(e.g. https://github.com/CERT-Polska/mwdb-core/actions/runs/1659097111)

I don't have idea what is the cause so let's just remove pushing to GHA cache until problem disappears. Caching isn't crucial for our development operations.