### PR TITLE
Fix: set response_time to None if not available

### DIFF
--- a/mwdb/app.py
+++ b/mwdb/app.py
@@ -134,7 +134,10 @@ def assign_request_id():
 
 @app.after_request
 def log_request(response):
-    response_time = datetime.utcnow() - g.request_start_time
+    if hasattr(g, "request_start_time"):
+        response_time = datetime.utcnow() - g.request_start_time
+    else:
+        response_time = None
     response_size = response.calculate_content_length()
 
     getLogger().info(


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- Sometimes exception happens before `@before_request` handlers has a chance to spawn and `log_request` fails because of missing `request_start_time`

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- Set `response_time` in log record extras to None if `g.request_start_time` is not available

**Test plan**
<!-- Explain how to test your changes -->
- Check if request handling still works (should be covered by automated tests)
