### PR TITLE
Fix the colour to mwdblib's link

### DIFF
--- a/mwdb/web/src/components/About.js
+++ b/mwdb/web/src/components/About.js
@@ -29,7 +29,7 @@ export default function About() {
                                 Try out our{" "}
                                 <a
                                     href="https://pypi.org/project/mwdblib/"
-                                    style={{ color: "lime" }}
+                                    style={{ color: "hsla(0,0%,100%,.5)" }}
                                 >
                                     mwdblib library
                                 </a>


### PR DESCRIPTION
**Your checklist for this pull request**
- [c] I've read the [contributing guideline](CONTRIBUTING.md).
- [c] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**

![before](https://user-images.githubusercontent.com/325724/190913397-30d95532-caa9-4a10-a43a-c2673ba8bbf0.png)

Oh the ugly limy green colour!

**What is the new behaviour?**
![after](https://user-images.githubusercontent.com/325724/190913409-bc3e5beb-26f6-489d-bd4d-ae74b948c62a.png)

Oh the sweet grey-ish colour, the very same that the one used for links in the navbar, which has the same background colour, making everything **much more** coherent and pleasant to the eyes!
