### PR TITLE
Feature/search time relative

### DIFF
--- a/docs/user-guide/7-Lucene-search.rst
+++ b/docs/user-guide/7-Lucene-search.rst
@@ -113,13 +113,13 @@ Query syntax: timestamps
 
 With timestamps you can search for objects within certain time range.
 
-If you want to find samples that were uploaded from the beginning of September till the 28th:
+If you want to find objects that were uploaded from the beginning of September till the 28th:
 
 .. code-block::
 
    upload_time:[2020-09-01 TO 2020-09-28]
 
-If you want to find samples that were uploaded from the beginning of September:
+If you want to find objects that were uploaded from the beginning of September:
 
 .. code-block::
 
@@ -131,19 +131,19 @@ Alternatively:
 
    upload_time:>=2020-09-01
 
-If you want to search for samples within time certain range:
+If you want to search for objects within time certain range:
 
 .. code-block::
 
    upload_time:["2020-09-28 08:00" TO "2020-09-28 09:00"]
 
-If you want to search for samples uploaded after certain hour:
+If you want to search for objects uploaded after certain hour:
 
 .. code-block::
 
    upload_time:">=2020-09-28 08:00"
 
-If you want to search for samples uploaded at certain minute:
+If you want to search for objects uploaded at certain minute:
 
 .. code-block::
 
@@ -156,6 +156,35 @@ Remember that exclusive range is not allowed for date-time field so this is not 
    upload_time:{2020-09-01 TO *]
 
    upload_time:>2020-09-01
+
+Query syntax: relative timestamps
+------------------------
+
+It is also possible to use upload_time in relation to current time.
+For example, if you want to search for objects uploaded during last 2 hours:
+
+.. code-block::
+
+   upload_time:2h
+
+
+This way of time definition contains value and relative time format.
+
+Below are listed acceptable relative time symbols:
+
+
+* **y** or **Y** : years
+* **m** : months
+* **w** or **W** : weeks
+* **d** or **D** : days
+* **h** or **H** : hours
+* **M** : minutes
+* **s** or **S** : seconds
+
+.. warning::
+
+   Bring awareness to symbols **m** and **M**. They means quite different period time. Other symbols can be used as uppercase or lowercase letters.
+
 
 Basic search fields
 -------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ prance==0.21.8.0  # apispec unpinned dependency
 regex==2021.7.6
 itsdangerous==2.0.1
 Flask-Limiter==2.1.3
+python-dateutil==2.8.2

--- a/tests/backend/test_search.py
+++ b/tests/backend/test_search.py
@@ -366,6 +366,44 @@ def test_search_date_time_unbounded(admin_session):
     with ShouldRaise(status_code=400):
         found_objs = test.search(f'upload_time:"<{now}" AND tag:{tag}')
 
+        
+def test_search_date_time_relative(admin_session):
+    filename_1 = base62uuid()
+    file_content_1 = b"abc" * 500 + rand_string(30).encode("utf-8")
+    sample_1 = admin_session.add_sample(filename_1, file_content_1)
+    time.sleep(1)
+    filename_2 = base62uuid()
+    file_content_2 = b"abc" * 500 + rand_string(30).encode("utf-8")
+    sample_2 = admin_session.add_sample(filename_2, file_content_2)
+    tag = rand_string(20)
+    admin_session.add_tag(sample_1["id"], tag)
+    admin_session.add_tag(sample_2["id"], tag)
+    time.sleep(1)
+    
+    found_objs = admin_session.search(f'upload_time:1s AND tag:{tag}')
+    assert len(found_objs) == 0
+    found_objs = admin_session.search(f'upload_time:2s AND tag:{tag}')
+    assert len(found_objs) == 1
+    found_objs = admin_session.search(f'upload_time:3s AND tag:{tag}')
+    assert len(found_objs) == 2
+    found_objs = admin_session.search(f'upload_time:1M AND tag:{tag}')
+    assert len(found_objs) == 2
+    found_objs = admin_session.search(f'upload_time:1h AND tag:{tag}')
+    assert len(found_objs) == 2
+    found_objs = admin_session.search(f'upload_time:1d AND tag:{tag}')
+    assert len(found_objs) == 2
+    found_objs = admin_session.search(f'upload_time:1w AND tag:{tag}')
+    assert len(found_objs) == 2
+    found_objs = admin_session.search(f'upload_time:1m AND tag:{tag}')
+    assert len(found_objs) == 2
+    found_objs = admin_session.search(f'upload_time:1y AND tag:{tag}')
+    assert len(found_objs) == 2
+
+    with ShouldRaise(status_code=400):
+        found_objs = admin_session.search(f'upload_time:s1 AND tag:{tag}')
+    with ShouldRaise(status_code=400):
+        found_objs = admin_session.search(f'upload_time:1x AND tag:{tag}')
+
 
 def test_search_no_access_to_parent(admin_session):
     filename = base62uuid()


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [x] I've added automated tests for my change (if applicable, optional)
- [x] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
There was not possibility to search object using upload_time field defining this value in relative way.
**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
Now, when we use search using upload_time field, we can use relative way of defining time (fe. upload_time: 2d3h - which means: give me object uploaded not later then 2 days and 3 hours ago) 

