### PR TITLE
Don't use a group in HashConverter's regex

### DIFF
--- a/mwdb/app.py
+++ b/mwdb/app.py
@@ -102,7 +102,7 @@ from mwdb.resources.user import (
 
 class HashConverter(BaseConverter):
     # MD5/SHA1/SHA256/SHA512 (32,40,64,128)
-    regex = "(root|[A-Fa-f0-9]{32,128})"
+    regex = "root|[A-Fa-f0-9]{32,128}"
 
 
 app.config["SQLALCHEMY_DATABASE_URI"] = app_config.mwdb.postgres_uri


### PR DESCRIPTION
Since the result isn't used, there is no need to keep it around.

<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [x] I've added automated tests for my change (if applicable, optional)
- [x] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
The regex used in `HashConverter` is using a group, but since mwdb only cares whether the regex is matching or not (and not what it matches on), there is no need to keep the result around.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

The match of `HashConverter`'s regex isn't kept.

**Test plan**
<!-- Explain how to test your changes -->

Simply run the testsuite

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->
