### PR TITLE
Fix: fallback to 'data' if MagicException is raised

### DIFF
--- a/mwdb/core/util.py
+++ b/mwdb/core/util.py
@@ -79,7 +79,7 @@ def get_fd_path(stream):
         return None
 
 
-def calc_magic(stream):
+def calc_magic(stream) -> str:
     # Missing python-magic features:
     # - magic_descriptor (https://github.com/ahupp/python-magic/pull/227)
     # - direct support for symlink flag
@@ -93,9 +93,11 @@ def calc_magic(stream):
             # Handle BytesIO in-memory streams
             stream.seek(0, os.SEEK_SET)
             return magic.maybe_decode(magic.magic_buffer(magic_cookie, stream.read()))
+    except magic.MagicException:
+        # If libmagic fails, we fallback to 'data'
+        return "data"
     finally:
         magic.magic_close(magic_cookie)
-    return None
 
 
 def calc_ssdeep(stream):


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
Described in #601 

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
If MagicException is raised, file_type fallbacks to `data`

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #601
