### PR TITLE
Fix: failed upload when duplicated tags are passed

### DIFF
--- a/mwdb/model/object.py
+++ b/mwdb/model/object.py
@@ -697,13 +697,15 @@ class Object(db.Model):
         db_tag.tag = tag_name
         db_tag, _ = Tag.get_or_create(db_tag)
 
+        if db_tag in self.tags:
+            return False
+
         is_new = False
         db.session.begin_nested()
         try:
-            if db_tag not in self.tags:
-                self.tags.append(db_tag)
-                db.session.commit()
-                is_new = True
+            self.tags.append(db_tag)
+            db.session.commit()
+            is_new = True
         except IntegrityError:
             db.session.rollback()
             db.session.refresh(self)
@@ -726,13 +728,15 @@ class Object(db.Model):
         else:
             db_tag = db_tag.one()
 
+        if db_tag not in self.tags:
+            return False
+
         is_removed = False
         db.session.begin_nested()
         try:
-            if db_tag in self.tags:
-                self.tags.remove(db_tag)
-                db.session.commit()
-                is_removed = True
+            self.tags.remove(db_tag)
+            db.session.commit()
+            is_removed = True
         except IntegrityError:
             db.session.rollback()
             db.session.refresh(self)
@@ -969,13 +973,15 @@ class Object(db.Model):
         if db_analysis is None:
             return False
 
+        if db_analysis not in self.analyses:
+            return False
+
         is_removed = False
         db.session.begin_nested()
         try:
-            if db_analysis in self.analyses:
-                self.analyses.remove(db_analysis)
-                db.session.commit()
-                is_removed = True
+            self.analyses.remove(db_analysis)
+            db.session.commit()
+            is_removed = True
         except IntegrityError:
             db.session.rollback()
             db.session.refresh(self)


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
Described in #586: when tag already exists, nested transaction is initiated by begin_nested() but is never committed nor rollbacked. That's why the commit that is meant to commit the whole transaction, only cancels the savepoint and object gets lost.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
Duplicated tag is handled correctly and rejected at the beginning of the function.

**Test plan**
<!-- Explain how to test your changes -->

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #586 
