### PR TITLE
core: Drop logmatic from dependencies

### DIFF
--- a/mwdb/core/log.py
+++ b/mwdb/core/log.py
@@ -1,7 +1,7 @@
 import logging
 
-import logmatic
 from flask import g
+from pythonjsonlogger import jsonlogger
 
 from .config import app_config
 
@@ -44,9 +44,10 @@ def setup_logger():
     handler = logging.StreamHandler()
 
     if enable_json_logger:
-        formatter = logmatic.JsonFormatter(
+        formatter = jsonlogger.JsonFormatter(
             fmt="%(filename) %(funcName) %(levelname) "
-            "%(lineno) %(module) %(threadName) %(message)"
+            "%(lineno) %(module) %(threadName) %(message)",
+            timestamp=True,
         )
     else:
         formatter = InlineFormatter(

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ apispec[yaml,validation]==3.3.1
 bcrypt==3.1.4
 python-magic==0.4.18
 luqum==0.7.4
-logmatic-python==0.1.7
+python-json-logger==2.0.2
 click==7.1.2
 click-default-group==1.2.2
 PyYAML==5.4


### PR DESCRIPTION
Replace logmatic.JsonFormatter with direct usage of python-json-logger.
The only thing that logmatic package introduces are timestamps, enabled
by default. Call jsonlogger.JsonFormatter with timestamp=True to retain
this behavior.

<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

**Test plan**
<!-- Explain how to test your changes -->

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**
