### PR TITLE
Upgrade Karton Core to v5.0.0 and move from Minio-Py to Boto3

### DIFF
--- a/dev/karton.ini
+++ b/dev/karton.ini
@@ -1,12 +1,11 @@
 [redis]
 host=redis
 
-[minio]
+[s3]
 access_key = mwdb-test-access
 secret_key = mwdb-test-key
-address = minio:9000
+address = http://minio:9000
 bucket = karton
-secure = 0
 
 [mwdb]
 api_url = http://mwdb-web.:3000/api/

--- a/docker-compose-dev-karton.yml
+++ b/docker-compose-dev-karton.yml
@@ -10,8 +10,8 @@ services:
     ports:
       - "127.0.0.1:9000:9000"
     environment:
-      - MINIO_ACCESS_KEY=mwdb-test-access
-      - MINIO_SECRET_KEY=mwdb-test-key
+      - MINIO_ROOT_USER=mwdb-test-access
+      - MINIO_ROOT_PASSWORD=mwdb-test-key
   mwdb:
     build:
       context: .
@@ -72,7 +72,7 @@ services:
     ports:
       - "127.0.0.1:8025:8025"
   karton-system:
-    image: certpl/karton-system:158d07960d8cd39dee8771af719f560df93b3212
+    image: certpl/karton-system:v5.0.0
     depends_on:
       - redis
       - minio
@@ -81,14 +81,14 @@ services:
     entrypoint: karton-system
     command: --setup-bucket
   karton-classifier:
-    image: certpl/karton-classifier:320c99de8e05ff3d029609e73ac31bcf2d0ba56c
+    image: certpl/karton-classifier:v1.4.0
     depends_on:
       - redis
       - minio
     volumes:
       - "./dev/karton.ini:/etc/karton/karton.ini"
   karton-dashboard:
-    image: certpl/karton-dashboard:2c35fb3cae399dba8913f8ad1be9dd6b820b1fd6
+    image: certpl/karton-dashboard:v1.4.0
     depends_on:
       - redis
       - minio
@@ -97,7 +97,7 @@ services:
     ports:
       - "127.0.0.1:8030:5000"
   karton-mwdb-reporter:
-    image: certpl/karton-mwdb-reporter:a4a5a2ece14073e3a25a38bd5f1b0fa14ba725d3
+    image: certpl/karton-mwdb-reporter:v1.2.0
     depends_on:
       - redis
       - minio

--- a/docker-compose-dev-remote.yml
+++ b/docker-compose-dev-remote.yml
@@ -10,8 +10,8 @@ services:
     ports:
       - "127.0.0.1:9000:9000"
     environment:
-      - MINIO_ACCESS_KEY=mwdb-test-access
-      - MINIO_SECRET_KEY=mwdb-test-key
+      - MINIO_ROOT_USER=mwdb-test-access
+      - MINIO_ROOT_PASSWORD=mwdb-test-key
   mwdb:
     build:
       context: .

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -10,8 +10,8 @@ services:
     ports:
       - "127.0.0.1:9000:9000"
     environment:
-      - MINIO_ACCESS_KEY=mwdb-test-access
-      - MINIO_SECRET_KEY=mwdb-test-key
+      - MINIO_ROOT_USER=mwdb-test-access
+      - MINIO_ROOT_PASSWORD=mwdb-test-key
   mwdb:
     build:
       context: .

--- a/docker-compose-e2e.yml
+++ b/docker-compose-e2e.yml
@@ -84,14 +84,14 @@ services:
     ports:
       - "127.0.0.1:9000:9000"
     environment:
-      - MINIO_ACCESS_KEY=mwdb-test-access
-      - MINIO_SECRET_KEY=mwdb-test-key
+      - MINIO_ROOT_USER=mwdb-test-access
+      - MINIO_ROOT_PASSWORD=mwdb-test-key
   mailhog:
     image: mailhog/mailhog:latest
     ports:
       - "127.0.0.1:8025:8025"
   karton-system:
-    image: certpl/karton-system:79ffabd3607406f1cc494b024b44f4dd1a753095
+    image: certpl/karton-system:v5.0.0
     depends_on:
       - redis
       - minio
@@ -99,23 +99,15 @@ services:
       - "./dev/karton.ini:/etc/karton/karton.ini"
     entrypoint: karton-system
     command: --setup-bucket
-    environment:
-      KARTON_MWDB_API_URL: http://mwdb-web.:80/api/
-      KARTON_MWDB_USERNAME: admin
-      KARTON_MWDB_PASSWORD: e2e-mwdb-admin-password
   karton-classifier:
-    image: certpl/karton-classifier:8f02c6e5188414f28d37515d903ce2b6955bc768
+    image: certpl/karton-classifier:v1.4.0
     depends_on:
       - redis
       - minio
     volumes:
       - "./dev/karton.ini:/etc/karton/karton.ini"
-    environment:
-      KARTON_MWDB_API_URL: http://mwdb-web.:80/api/
-      KARTON_MWDB_USERNAME: admin
-      KARTON_MWDB_PASSWORD: e2e-mwdb-admin-password
   karton-dashboard:
-    image: certpl/karton-dashboard:7b8ec871c4902cc7236eaa4782d9f7acdbc8809c
+    image: certpl/karton-dashboard:v1.4.0
     depends_on:
       - redis
       - minio
@@ -123,12 +115,8 @@ services:
       - "./dev/karton.ini:/etc/karton/karton.ini"
     ports:
       - "127.0.0.1:8030:5000"
