### PR TITLE
Bump typed-config and fix default handling

### DIFF
--- a/mwdb/core/config.py
+++ b/mwdb/core/config.py
@@ -1,6 +1,6 @@
 import os
 from enum import Enum
-from typing import List, Optional
+from typing import List
 
 from typedconfig import Config, group_key, key, section
 from typedconfig.source import EnvironmentConfigSource, IniFileConfigSource
@@ -18,7 +18,7 @@ def list_of_str(v: str) -> List[str]:
 
 def path(v: str) -> str:
     if not v:
-        raise ValueError(f"Path can't be empty")
+        raise ValueError("Path can't be empty")
     v = os.path.abspath(v)
     if not os.path.exists(v):
         raise ValueError(f"Path {v} doesn't exist")

--- a/mwdb/core/config.py
+++ b/mwdb/core/config.py
@@ -8,15 +8,15 @@ from typedconfig.source import EnvironmentConfigSource, IniFileConfigSource
 from mwdb.paths import mail_templates_dir
 
 
-def intbool(v) -> bool:
+def intbool(v: str) -> bool:
     return bool(int(v))
 
 
-def list_of_str(v) -> List[str]:
+def list_of_str(v: str) -> List[str]:
     return [el.strip() for el in v.split(",") if el.strip()]
 
 
-def path(v) -> Optional[str]:
+def path(v: str) -> str:
     if not v:
         raise ValueError(f"Path can't be empty")
     v = os.path.abspath(v)

--- a/mwdb/core/config.py
+++ b/mwdb/core/config.py
@@ -18,7 +18,7 @@ def list_of_str(v) -> List[str]:
 
 def path(v) -> Optional[str]:
     if not v:
-        return None
+        raise ValueError(f"Path can't be empty")
     v = os.path.abspath(v)
     if not os.path.exists(v):
         raise ValueError(f"Path {v} doesn't exist")
@@ -30,9 +30,9 @@ class StorageProviderType(Enum):
     S3 = "S3"
 
 
-def storage_provider_from_str(v: str) -> Optional[StorageProviderType]:
+def storage_provider_from_str(v: str) -> StorageProviderType:
     if not v:
-        return None
+        return StorageProviderType.DISK
 
     v = v.upper()
     try:
@@ -66,7 +66,7 @@ class MWDBConfig(Config):
     request_timeout = key(cast=int, required=False, default=20000)
     # Which storage provider to use (options: disk or s3)
     storage_provider = key(
-        cast=storage_provider_from_str, required=False, default="disk"
+        cast=storage_provider_from_str, required=False, default=StorageProviderType.DISK
     )
     # File upload timeout
     file_upload_timeout = key(cast=int, required=False, default=60000)
@@ -97,21 +97,20 @@ class MWDBConfig(Config):
 
     enable_plugins = key(cast=intbool, required=False, default=True)
     # List of plugin names to be loaded, separated by commas
-    plugins = key(cast=list_of_str, required=False, default="")
+    plugins = key(cast=list_of_str, required=False, default=[])
     # Directory that will be added to sys.path for plugin imports
     # Allows to load local plugins without installing them in site-packages
     local_plugins_folder = key(cast=path, required=False, default=None)
     # Auto-discover plugins contained in local_plugins_folder
     local_plugins_autodiscover = key(cast=intbool, required=False, default=False)
 
-    remotes = key(cast=list_of_str, required=False, default="")
+    remotes = key(cast=list_of_str, required=False, default=[])
 
     enable_rate_limit = key(cast=intbool, required=False, default=False)
     enable_registration = key(cast=intbool, required=False, default=False)
     enable_maintenance = key(cast=intbool, required=False, default=False)
     enable_hooks = key(cast=intbool, required=False, default=True)
     enable_karton = key(cast=intbool, required=False, default=False)
-    # Feature flag: OIDC is under development
     enable_oidc = key(cast=intbool, required=False, default=False)
 
     mail_smtp = key(cast=str, required=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ click-default-group==1.2.2
 PyYAML==5.4
 redis==3.2.1
 minio==7.1.0
-typed-config==0.2.1
+typed-config==1.1.0
 karton-core==4.4.1
 Authlib==0.15.4
 prance==0.21.8.0  # apispec unpinned dependency


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- Default values are casted by typed-config < 1.1.0
- Cast functions incorrectly handle empty values

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- Bumped typed-config to 1.1.0 and changed default values to appropriate type
- Changed `storage_provider_from_str` to return DISK if value is empty
- Changed `path` to raise exception if value is provided but empty

**Test plan**
<!-- Explain how to test your changes -->

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #634
