### PR TITLE
web: Fix crash in AttributesAddModal

### DIFF
--- a/mwdb/web/src/commons/ui/ConfirmationModal.js
+++ b/mwdb/web/src/commons/ui/ConfirmationModal.js
@@ -54,7 +54,7 @@ export default function ConfirmationModal(props) {
                     className={`btn ${props.buttonStyle || "btn-danger"}`}
                     data-dismiss="modal"
                     onClick={props.onConfirm}
-                    disabled={props.disabled}
+                    disabled={props.disabled || !props.confirmEnabled}
                 >
                     {props.confirmText || "Yes"}
                 </button>

--- a/mwdb/web/src/components/AttributesAddModal.js
+++ b/mwdb/web/src/components/AttributesAddModal.js
@@ -67,6 +67,7 @@ export default function AttributesAddModal({ isOpen, onAdd, onRequestClose }) {
     }
 
     const getAttributeDefinitions = useCallback(updateAttributeDefinitions, []);
+    const attributesAvailable = Object.keys(attributeDefinitions).length != 0;
 
     useEffect(() => {
         getAttributeDefinitions();
@@ -80,6 +81,7 @@ export default function AttributesAddModal({ isOpen, onAdd, onRequestClose }) {
             isOpen={isOpen}
             onRequestClose={onRequestClose}
             onConfirm={handleSubmit}
+            confirmEnabled={attributesAvailable}
         >
             {error ? (
                 <div
@@ -91,7 +93,7 @@ export default function AttributesAddModal({ isOpen, onAdd, onRequestClose }) {
             ) : (
                 []
             )}
-            {!Object.keys(attributeDefinitions).length ? (
+            {!attributesAvailable ? (
                 <div>
                     Sorry, there are no attributes you can set at this moment.
                 </div>


### PR DESCRIPTION
If no attributes are available to be added and the user clicked "Add",
the application would crash.

Fix this by disabling the button when there are none available.

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
The application crashes

**What is the new behaviour?**
The application doesn't crash

**Test plan**
<!-- Explain how to test your changes -->

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**
