### PR TITLE
Pre-download file from S3 to TemporaryFile on File.open

### DIFF
--- a/docker-compose-dev-karton.yml
+++ b/docker-compose-dev-karton.yml
@@ -4,11 +4,12 @@ version: "3.3"
 services:
   minio:
     image: minio/minio
-    command: server /data
+    command: "server --address 0.0.0.0:9000 --console-address :8070 /data"
     volumes:
       - /tmp/minio:/data
     ports:
       - "127.0.0.1:9000:9000"
+      - "127.0.0.1:8070:8070"
     environment:
       - MINIO_ROOT_USER=mwdb-test-access
       - MINIO_ROOT_PASSWORD=mwdb-test-key
@@ -34,12 +35,12 @@ services:
       MWDB_ENABLE_REGISTRATION: 1
       MWDB_ENABLE_KARTON: 1
       # Uncomment if you want to test S3 functions
-      # MWDB_STORAGE_PROVIDER: s3
-      # MWDB_HASH_PATHING: 0
-      # MWDB_S3_STORAGE_ENDPOINT: "minio:9000"
-      # MWDB_S3_STORAGE_ACCESS_KEY: "mwdb-test-access"
-      # MWDB_S3_STORAGE_SECRET_KEY: "mwdb-test-key"
-      # MWDB_S3_STORAGE_BUCKET_NAME: "mwdb"
+      MWDB_STORAGE_PROVIDER: s3
+      MWDB_HASH_PATHING: 0
+      MWDB_S3_STORAGE_ENDPOINT: "minio:9000"
+      MWDB_S3_STORAGE_ACCESS_KEY: "mwdb-test-access"
+      MWDB_S3_STORAGE_SECRET_KEY: "mwdb-test-key"
+      MWDB_S3_STORAGE_BUCKET_NAME: "mwdb"
     volumes:
       - "./docker/mail_templates:/app/mail_templates"
       - "./mwdb:/app/mwdb"

--- a/mwdb/model/file.py
+++ b/mwdb/model/file.py
@@ -240,8 +240,10 @@ class File(Object):
                     Fileobj=stream,
                 )
                 stream.seek(0, io.SEEK_SET)
-            finally:
+                return stream
+            except Exception:
                 stream.close()
+                raise
         elif app_config.mwdb.storage_provider == StorageProviderType.DISK:
             return open(self._calculate_path(), "rb")
         else:

--- a/mwdb/model/file.py
+++ b/mwdb/model/file.py
@@ -223,19 +223,25 @@ class File(Object):
                 stream.seek(0, os.SEEK_SET)
                 return stream
         if app_config.mwdb.storage_provider == StorageProviderType.S3:
-            return get_s3_client(
-                app_config.mwdb.s3_storage_endpoint,
-                app_config.mwdb.s3_storage_access_key,
-                app_config.mwdb.s3_storage_secret_key,
-                app_config.mwdb.s3_storage_region_name,
-                app_config.mwdb.s3_storage_secure,
-                app_config.mwdb.s3_storage_iam_auth,
-            ).get_object(
-                Bucket=app_config.mwdb.s3_storage_bucket_name,
-                Key=self._calculate_path(),
-            )[
-                "Body"
-            ]
+            # Stream coming from Boto3 get_object is not buffered and not seekable.
+            # We need to download it to the temporary file first.
+            stream = tempfile.TemporaryFile(mode="w+b")
+            try:
+                get_s3_client(
+                    app_config.mwdb.s3_storage_endpoint,
+                    app_config.mwdb.s3_storage_access_key,
+                    app_config.mwdb.s3_storage_secret_key,
+                    app_config.mwdb.s3_storage_region_name,
+                    app_config.mwdb.s3_storage_secure,
+                    app_config.mwdb.s3_storage_iam_auth,
+                ).download_fileobj(
+                    Bucket=app_config.mwdb.s3_storage_bucket_name,
+                    Key=self._calculate_path(),
+                    Fileobj=stream,
+                )
+                stream.seek(0, io.SEEK_SET)
+            finally:
+                stream.close()
         elif app_config.mwdb.storage_provider == StorageProviderType.DISK:
             return open(self._calculate_path(), "rb")
         else:


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
File can't be reanalyzed because stream provided by File.open is not seekable

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
File is pre-downloaded from S3 storage into temporary file

**Test plan**
<!-- Explain how to test your changes -->

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->
closes #693 
