### PR TITLE
Replace ssdeep with ppdeep

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -5,8 +5,8 @@ LABEL maintainer="info@cert.pl"
 RUN apk add --no-cache postgresql-client postgresql-dev libmagic
 
 COPY requirements.txt docker/plugins/requirements-*.txt /tmp/
-RUN apk add --no-cache -t build libffi libffi-dev py3-cffi build-base python3-dev automake m4 autoconf libtool gcc g++ musl-dev libffi-dev openssl-dev cargo \
-    && BUILD_LIB=1 pip --no-cache-dir install -r /tmp/requirements.txt \
+RUN apk add --no-cache -t build libffi libffi-dev py3-cffi build-base python3-dev automake m4 autoconf libtool gcc g++ musl-dev openssl-dev cargo \
+    && pip --no-cache-dir install -r /tmp/requirements.txt \
     && ls /tmp/requirements-*.txt | xargs -i,, pip --no-cache-dir install -r ,, \
     && apk del build
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -63,6 +63,8 @@ services:
     env_file:
       # NOTE: use gen_vars.sh in order to generate this file
       - postgres-vars.env
+    ports:
+      - "127.0.0.1:54322:5432"
   redis:
     image: redis:alpine
   mailhog:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     depends_on:
       - postgres
       - redis
-    image: certpl/mwdb:v2.8.2
+    image: certpl/mwdb:v2.9.0
     restart: on-failure
     env_file:
       # NOTE: use gen_vars.sh in order to generate this file
@@ -22,7 +22,7 @@ services:
     build:
       context: .
       dockerfile: deploy/docker/Dockerfile-web
-    image: certpl/mwdb-web:v2.8.2
+    image: certpl/mwdb-web:v2.9.0
     ports:
       - "80:80"
     restart: on-failure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     depends_on:
       - postgres
       - redis
-    image: certpl/mwdb:v2.8.1
+    image: certpl/mwdb:v2.8.2
     restart: on-failure
     env_file:
       # NOTE: use gen_vars.sh in order to generate this file
@@ -22,7 +22,7 @@ services:
     build:
       context: .
       dockerfile: deploy/docker/Dockerfile-web
-    image: certpl/mwdb-web:v2.8.1
+    image: certpl/mwdb-web:v2.8.2
     ports:
       - "80:80"
     restart: on-failure

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ copyright = '2021, CERT Polska'
 author = 'CERT Polska'
 
 # The full version, including alpha/beta/rc tags
-release = '2.8.2'
+release = '2.9.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ copyright = '2021, CERT Polska'
 author = 'CERT Polska'
 
 # The full version, including alpha/beta/rc tags
-release = '2.8.1'
+release = '2.8.2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/mwdb/core/util.py
+++ b/mwdb/core/util.py
@@ -16,7 +16,7 @@ from zlib import crc32
 import boto3
 import botocore.client
 import magic
-import ssdeep
+import ppdeep
 from flask_restful import abort
 from flask_sqlalchemy import Pagination
 
@@ -101,7 +101,12 @@ def calc_magic(stream) -> str:
 
 
 def calc_ssdeep(stream):
-    return calc_hash(stream, ssdeep.Hash(), lambda h: h.digest())
+    stream.seek(0, os.SEEK_END)
+    file_size = stream.tell()
+
+    stream.seek(0, os.SEEK_SET)
+
+    return ppdeep._spamsum(stream, file_size)
 
 
 def calc_crc32(stream):

--- a/mwdb/version.py
+++ b/mwdb/version.py
@@ -4,5 +4,5 @@ try:
 except IOError:
     git_revision = ""
 
-app_version = "2.8.2"
+app_version = "2.9.0"
 app_build_version = f"{app_version}+{git_revision}" if git_revision else app_version

--- a/mwdb/version.py
+++ b/mwdb/version.py
@@ -4,5 +4,5 @@ try:
 except IOError:
     git_revision = ""
 
-app_version = "2.8.1"
+app_version = "2.8.2"
 app_build_version = f"{app_version}+{git_revision}" if git_revision else app_version

--- a/mwdb/web/package-lock.json
+++ b/mwdb/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mwdb-web",
-  "version": "2.8.2",
+  "version": "2.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mwdb-web",
-      "version": "2.8.2",
+      "version": "2.9.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/free-regular-svg-icons": "^6.1.1",

--- a/mwdb/web/package-lock.json
+++ b/mwdb/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mwdb-web",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mwdb-web",
-      "version": "2.8.1",
+      "version": "2.8.2",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/free-regular-svg-icons": "^6.1.1",

--- a/mwdb/web/package.json
+++ b/mwdb/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mwdb-web",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.1.1",

--- a/mwdb/web/package.json
+++ b/mwdb/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mwdb-web",
-  "version": "2.8.2",
+  "version": "2.9.0",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.1.1",

--- a/mwdb/web/src/commons/package.json
+++ b/mwdb/web/src/commons/package.json
@@ -2,7 +2,7 @@
     "name": "@mwdb-web/commons",
     "main": "index.js",
     "private": true,
-    "version": "2.8.1",
+    "version": "2.8.2",
     "peerDependencies": {
         "@fortawesome/react-fontawesome": "*",
         "bootstrap-select": "*",

--- a/mwdb/web/src/commons/package.json
+++ b/mwdb/web/src/commons/package.json
@@ -2,7 +2,7 @@
     "name": "@mwdb-web/commons",
     "main": "index.js",
     "private": true,
-    "version": "2.8.2",
+    "version": "2.9.0",
     "peerDependencies": {
         "@fortawesome/react-fontawesome": "*",
         "bootstrap-select": "*",

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Flask-Migrate==3.1.0
 Flask-RESTful==0.3.9
 SQLAlchemy==1.3.18
 marshmallow==3.7.1
-ssdeep==3.4
+ppdeep==20200505
 psycopg2-binary==2.8.5
 requests==2.26.0
 apispec[yaml,validation]==3.3.1

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ Under the hood of mwdb.cert.pl service hosted by CERT.pl.
 """
 
 setup(name="mwdb-core",
-      version="2.8.1",
+      version="2.8.2",
       description="MWDB Core malware database",
       long_description=LONG_DESCRIPTION,
       author="CERT Polska",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ Under the hood of mwdb.cert.pl service hosted by CERT.pl.
 """
 
 setup(name="mwdb-core",
-      version="2.8.2",
+      version="2.9.0",
       description="MWDB Core malware database",
       long_description=LONG_DESCRIPTION,
       author="CERT Polska",


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
MWDB uses library ssdeep with relies on libfuzzy-dev, which complicates the building process and provides additional requirements that might be difficult to fulfill in some environments.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
Instead of ssdeep I use ppdeep, which is a purely python library.

**Test plan**
<!-- Explain how to test your changes -->


<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #412 
