### PR TITLE
Remove decode method from legacy download_token

### DIFF
--- a/mwdb/resources/download.py
+++ b/mwdb/resources/download.py
@@ -93,7 +93,5 @@ class RequestSampleDownloadResource(Resource):
 
         download_token = file.generate_download_token()
         schema = DownloadURLResponseSchema()
-        url = api.relative_url_for(
-            DownloadResource, access_token=download_token.decode()
-        )
+        url = api.relative_url_for(DownloadResource, access_token=download_token)
         return schema.dump({"url": url})


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
decode method in legacy download token

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
Pass download_token as string to function without decoding method

**Test plan**
<!-- Explain how to test your changes -->
Try to use endpoint and access token for download some file.

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #588 
