### PR TITLE
Draft: Remove the dependency on regex

### DIFF
--- a/mwdb/core/search/fields.py
+++ b/mwdb/core/search/fields.py
@@ -3,7 +3,6 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any, List, Type, Union
 
-import regex
 from dateutil.relativedelta import relativedelta
 from flask import g
 from luqum.tree import Range, Term
@@ -68,7 +67,7 @@ def make_jsonpath(field_path: List[str]) -> str:
     def jsonpath_escape(field):
         """Escapes field to be correctly represented in jsonpath"""
         # Escape all unescaped double quotes
-        field = regex.sub(r'(?<!\\)(?:\\\\)*\K["]', '\\"', field)
+        field = re.sub(r'\\([\s\S])|(")', r"\\\1\2", field)
         # Find trailing non-escaped asterisks
         asterisk_r = re.search(r"(?<!\\)(?:\\\\)*([*]+)$", field)
         if not asterisk_r:
@@ -78,7 +77,7 @@ def make_jsonpath(field_path: List[str]) -> str:
             field = field[:-asterisk_levels]
             asterisks = asterisk_levels * "[*]"
         # Unescape all escaped asterisks
-        field = regex.sub(r"(?<!\\)(?:\\\\)*\K(\\[*])", "*", field)
+        field = re.sub(r"\\([\s\S)|(\*)])", r"\1\2", field)
         return f'"{field}"{asterisks}'
 
     return ".".join(["$"] + [jsonpath_escape(field) for field in field_path])

--- a/mwdb/core/search/mappings.py
+++ b/mwdb/core/search/mappings.py
@@ -1,6 +1,5 @@
+import re
 from typing import Dict, List, Tuple, Type
-
-import regex
 
 from mwdb.model import (
     Comment,
@@ -91,7 +90,7 @@ field_mapping: Dict[str, Dict[str, BaseField]] = {
 def get_field_mapper(
     queried_type: Type[Object], field_selector: str
 ) -> Tuple[BaseField, List[str]]:
-    field_path = regex.split(r"(?<!\\)(?:\\\\)*\K[.]", field_selector)
+    field_path = re.split(r"(?<!\\)(?:\\\\)*[.]", field_selector)
 
     # Map object type selector
     if field_path[0] in object_mapping:

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,6 @@ typed-config==1.1.0
 karton-core==5.0.0
 Authlib==0.15.4
 prance==0.21.8.0  # apispec unpinned dependency
-regex==2021.7.6
 pyJWT==2.4.0
 Flask-Limiter==2.1.3
 python-dateutil==2.8.2


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [x] I've added automated tests for my change (if applicable, optional)
- [x] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

There is currently a dependency on the [regex](https://pypi.org/project/regex/), but it can be removed, and its usages replaced with stdlib's `re` instead.

**What is the new behaviour?**
Usage of stdlib's `re` package instead of `regex`

**Test plan**
<!-- Explain how to test your changes -->

I've tested my changes with a script looking like this one:

```python
import regex
import re

#field = 'lol"lol""\\"\\""\""'
#field = '*\*\\**8\*olpio*'
field = 'pif.paf\\.pouf.pouet\\.net.test\.com\\.\\.\\.lol.\\.com'         

#one = regex.sub(r'(?<!\\)(?:\\\\)*\K["]', '\\"', field)
#two = re.sub(r'\\([\s\S])|(")', r'\\\1\2', field)

#one = regex.sub(r"(?<!\\)(?:\\\\)*\K(\\[*])", "*", field)
#two = re.sub(r"\\([\s\S])|([*])", r"\1\2", field)

one = regex.split(r"(?<!\\)(?:\\\\)*\K[.]", field)
two = re.split(r"(?<!\\)(?:\\\\)*[.]", field)
if one != two:
  print('Nope: %s != %s' % (one, two))
```

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->
