### PR TITLE
CI: Remove GHA cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,6 @@ jobs:
             certpl/mwdb:master
           cache-from: |
             type=registry,ref=certpl/mwdb:master
-            type=gha,scope=${{github.ref_name}}-mwdb
           outputs: type=docker,dest=./mwdb-image
       - name: Upload mwdb-core image
         uses: actions/upload-artifact@v2 
@@ -83,7 +82,6 @@ jobs:
             certpl/mwdb-web:master
           cache-from: |
             type=registry,ref=certpl/mwdb-web:master
-            type=gha,scope=${{github.ref_name}}-mwdb-web
           outputs: type=docker,dest=./mwdb-web-image
       - name: Upload mwdb-core web image
         uses: actions/upload-artifact@v2 
@@ -111,7 +109,6 @@ jobs:
             certpl/mwdb-tests:${{ github.sha }}
           cache-from: |
             type=registry,ref=certpl/mwdb-tests:master
-            type=gha,scope=${{github.ref_name}}-mwdb-tests
           outputs: type=docker,dest=./mwdb-tests-image
       - name: Upload test image
         uses: actions/upload-artifact@v2 
@@ -139,7 +136,6 @@ jobs:
             certpl/mwdb-web-tests:${{ github.sha }}
           cache-from: |
             type=registry,ref=certpl/mwdb-web-tests:master
-            type=gha,scope=${{github.ref_name}}-mwdb-web-tests
           outputs: type=docker,dest=./mwdb-web-tests-image
       - name: Upload test image
         uses: actions/upload-artifact@v2
@@ -237,7 +233,6 @@ jobs:
             certpl/mwdb:master
           cache-from: |
             type=registry,ref=certpl/mwdb:master
-            type=gha,scope=${{github.ref_name}}-mwdb
           cache-to: |
             type=registry,ref=certpl/mwdb:master,mode=max
           push: true
@@ -249,7 +244,6 @@ jobs:
             certpl/mwdb-web:master
           cache-from: |
             type=registry,ref=certpl/mwdb-web:master
-            type=gha,scope=${{github.ref_name}}-mwdb-web
           cache-to: |
             type=registry,ref=certpl/mwdb-web:master,mode=max
           push: true
@@ -281,7 +275,6 @@ jobs:
             certpl/mwdb-tests:master
           cache-from: |
             type=registry,ref=certpl/mwdb-tests:master
-            type=gha,scope=${{github.ref_name}}-mwdb-tests
           cache-to: |
             type=registry,ref=certpl/mwdb-tests:master,mode=max
           push: true
@@ -294,7 +287,6 @@ jobs:
             certpl/mwdb-web-tests:master
           cache-from: |
             type=registry,ref=certpl/mwdb-web-tests:master
-            type=gha,scope=${{github.ref_name}}-mwdb-web-tests
           cache-to: |
             type=registry,ref=certpl/mwdb-web-tests:master,mode=max
           push: true


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**What is the current behaviour?**
<!-- Explain how the code works currently -->

Images on Docker Hub are still broken, possibly due to GHA cache

![image](https://user-images.githubusercontent.com/8720367/159702462-4eeedd6f-f1be-40cb-8952-e97403974bcc.png)

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

Removed usage of GHA cache from build workflow
