### PR TITLE
rename sharing_objects capability

### DIFF
--- a/docs/user-guide/9-Sharing-objects.rst
+++ b/docs/user-guide/9-Sharing-objects.rst
@@ -171,7 +171,7 @@ Each capability has its own name and scope:
   Capability used by ``everything`` group, useful when you want to make additional "everything" that is separate from the original one. Keep in mind that it applies only to the **uploads made during the capability was enabled**\ , so if you want the new group to be truly "everything", you may need to share the old objects manually.
 
 * 
-  **sharing_objects - Can share objects with all groups in system**
+  **sharing_with_all - Can share objects with all groups in system**
 
   Implies the access to the list of all group names, but without access to the membership information and management features. Allows to share object with arbitrary group in MWDB.
 

--- a/mwdb/core/capabilities.py
+++ b/mwdb/core/capabilities.py
@@ -6,7 +6,7 @@ class Capabilities(object):
     # All new uploaded objects are automatically shared with this group
     access_all_objects = "access_all_objects"
     # Can share objects with all groups, have access to complete list of groups
-    sharing_objects = "sharing_objects"
+    sharing_with_all = "sharing_with_all"
     # Can add tags
     adding_tags = "adding_tags"
     # Can remove tags

--- a/mwdb/model/migrations/versions/c7c72fd7fac5_rename_sharing_object_capability.py
+++ b/mwdb/model/migrations/versions/c7c72fd7fac5_rename_sharing_object_capability.py
@@ -1,0 +1,31 @@
+"""rename sharing object capability
+
+Revision ID: c7c72fd7fac5
+Revises: e81d851aa91f
+Create Date: 2022-10-19 13:36:25.254592
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c7c72fd7fac5"
+down_revision = "e81d851aa91f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        UPDATE public.group SET capabilities = array_replace(capabilities, 'sharing_objects', 'sharing_with_all');
+        """
+    )
+
+
+def downgrade():
+    op.execute(
+        """
+        UPDATE public.group SET capabilities = array_replace(capabilities, 'sharing_with_all', 'sharing_objects');
+        """
+    )

--- a/mwdb/model/object.py
+++ b/mwdb/model/object.py
@@ -899,7 +899,7 @@ class Object(db.Model):
         """
         permission_filter = ObjectPermission.object_id == self.id
 
-        if not g.auth_user.has_rights(Capabilities.sharing_objects):
+        if not g.auth_user.has_rights(Capabilities.sharing_with_all):
             permission_filter = and_(
                 permission_filter, g.auth_user.is_member(ObjectPermission.group_id)
             )

--- a/mwdb/resources/__init__.py
+++ b/mwdb/resources/__init__.py
@@ -120,7 +120,7 @@ def get_shares_for_upload(upload_as):
             raise NotFound(f"Group {upload_as} doesn't exist")
         # Has user access to group?
         if share_group not in g.auth_user.groups and not g.auth_user.has_rights(
-            Capabilities.sharing_objects
+            Capabilities.sharing_with_all
         ):
             raise NotFound(f"Group {upload_as} doesn't exist")
         # Is group pending?

--- a/mwdb/resources/blob.py
+++ b/mwdb/resources/blob.py
@@ -276,7 +276,7 @@ class TextBlobItemResource(ObjectItemResource, TextBlobUploader):
                       description: |
                         Group that object will be shared with.
 
-                        If user doesn't have `sharing_objects` capability,
+                        If user doesn't have `sharing_with_all` capability,
                         user must be a member of specified group
                         (unless `Group doesn't exist` error will occur).
 

--- a/mwdb/resources/config.py
+++ b/mwdb/resources/config.py
@@ -399,7 +399,7 @@ class ConfigItemResource(ObjectItemResource, ConfigUploader):
                       description: |
                         Group that object will be shared with.
 
-                        If user doesn't have `sharing_objects` capability,
+                        If user doesn't have `sharing_with_all` capability,
                         user must be a member of specified group
                         (unless `Group doesn't exist` error will occur).
 

--- a/mwdb/resources/file.py
+++ b/mwdb/resources/file.py
@@ -284,7 +284,7 @@ class FileItemResource(ObjectItemResource, FileUploader):
                       description: |
                         Group that object will be shared with.
 
-                        If user doesn't have `sharing_objects` capability,
+                        If user doesn't have `sharing_with_all` capability,
                         user must be a member of specified group
                         (unless `Group doesn't exist` error will occur).
 

--- a/mwdb/resources/share.py
+++ b/mwdb/resources/share.py
@@ -26,7 +26,7 @@ class ShareGroupListResource(Resource):
         description: |
             Returns list of available groups that user can share objects with.
 
-            If user doesn't have `sharing_objects` capability,
+            If user doesn't have `sharing_with_all` capability,
             list includes only groups of which the user is a member.
         security:
             - bearerAuth: []
@@ -42,7 +42,7 @@ class ShareGroupListResource(Resource):
                 description: |
                     Request canceled due to database statement timeout.
         """
