### PR TITLE
[v2.6.x] CI: Run workflows on backport branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
     - master
+    - v[23456789].*.*
   pull_request:
     branches:
     - master
+    - v[23456789].*.*
 jobs:
   lint_core:
     name: Lint mwdb-core core sources


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- Workflows doesn't run for v2.6.x branch

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- Add rule to run workflow on backport branches
