### PR TITLE
Fix docker/start.sh: don't run if configure fails

### DIFF
--- a/docker/start.sh
+++ b/docker/start.sh
@@ -7,6 +7,4 @@ until psql "$MWDB_POSTGRES_URI" -c "\q" ; do
 done
 
 echo "Configuring mwdb-core instance"
-mwdb-core configure --quiet basic
-
-exec uwsgi --ini /app/uwsgi.ini
+mwdb-core configure --quiet basic && exec uwsgi --ini /app/uwsgi.ini


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
Docker starts MWDB server even if migration fails

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
`uwsgi` is run only if `mwdb-core configure` passes without error

**Test plan**
<!-- Explain how to test your changes -->

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->