-        if g.auth_user.has_rights(Capabilities.sharing_objects):
+        if g.auth_user.has_rights(Capabilities.sharing_with_all):
             groups = db.session.query(Group.name)
         else:
             groups = db.session.query(Group.name).filter(
@@ -71,7 +71,7 @@ class ShareResource(Resource):
         description: |
             Returns list of available groups and sharing info for specified object.
 
-            If user doesn't have `sharing_objects` capability,
+            If user doesn't have `sharing_with_all` capability,
             only own groups are included.
         security:
             - bearerAuth: []
@@ -103,7 +103,7 @@ class ShareResource(Resource):
                 description: |
                     Request canceled due to database statement timeout.
         """
-        if g.auth_user.has_rights(Capabilities.sharing_objects):
+        if g.auth_user.has_rights(Capabilities.sharing_with_all):
             groups = db.session.query(Group.name)
         else:
             groups = db.session.query(Group.name).filter(
@@ -135,7 +135,7 @@ class ShareResource(Resource):
         description: |
             Shares object with another group.
 
-            If user doesn't have `sharing_objects` capability,
+            If user doesn't have `sharing_with_all` capability,
             it can share object only within its own groups.
         security:
             - bearerAuth: []
@@ -183,7 +183,7 @@ class ShareResource(Resource):
 
         group_name = obj["group"]
         group = db.session.query(Group).filter(Group.name == group_name)
-        if not g.auth_user.has_rights(Capabilities.sharing_objects):
+        if not g.auth_user.has_rights(Capabilities.sharing_with_all):
             group = group.filter(g.auth_user.is_member(Group.id))
         group = group.first()
 

--- a/mwdb/web/src/commons/auth/capabilities.js
+++ b/mwdb/web/src/commons/auth/capabilities.js
@@ -32,7 +32,7 @@ export let capabilitiesList = {
     [Capability.shareQueriedObjects]: "Query for all objects in system",
     [Capability.accessAllObjects]:
         "Has access to all new uploaded objects into system",
-    [Capability.sharingObjects]: "Can share objects with all groups in system",
+    [Capability.sharingWithAll]: "Can share objects with all groups in system",
     [Capability.addingTags]: "Can add tags",
     [Capability.removingTags]: "Can remove tags",
     [Capability.addingComments]: "Can add comments",

--- a/mwdb/web/src/commons/auth/capabilities.js
+++ b/mwdb/web/src/commons/auth/capabilities.js
@@ -4,7 +4,7 @@ export const Capability = {
     manageUsers: "manage_users",
     shareQueriedObjects: "share_queried_objects",
     accessAllObjects: "access_all_objects",
-    sharingObjects: "sharing_objects",
+    sharingWithAll: "sharing_with_all",
     addingTags: "adding_tags",
     removingTags: "removing_tags",
     addingComments: "adding_comments",

--- a/tests/backend/test_multigroup_groups.py
+++ b/tests/backend/test_multigroup_groups.py
@@ -133,7 +133,7 @@ def test_multigroup_sharing(admin_session):
 
     Alice = testCase.new_user("Alice")
     Bob = testCase.new_user("Bob")
-    Joe = testCase.new_user("Joe", capabilities=["sharing_objects"])
+    Joe = testCase.new_user("Joe", capabilities=["sharing_with_all"])
 
     File = testCase.new_sample("File")
 

--- a/tests/backend/test_permissions.py
+++ b/tests/backend/test_permissions.py
@@ -63,11 +63,11 @@ def test_access_all_objects(admin_session):
     ], should_access=[Bob]).test()
 
 
-def test_sharing_objects(admin_session):
+def test_sharing_with_all(admin_session):
     testCase = RelationTestCase(admin_session)
 
     Alice = testCase.new_user("Alice")
-    Bob = testCase.new_user("Bob", capabilities=["sharing_objects"])
+    Bob = testCase.new_user("Bob", capabilities=["sharing_with_all"])
 
     Sample = testCase.new_sample("Sample")
     Sample.create(Bob)

--- a/tests/backend/test_sharing.py
+++ b/tests/backend/test_sharing.py
@@ -10,7 +10,7 @@ def test_share_with_foreign(admin_session):
     Joe = testCase.new_user("Joe")
 
     Workgroup = testCase.new_group("Workgroup")
-    Homegroup = testCase.new_group("Homegroup", ["sharing_objects"])
+    Homegroup = testCase.new_group("Homegroup", ["sharing_with_all"])
 
     Workgroup.add_member(Alice)
     Workgroup.add_member(Bob)
@@ -44,7 +44,7 @@ def test_share_with_public(admin_session):
     Joe = testCase.new_user("Joe")
 
     Workgroup = testCase.new_group("Workgroup")
-    Homegroup = testCase.new_group("Homegroup", ["sharing_objects"])
+    Homegroup = testCase.new_group("Homegroup", ["sharing_with_all"])
 
     Workgroup.add_member(Alice)
     Workgroup.add_member(Bob)
@@ -71,7 +71,7 @@ def test_share_and_leave(admin_session):
     Joe = testCase.new_user("Joe")
 
     Workgroup = testCase.new_group("Workgroup")
-    Homegroup = testCase.new_group("Homegroup", ["sharing_objects"])
+    Homegroup = testCase.new_group("Homegroup", ["sharing_with_all"])
 
     Workgroup.add_member(Alice)
     Workgroup.add_member(Bob)
@@ -100,7 +100,7 @@ def test_list_groups_for_share(admin_session):
     Joe = testCase.new_user("Joe")
 
     Workgroup = testCase.new_group("Workgroup")
-    Homegroup = testCase.new_group("Homegroup", ["sharing_objects"])
+    Homegroup = testCase.new_group("Homegroup", ["sharing_with_all"])
 
     Workgroup.add_member(Alice)
     Workgroup.add_member(Bob)


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
Name of "sharing_objects" capability is misleading. Every user can share objects. This capability allows sharing object with any other user.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
Rename "sharing_objects" to "sharing_with_all"

**Test plan**
<!-- Explain how to test your changes -->
1) Test if the capability still works properly
2) Test if the migration changes capability name in database

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

connected to #604  