-    environment:
-      KARTON_MWDB_API_URL: http://mwdb-web.:80/api/
-      KARTON_MWDB_USERNAME: admin
-      KARTON_MWDB_PASSWORD: e2e-mwdb-admin-password
   karton-mwdb-reporter:
-    image: certpl/karton-mwdb-reporter:6f935f6dfbf459e278a496586b581b4ba0d4cbad
+    image: certpl/karton-mwdb-reporter:v1.2.0
     depends_on:
       - redis
       - minio

--- a/docker-compose-oidc-dev.yml
+++ b/docker-compose-oidc-dev.yml
@@ -10,8 +10,8 @@ services:
     ports:
       - "127.0.0.1:9000:9000"
     environment:
-      - MINIO_ACCESS_KEY=mwdb-test-access
-      - MINIO_SECRET_KEY=mwdb-test-key
+      - MINIO_ROOT_USER=mwdb-test-access
+      - MINIO_ROOT_PASSWORD=mwdb-test-key
   mwdb:
     build:
       context: .

--- a/mwdb/core/karton.py
+++ b/mwdb/core/karton.py
@@ -1,6 +1,4 @@
 import logging
-import shutil
-import tempfile
 
 from flask import g
 from karton.core import Config as KartonConfig
@@ -21,24 +19,8 @@ def get_karton_producer() -> Producer:
 
 
 def send_file_to_karton(file) -> str:
-    from mwdb.model.file import File
-
-    tmpfile = None
-
+    file_stream = file.open()
     try:
-        # TODO: Use file.open() directly when Resource(fd=...)
-        # is implemented in Karton
-        try:
-            # If file contents are available via path: just use the path
-            path = file.get_path()
-        except (ValueError, IOError):
-            # If get_path doesn't work: download content to NamedTemporaryFile
-            tmpfile = tempfile.NamedTemporaryFile()
-            file_stream = file.open()
-            shutil.copyfileobj(file_stream, tmpfile)
-            File.close(file_stream)
-            path = tmpfile.name
-
         producer = get_karton_producer()
         feed_quality = g.auth_user.feed_quality
         task_priority = (
@@ -47,7 +29,7 @@ def send_file_to_karton(file) -> str:
         task = Task(
             headers={"type": "sample", "kind": "raw", "quality": feed_quality},
             payload={
-                "sample": Resource(file.file_name, path=path, sha256=file.sha256),
+                "sample": Resource(file.file_name, fd=file_stream, sha256=file.sha256),
                 "attributes": file.get_attributes(
                     as_dict=True, check_permissions=False
                 ),
@@ -56,8 +38,7 @@ def send_file_to_karton(file) -> str:
         )
         producer.send_task(task)
     finally:
-        if tmpfile is not None:
-            tmpfile.close()
+        file_stream.close()
 
     logger.info("File sent to Karton with %s", task.root_uid)
     return task.root_uid

--- a/mwdb/model/file.py
+++ b/mwdb/model/file.py
@@ -19,7 +19,7 @@ from mwdb.core.util import (
     calc_magic,
     calc_ssdeep,
     get_fd_path,
-    get_minio_client,
+    get_s3_client,
 )
 
 from . import db
@@ -131,7 +131,7 @@ class File(Object):
         if is_new:
             file_stream.seek(0, os.SEEK_SET)
             if app_config.mwdb.storage_provider == StorageProviderType.S3:
-                get_minio_client(
+                get_s3_client(
                     app_config.mwdb.s3_storage_endpoint,
                     app_config.mwdb.s3_storage_access_key,
                     app_config.mwdb.s3_storage_secret_key,
@@ -210,7 +210,7 @@ class File(Object):
         """
         if self.upload_stream is not None:
             # If file contents are uploaded in this request,
-            # try to reuse the existing file instead of downloading it from Minio.
+            # try to reuse the existing file instead of downloading it from S3.
             if isinstance(self.upload_stream, io.BytesIO):
                 return io.BytesIO(self.upload_stream.getbuffer())
             else:
@@ -219,7 +219,7 @@ class File(Object):
                 stream.seek(0, os.SEEK_SET)
                 return stream
         if app_config.mwdb.storage_provider == StorageProviderType.S3:
-            return get_minio_client(
+            return get_s3_client(
                 app_config.mwdb.s3_storage_endpoint,
                 app_config.mwdb.s3_storage_access_key,
                 app_config.mwdb.s3_storage_secret_key,
@@ -268,8 +268,6 @@ class File(Object):
         Closes file stream opened by File.open
         """
         fh.close()
-        if hasattr(fh, "release_conn"):
-            fh.release_conn()
 
     def zip_file(self):
         secret_password = b"infected"

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,9 +19,9 @@ click==7.1.2
 click-default-group==1.2.2
 PyYAML==5.4
 redis==3.2.1
-minio==7.1.0
+boto3==1.24.38
 typed-config==1.1.0
-karton-core==4.4.1
+karton-core==5.0.0
 Authlib==0.15.4
 prance==0.21.8.0  # apispec unpinned dependency
 regex==2021.7.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ python-json-logger==2.0.2
 click==7.1.2
 click-default-group==1.2.2
 PyYAML==5.4
-redis==3.2.1
+redis==4.3.4
 boto3==1.24.38
 typed-config==1.1.0
 karton-core==5.0.0


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- Upgraded Karton Core to v5.0.0 and removed workarounds required because of missing `Resource(fd=...)`  in previous versions
- Moved from minio-py to boto3 (Karton v5 uses boto3 as S3 client)

**Test plan**
<!-- Explain how to test your changes -->
- Test if interaction with Minio via Boto3 works correctly (storing and downloading files)
<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**
