### PR TITLE
Fix the padding/margin of the logo on the about page

### DIFF
--- a/mwdb/web/src/components/About.js
+++ b/mwdb/web/src/components/About.js
@@ -16,7 +16,7 @@ export default function About() {
             >
                 <View ident="about">
                     <div className="row justify-content-center">
-                        <div className="col-lg-2 col-sm-4 offset-2 text-center">
+                        <div className="col-sm-4 offset-2 text-center">
                             <img src={logo} alt="logo" className="logo-about" />
                         </div>
                         <div className="col-lg-6 col-sm-4">


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**

With the current logo:

![before](https://user-images.githubusercontent.com/325724/190913199-3daa0c1b-82b0-4fb5-9805-9468b138b3e6.png)

With a custom logo:

![echap_before](https://user-images.githubusercontent.com/325724/190913245-a47829e9-408c-4c50-9bef-b5c0d6f7e660.png)

**What is the new behaviour?**

With the current logo:

![image](https://user-images.githubusercontent.com/325724/190913270-efc17dfe-a705-4161-bc0c-919159e8ec1e.png)


The margins are a bit wider, but it doesn't really matter, since it makes the page feel less empty anyway.


With a custom logo:
![echap_after](https://user-images.githubusercontent.com/325724/190913169-16015692-5b85-4f2d-a7e7-de2a183abcdc.png)
