### PR TITLE
Fix: wrong configuration template for timeouts

### DIFF
--- a/mwdb/templates/mwdb.ini.tmpl
+++ b/mwdb/templates/mwdb.ini.tmpl
@@ -12,9 +12,16 @@ postgres_uri = {{ postgres_uri }}
 secret_key = {{ secret_key }}
 uploads_folder = {{ uploads_folder }}
 base_url = {{ base_url }}
-file_upload_timeout = {{ file_upload_timeout }}
-statement_timeout = {{ statement_timeout }}
-request_timeout = {{ request_timeout }}
+
+# Set longer timeout values if your queries last too long.
+# request_timeout = 20000
+# file_upload_timeout = 60000
+
+# Timeouts are recommended values for client-side and SQL queries are not interrupted
+# by finished connection. These timeouts doesn't have to be respected by the client.
+# If you want to control timeout on the backend (database) side, set statement_timeout
+# to desired number of milliseconds.
+# statement_timeout = 0
 
 ### Web application settings
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
Timeouts are templated in `mwdb.ini.tmpl`. In the same time, values are not set by `mwdb configure` which results in wrong configuration.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- Timeout values are commented out in template with additional documentation provided

**Test plan**
<!-- Explain how to test your changes -->
Check if `mwdb configure` generates correct configuration.
<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #590 
