### PR TITLE
web: OAuthRegister.js: Fix the order of arguments to api.oauthRegiste…

### DIFF
--- a/mwdb/web/src/components/Settings/Views/OAuthRegister.js
+++ b/mwdb/web/src/components/Settings/Views/OAuthRegister.js
@@ -34,8 +34,8 @@ export default function OAuthRegister() {
                 values.client_id,
                 values.client_secret,
                 values.authorization_endpoint,
-                values.userinfo_endpoint,
                 values.token_endpoint,
+                values.userinfo_endpoint,
                 values.jwks_endpoint
             );
             viewAlert.redirectToAlert({


### PR DESCRIPTION
…rProvider

<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
When registering a new OpenID Connect provider, the Token endpoint and Userinfo endpoint values are switched, resulting in an invalid configuration.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
This bug is due to an incorrect order of arguments to `api.oauthRegisterProvider`, which this PR fixes.

**Test plan**
<!-- Explain how to test your changes -->
Adding a new oidc provider and checking the values is a sufficient test. I confirmed the bug and tested the fix in docker using the `docker-compose-oidc-dev.yml` configuration.

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

