### PR TITLE
CI: Use buildcache tag for cache manifest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
             certpl/mwdb:${{ github.sha }}
             certpl/mwdb:master
           cache-from: |
-            type=registry,ref=certpl/mwdb:master
+            type=registry,ref=certpl/mwdb:buildcache
           outputs: type=docker,dest=./mwdb-image
       - name: Upload mwdb-core image
         uses: actions/upload-artifact@v2 
@@ -81,7 +81,7 @@ jobs:
             certpl/mwdb-web:${{ github.sha }}
             certpl/mwdb-web:master
           cache-from: |
-            type=registry,ref=certpl/mwdb-web:master
+            type=registry,ref=certpl/mwdb-web:buildcache
           outputs: type=docker,dest=./mwdb-web-image
       - name: Upload mwdb-core web image
         uses: actions/upload-artifact@v2 
@@ -108,7 +108,7 @@ jobs:
           tags: |
             certpl/mwdb-tests:${{ github.sha }}
           cache-from: |
-            type=registry,ref=certpl/mwdb-tests:master
+            type=registry,ref=certpl/mwdb-tests:buildcache
           outputs: type=docker,dest=./mwdb-tests-image
       - name: Upload test image
         uses: actions/upload-artifact@v2 
@@ -135,7 +135,7 @@ jobs:
           tags: |
             certpl/mwdb-web-tests:${{ github.sha }}
           cache-from: |
-            type=registry,ref=certpl/mwdb-web-tests:master
+            type=registry,ref=certpl/mwdb-web-tests:buildcache
           outputs: type=docker,dest=./mwdb-web-tests-image
       - name: Upload test image
         uses: actions/upload-artifact@v2
@@ -232,9 +232,9 @@ jobs:
           tags: |
             certpl/mwdb:master
           cache-from: |
-            type=registry,ref=certpl/mwdb:master
+            type=registry,ref=certpl/mwdb:buildcache
           cache-to: |
-            type=registry,ref=certpl/mwdb:master,mode=max
+            type=registry,ref=certpl/mwdb:buildcache,mode=max
           push: true
       - name: Build and push mwdb-core web image
         uses: docker/build-push-action@v2
@@ -243,9 +243,9 @@ jobs:
           tags: |
             certpl/mwdb-web:master
           cache-from: |
-            type=registry,ref=certpl/mwdb-web:master
+            type=registry,ref=certpl/mwdb-web:buildcache
           cache-to: |
-            type=registry,ref=certpl/mwdb-web:master,mode=max
+            type=registry,ref=certpl/mwdb-web:buildcache,mode=max
           push: true
   push_test_images:
     needs: [test_backend_e2e, test_frontend_e2e]
@@ -274,9 +274,9 @@ jobs:
           tags: |
             certpl/mwdb-tests:master
           cache-from: |
-            type=registry,ref=certpl/mwdb-tests:master
+            type=registry,ref=certpl/mwdb-tests:buildcache
           cache-to: |
-            type=registry,ref=certpl/mwdb-tests:master,mode=max
+            type=registry,ref=certpl/mwdb-tests:buildcache,mode=max
           push: true
       - name: Build and push mwdb-web-tests image
         uses: docker/build-push-action@v2
@@ -286,7 +286,7 @@ jobs:
           tags: |
             certpl/mwdb-web-tests:master
           cache-from: |
-            type=registry,ref=certpl/mwdb-web-tests:master
+            type=registry,ref=certpl/mwdb-web-tests:buildcache
           cache-to: |
-            type=registry,ref=certpl/mwdb-web-tests:master,mode=max
+            type=registry,ref=certpl/mwdb-web-tests:buildcache,mode=max
           push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
           file: ./deploy/docker/Dockerfile
           tags: |
             certpl/mwdb:${{ github.event.release.tag_name }}
+            certpl/mwdb:latest
           push: true
           context: .
       - name: Build and push mwdb-core web image
@@ -54,5 +55,6 @@ jobs:
           file: ./deploy/docker/Dockerfile-web
           tags: |
             certpl/mwdb-web:${{ github.event.release.tag_name }}
+            certpl/mwdb:latest
           push: true
           context: .


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
Our workflow produces empty images. After debugging I found that if `cache-to` uses the same tag as target image tag: target image is overwritten by cache manifest.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- Use `buildcache` tag for cache manifest pushed to Docker Hub
- Added `latest` tag for release workflow

