### PR TITLE
Fix: unable to delete objects with comments

### DIFF
--- a/mwdb/model/object.py
+++ b/mwdb/model/object.py
@@ -249,10 +249,7 @@ class Object(db.Model):
         "Attribute", backref="object", lazy=True, cascade="save-update, merge, delete"
     )
     comments = db.relationship(
-        "Comment",
-        backref="object",
-        lazy="dynamic",
-        cascade="save-update, merge, delete",
+        "Comment", backref="object", lazy="dynamic", passive_deletes=True
     )
     tags = db.relationship(
         "Tag",
@@ -266,7 +263,10 @@ class Object(db.Model):
     )
 
     comment_authors = db.relationship(
-        "User", secondary="comment", back_populates="commented_objects"
+        "User",
+        secondary="comment",
+        back_populates="commented_objects",
+        passive_deletes=True,
     )
 
     shares = db.relationship(

--- a/tests/backend/test_permissions.py
+++ b/tests/backend/test_permissions.py
@@ -226,3 +226,16 @@ def test_removing_objects(admin_session):
 
     assert {"tag": "tag123"} in admin_session.get_tags(SampleB.dhash)
 
+
+def test_removing_object_with_comments(admin_session):
+    testCase = RelationTestCase(admin_session)
+    sample = testCase.new_sample("Sample")
+    sample.create()
+
+    admin_session.add_comment(sample.dhash, "comment1")
+    admin_session.add_comment(sample.dhash, "comment2")
+    admin_session.add_comment(sample.dhash, "comment3")
+    admin_session.remove_object(sample.dhash)
+
+    with ShouldRaise(status_code=404):
+        admin_session.get_sample(sample.dhash)


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

We're unable to delete object with comments.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

Problem was caused by two relationships between Object and Comment table that were trying to reconcilate the fact that Object is deleted:
- comments with `cascade="delete"` included that deletes all comments that are orphaned
- comment_authors with default cascade setting that expects comments to be not deleted because they're treated like secondary table representing many-to-many relationship between objects and users.

These actions are in conflict that can be solved using `passive_deletes=True`, because foreign key constraints have already set `ondelete` behavior.

In addition, I set `passive_deletes` on comments as well to make sqlalchemy not even bother about that relationship (`ondelete` does the job passively from the SQLAlchemy perspective)

I don't know why it never happened before, maybe bug was somehow exposed by flattening the object inheritance model in 2.8.0.

**Test plan**
<!-- Explain how to test your changes -->

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #697
