### PR TITLE
Fix: removed default expiration for JWT

### DIFF
--- a/mwdb/core/auth.py
+++ b/mwdb/core/auth.py
@@ -14,11 +14,10 @@ class AuthScope(Enum):
     download_file = "download_file"
 
 
-def generate_token(fields, scope, expiration=24 * 3600):
+def generate_token(fields, scope, expiration=None):
     issued_at = datetime.datetime.now(tz=datetime.timezone.utc)
     token_claims = {
         **fields,
-        "exp": (issued_at + datetime.timedelta(seconds=expiration)),
         "iat": issued_at,
         "aud": app_config.mwdb.base_url,
         "scope": scope.value,
@@ -26,6 +25,8 @@ def generate_token(fields, scope, expiration=24 * 3600):
 
     if "login" in fields.keys():
         token_claims["sub"] = fields["login"]
+    if expiration is not None:
+        token_claims["exp"] = issued_at + datetime.timedelta(seconds=expiration)
     payload = {**fields, **token_claims}
     token = jwt.encode(payload, app_config.mwdb.secret_key, algorithm="HS512")
     return token


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [ ] I've read the [contributing guideline](CONTRIBUTING.md).
- [ ] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
API key expires because there is no possibility to make JWT without expiration time/

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
Set expiration default to None and make `exp` claim optional.
