### PR TITLE
Fix: handle /api endpoint without trailing slash in mwdb-web Docker

### DIFF
--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -11,6 +11,11 @@ server {
         proxy_set_header  X-Forwarded-For $remote_addr;
     }
 
+    location = /api {
+        absolute_redirect off;
+        return 301 /api/;
+    }
+
     location / {
         try_files $uri /index.html =404;
     }


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
Nginx configuration used in mwdb-web doesn't handle correctly `/api` request without trailing slash

![image](https://user-images.githubusercontent.com/8720367/162212666-79bb4fde-d15f-471e-9d0c-980e96a8f4d3.png)

In that case, it redirects to absolute URL with server name that might be incorrect for end user.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

Added nginx rule to make a relative redirect in case of missing trailing slash

**Test plan**
<!-- Explain how to test your changes -->

Checked in Docker-Compose environment

```
$ curl http://127.0.0.1/api -vvv -L
*   Trying 127.0.0.1:80...
* Connected to 127.0.0.1 (127.0.0.1) port 80 (#0)
> GET /api HTTP/1.1
> Host: 127.0.0.1
> User-Agent: curl/7.74.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 301 Moved Permanently
< Server: nginx/1.20.2
< Date: Thu, 07 Apr 2022 13:38:51 GMT
< Content-Type: text/html
< Content-Length: 169
< Connection: keep-alive
< Location: /api/
< 
* Ignoring the response-body
* Connection #0 to host 127.0.0.1 left intact
* Issue another request to this URL: 'http://127.0.0.1/api/'
* Found bundle for host 127.0.0.1: 0x55d7ee16f1a0 [serially]
* Can not multiplex, even if we wanted to!
* Re-using existing connection! (#0) with host 127.0.0.1
* Connected to 127.0.0.1 (127.0.0.1) port 80 (#0)
> GET /api/ HTTP/1.1
> Host: 127.0.0.1
> User-Agent: curl/7.74.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 404 NOT FOUND
< Server: nginx/1.20.2
< Date: Thu, 07 Apr 2022 13:38:51 GMT
< Content-Type: application/json
< Content-Length: 136
< Connection: keep-alive
< 
{"message": "The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again."}
* Connection #0 to host 127.0.0.1 left intact
```

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->
