### PR TITLE
Docs: mark deprecated methods using OAS3 attribute instead of tag

### DIFF
--- a/mwdb/resources/blob.py
+++ b/mwdb/resources/blob.py
@@ -222,10 +222,13 @@ class TextBlobItemResource(ObjectItemResource, TextBlobUploader):
             Uploads a new text blob.
 
             Requires `adding_blobs` capability.
+
+            Deprecated: use POST /blob method instead.
         security:
             - bearerAuth: []
+        deprecated: true
         tags:
-            - deprecated
+            - blob
         parameters:
             - in: path
               name: identifier

--- a/mwdb/resources/config.py
+++ b/mwdb/resources/config.py
@@ -344,10 +344,13 @@ class ConfigItemResource(ObjectItemResource, ConfigUploader):
             Uploads a new config.
 
             Requires `adding_configs` capability.
+
+            Deprecated: use POST /config method instead.
         security:
             - bearerAuth: []
+        deprecated: true
         tags:
-            - deprecated
+            - config
         parameters:
             - in: path
               name: identifier

--- a/mwdb/resources/download.py
+++ b/mwdb/resources/download.py
@@ -19,8 +19,11 @@ class DownloadResource(Resource):
         summary: Download file
         description: |
             Returns file contents based on provided file download token.
+
+            Deprecated: use GET /file/{identifier}/download instead.
+        deprecated: true
         tags:
-            - deprecated
+            - file
         parameters:
             - in: path
               name: access_token
@@ -63,10 +66,13 @@ class RequestSampleDownloadResource(Resource):
         summary: Get file download URL
         description: |
             Returns download URL for given file.
+
+            Deprecated: use POST /file/{identifier}>/download instead.
         security:
             - bearerAuth: []
+        deprecated: true
         tags:
-            - deprecated
+            - file
         parameters:
             - in: path
               name: identifier

--- a/mwdb/resources/file.py
+++ b/mwdb/resources/file.py
@@ -239,10 +239,13 @@ class FileItemResource(ObjectItemResource, FileUploader):
             Uploads a new file.
 
             Requires `adding_files` capability.
+
+            Deprecated: use POST /file instead.
         security:
             - bearerAuth: []
+        deprecated: true
         tags:
-            - deprecated
+            - file
         parameters:
             - in: path
               name: identifier

--- a/mwdb/resources/metakey.py
+++ b/mwdb/resources/metakey.py
@@ -42,10 +42,13 @@ class MetakeyResource(Resource):
         summary: Get object attributes
         description: |
             Returns all attributes of specified object that user is allowed to read.
+
+            Deprecated: use Attributes API instead
         security:
             - bearerAuth: []
+        deprecated: true
         tags:
-            - deprecated
+            - metakey
         parameters:
             - in: path
               name: type
@@ -111,10 +114,13 @@ class MetakeyResource(Resource):
 
             User must have `set` access to the attribute key
             or `adding_all_attributes` capability.
+
+            Deprecated: use Attributes API instead
         security:
             - bearerAuth: []
+        deprecated: true
         tags:
-            - deprecated
+            - metakey
         parameters:
             - in: path
               name: type
@@ -190,10 +196,13 @@ class MetakeyResource(Resource):
 
             If value is not specified, all values under the specified
             key are removed.
+
+            Deprecated: use Attributes API instead
         security:
             - bearerAuth: []
+        deprecated: true
         tags:
-            - deprecated
+            - metakey
         parameters:
             - in: path
               name: type
@@ -260,10 +269,13 @@ class MetakeyListDefinitionResource(Resource):
         description: |
             Returns list of attribute keys which currently authenticated user
             can read or set.
+
+            Deprecated: use Attributes API instead
         security:
             - bearerAuth: []
+        deprecated: true
         tags:
-            - deprecated
+            - metakey
         parameters:
             - in: path
               name: access
@@ -307,10 +319,13 @@ class MetakeyListDefinitionManageResource(Resource):
             Returns list of attribute key definitions.
 
             Requires `manage_users` capability.
