### PR TITLE
Fix OpenIDConnect testing script URLs and details view error

### DIFF
--- a/dev/oidc/init.py
+++ b/dev/oidc/init.py
@@ -1,6 +1,5 @@
 import json
 import pathlib
-
 import requests
 
 print("[+] Authenticating")

--- a/dev/oidc/init.py
+++ b/dev/oidc/init.py
@@ -1,11 +1,12 @@
 import json
 import pathlib
+
 import requests
 
 print("[+] Authenticating")
 
 response = requests.post(
-    "http://127.0.0.1:8080/auth/realms/master/protocol/openid-connect/token",
+    "http://127.0.0.1:8080/realms/master/protocol/openid-connect/token",
     data={
         "client_id": "admin-cli",
         "username": "user",
@@ -25,7 +26,7 @@ print("[+] Registering realm")
 
 realm_path = pathlib.Path(__file__).parent / "realm-export.json"
 realm = realm_path.read_bytes()
-response = session.post("http://127.0.0.1:8080/auth/admin/realms/", data=realm)
+response = session.post("http://127.0.0.1:8080/admin/realms/", data=realm)
 if response.status_code != 409:
     response.raise_for_status()
 
@@ -53,13 +54,13 @@ user = {
     "credentials": [{"type": "password", "temporary": False, "value": "foobar"}],
 }
 response = session.post(
-    "http://127.0.0.1:8080/auth/admin/realms/mwdb-oidc-dev/users", data=json.dumps(user)
+    "http://127.0.0.1:8080/admin/realms/mwdb-oidc-dev/users", data=json.dumps(user)
 )
 if response.status_code != 409:
     response.raise_for_status()
 
 response = session.get(
-    "http://127.0.0.1:8080/auth/admin/realms/mwdb-oidc-dev/users?username=foo"
+    "http://127.0.0.1:8080/admin/realms/mwdb-oidc-dev/users?username=foo"
 )
 user_id = response.json()[0]["id"]
 print(f"'foo' => {user_id}")
@@ -95,10 +96,10 @@ response = mwdb_session.post(
         "name": "keycloak",
         "client_id": "mwdb",
         "client_secret": "",
-        "authorization_endpoint": "http://127.0.0.1:8080/auth/realms/mwdb-oidc-dev/protocol/openid-connect/auth",
-        "userinfo_endpoint": "http://keycloak.:8080/auth/realms/mwdb-oidc-dev/protocol/openid-connect/userinfo",
-        "token_endpoint": "http://keycloak.:8080/auth/realms/mwdb-oidc-dev/protocol/openid-connect/token",
-        "jwks_endpoint": "http://keycloak.:8080/auth/realms/mwdb-oidc-dev/protocol/openid-connect/certs",
+        "authorization_endpoint": "http://127.0.0.1:8080/realms/mwdb-oidc-dev/protocol/openid-connect/auth",
+        "userinfo_endpoint": "http://keycloak.:8080/realms/mwdb-oidc-dev/protocol/openid-connect/userinfo",
+        "token_endpoint": "http://keycloak.:8080/realms/mwdb-oidc-dev/protocol/openid-connect/token",
+        "jwks_endpoint": "http://keycloak.:8080/realms/mwdb-oidc-dev/protocol/openid-connect/certs",
     },
 )
 response.raise_for_status()

--- a/mwdb/web/src/components/Settings/Views/OAuthProvider.js
+++ b/mwdb/web/src/components/Settings/Views/OAuthProvider.js
@@ -22,7 +22,7 @@ function ProviderItem(props) {
 export default function OAuthProvider() {
     const viewAlert = useViewAlert();
     const { name } = useParams();
-    const [provider, setProvider] = useState({});
+    const [provider, setProvider] = useState(null);
     const [isDeleteModalOpen, setDeleteModalOpen] = useState(false);
     const [isDeleteModalDisabled, setDeleteModalDisabled] = useState(false);
 
@@ -94,7 +94,7 @@ export default function OAuthProvider() {
                         <EditableItem
                             name="client_secret"
                             type="client_secret"
-                            defaultValue={provider.client_secret}
+                            defaultValue={provider.client_secret || ""}
                             onSubmit={handleSubmit}
                             masked
                         />


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
Wrong URL in testing script for setting up Keycloak couse HTTPError.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
Fixed URLs in init.py that setting up Keycloak instance and account for mwdb.

**Test plan**
<!-- Explain how to test your changes -->
Check if mwdb environment for local OpenIDConnect works properly.

closes #638 