### PR TITLE
Fix: attributes appear in two different formats in context.object

### DIFF
--- a/mwdb/web/src/components/ShowObject/Views/AttributesBox.js
+++ b/mwdb/web/src/components/ShowObject/Views/AttributesBox.js
@@ -48,18 +48,7 @@ export default function AttributesBox() {
     async function updateAttributes() {
         try {
             const response = await api.getObjectAttributes(objectId);
-            const attributes = response.data.attributes.reduce(
-                (agg, attribute) => ({
-                    ...agg,
-                    [attribute.key]: [
-                        {
-                            id: attribute.id,
-                            value: attribute.value,
-                        },
-                    ].concat(agg[attribute.key] || []),
-                }),
-                {}
-            );
+            const attributes = response.data.attributes;
             updateObjectData({ attributes });
         } catch (error) {
             setObjectError(error);
@@ -102,9 +91,18 @@ export default function AttributesBox() {
         updateObjectData,
     ]);
 
-    useEffect(() => {
-        getAttributes();
-    }, [getAttributes]);
+    const aggregatedAttributes = attributes.reduce(
+        (agg, attribute) => ({
+            ...agg,
+            [attribute.key]: [
+                {
+                    id: attribute.id,
+                    value: attribute.value,
+                },
+            ].concat(agg[attribute.key] || []),
+        }),
+        {}
+    );
 
     return (
         <Extendable ident="attributesBox">
@@ -135,7 +133,7 @@ export default function AttributesBox() {
                     <div className="card-body text-muted">Loading data...</div>
                 ) : (
                     <Attributes
-                        attributes={attributes}
+                        attributes={aggregatedAttributes}
                         attributeDefinitions={attributeDefinitions}
                         onUpdateAttributes={getAttributes}
                         onRemoveAttribute={


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- `context.object.attributes` are already loaded in `[{key, value, id}, {key, value, id}, ...]` format
- then are reloaded by updateAttributes and converted to `{key: {value, id}, key: {value, id}}` format
- `context.object.attributes` has inconsistent format

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

Don't overwrite aggregated attributes in `context.object`.

