### PR TITLE
Add "sha1" to [GET] /api/file response - "Search or list files"

### DIFF
--- a/mwdb/schema/file.py
+++ b/mwdb/schema/file.py
@@ -45,6 +45,7 @@ class FileListItemResponseSchema(ObjectListItemResponseSchema):
     file_type = fields.Str(required=True, allow_none=False)
 
     md5 = fields.Str(required=True, allow_none=False)
+    sha1 = fields.Str(required=True, allow_none=False)
     sha256 = fields.Str(required=True, allow_none=False)
 
 


### PR DESCRIPTION
Hey!

I was noticing that SHA1 was missing from the API response while searching for files using [GET] /api/file and using queries for searching. While it doesn't make sense to include every type of hash in the API response, I'd argue that SHA1 is still in common use. It would reduce to the amount of API calls to fetch SHA1 hashes en-masse. 

Please let me know if it's not feasible or if there is an alternative method recommended. :)

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
Currently the "Search or list files" API query only returns MD5 and SHA256 hashes.

**What is the new behaviour?**
The API query now also returns SHA1 hashes.

**Test plan**
Should work from the get-go. Changes can be reproduced easily while using the Docker-based dev environment for mwdb-core.

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**
N/A