+
+            Deprecated: use Attributes API instead
         security:
             - bearerAuth: []
+        deprecated: true
         tags:
-            - deprecated
+            - metakey
         responses:
             200:
                 description: List of attribute keys and definitions
@@ -344,10 +359,13 @@ class MetakeyDefinitionManageResource(Resource):
             Returns attribute key definition details.
 
             Requires `manage_users` capability.
+
+            Deprecated: use Attributes API instead
         security:
             - bearerAuth: []
+        deprecated: true
         tags:
-            - deprecated
+            - metakey
         parameters:
             - in: path
               name: key
@@ -388,10 +406,13 @@ class MetakeyDefinitionManageResource(Resource):
             Creates attribute key definition.
 
             Requires `manage_users` capability.
+
+            Deprecated: use Attributes API instead
         security:
             - bearerAuth: []
+        deprecated: true
         tags:
-            - deprecated
+            - metakey
         parameters:
             - in: path
               name: key
@@ -447,10 +468,13 @@ class MetakeyDefinitionManageResource(Resource):
             Update attribute key definition.
 
             Requires `manage_users` capability.
+
+            Deprecated: use Attribute API instead.
         security:
             - bearerAuth: []
+        deprecated: true
         tags:
-            - deprecated
+            - metakey
         parameters:
             - in: path
               name: key
@@ -523,10 +547,13 @@ class MetakeyDefinitionManageResource(Resource):
             Deletes attribute key including all related object attributes.
 
             Requires `manage_users` capability.
+
+            Deprecated: use Attribute API instead.
         security:
             - bearerAuth: []
+        deprecated: true
         tags:
-            - deprecated
+            - metakey
         parameters:
             - in: path
               name: key
@@ -568,10 +595,13 @@ class MetakeyPermissionResource(Resource):
             for specified key and group name.
 
             Requires `manage_users` capability.
+
+            Deprecated: use Attribute API instead.
         security:
             - bearerAuth: []
+        deprecated: true
         tags:
-            - deprecated
+            - metakey
         parameters:
             - in: path
               name: key
@@ -648,10 +678,13 @@ class MetakeyPermissionResource(Resource):
             Removes attribute key permission for specified key and group name.
 
             Requires `manage_users` capability.
+
+            Deprecated: use Attribute API instead.
         security:
             - bearerAuth: []
+        deprecated: true
         tags:
-            - deprecated
+            - metakey
         parameters:
             - in: path
               name: key

--- a/mwdb/resources/quick_query.py
+++ b/mwdb/resources/quick_query.py
@@ -23,7 +23,7 @@ class QuickQueryResource(Resource):
 
             Requires `personalize` capability.
         tags:
-            - query
+            - quick-query
         requestBody:
             description: Basic information for saving query
             content:
@@ -69,7 +69,7 @@ class QuickQueryResource(Resource):
         summary: Get stored quick queries
         description: Returns all saved queries related with specified object type.
         tags:
-            - query
+            - quick-query
         parameters:
             - in: path
               name: type
@@ -112,7 +112,7 @@ class QuickQueryItemResource(Resource):
 
             Requires `personalize` capability.
         tags:
-            - query
+            - quick-query
         parameters:
             - in: path
               name: id

--- a/mwdb/resources/search.py
+++ b/mwdb/resources/search.py
@@ -25,10 +25,13 @@ class SearchResource(Resource):
 
             Hard-limited to 10000 records.
             Use `query` argument in object get methods instead.
+
+            Deprecated: use /object?query= instead
+        deprecated: true
         security:
             - bearerAuth: []
         tags:
-            - deprecated
+            - object
         requestBody:
             description: Search query
             content:


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
Deprecated methods are grouped into `deprecated` tag which isn't very discoverable.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
Used `deprecated` attribute from OpenAPI Spec (better described in https://github.com/CERT-Polska/mwdb-core/issues/630)

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #630 
