### PR TITLE
Prevent browser from caching samples (malware)

### DIFF
--- a/mwdb/app.py
+++ b/mwdb/app.py
@@ -41,7 +41,6 @@ from mwdb.resources.config import (
 from mwdb.resources.download import DownloadResource, RequestSampleDownloadResource
 from mwdb.resources.file import (
     FileDownloadResource,
-    FileDownloadResourceXored,
     FileDownloadZipResource,
     FileItemResource,
     FileResource,
@@ -258,7 +257,6 @@ api.add_resource(
 api.add_resource(FileResource, "/file")
 api.add_resource(FileItemResource, "/file/<hash64:identifier>")
 api.add_resource(FileDownloadResource, "/file/<hash64:identifier>/download")
-api.add_resource(FileDownloadResourceXored, "/file/<hash64:identifier>/download/xor")
 api.add_resource(FileDownloadZipResource, "/file/<hash64:identifier>/download/zip")
 
 # Config endpoints

--- a/mwdb/app.py
+++ b/mwdb/app.py
@@ -41,6 +41,7 @@ from mwdb.resources.config import (
 from mwdb.resources.download import DownloadResource, RequestSampleDownloadResource
 from mwdb.resources.file import (
     FileDownloadResource,
+    FileDownloadResourceXored,
     FileDownloadZipResource,
     FileItemResource,
     FileResource,
@@ -257,6 +258,7 @@ api.add_resource(
 api.add_resource(FileResource, "/file")
 api.add_resource(FileItemResource, "/file/<hash64:identifier>")
 api.add_resource(FileDownloadResource, "/file/<hash64:identifier>/download")
+api.add_resource(FileDownloadResourceXored, "/file/<hash64:identifier>/download/xor")
 api.add_resource(FileDownloadZipResource, "/file/<hash64:identifier>/download/zip")
 
 # Config endpoints

--- a/mwdb/model/file.py
+++ b/mwdb/model/file.py
@@ -304,7 +304,7 @@ class File(Object):
             else:
                 while True:
                     chunk = fh.read(chunk_size)
-                    chunk = self.xor(chunk)
+                    chunk = self.negate_bits(chunk)
                     if chunk:
                         yield chunk
                     else:

--- a/mwdb/model/file.py
+++ b/mwdb/model/file.py
@@ -280,7 +280,7 @@ class File(Object):
         finally:
             File.close(fh)
 
-    def xor(self, chunk):
+    def negate_bits(self, chunk):
         """
         xor data with key equal 255 of length of chunk; using numpy
         https://stackoverflow.com/questions/23312571/fast-xoring-bytes-in-python-3
@@ -289,10 +289,10 @@ class File(Object):
         chunk = np.frombuffer(chunk, dtype='uint8')
         return (key ^ chunk).tobytes()
 
-    def iterate_xored(self, chunk_size=1024 * 256):
+    def iterate_obfuscated(self, chunk_size=1024 * 256):
         """
         Iterates over bytes in the file contents with xor applied
-        The idea behind xoring before send is to prevent Chrome browser
+        The idea behind xoring before send is to prevent browsers
         from caching original samples (malware). Unxoring is provided
         in mwdb\web\src\components\ShowSample.js in SamplePreview
         """
@@ -300,7 +300,7 @@ class File(Object):
         stream_type = hasattr(fh, "stream")
         try:
             if hasattr(fh, "stream"):
-                yield from map(self.xor, fh.stream(chunk_size))
+                yield from map(self.negate_bits, fh.stream(chunk_size))
             else:
                 while True:
                     chunk = fh.read(chunk_size)

--- a/mwdb/model/file.py
+++ b/mwdb/model/file.py
@@ -283,8 +283,8 @@ class File(Object):
     def xor(self, chunk):
         """
         xor data with key equal 255 of length of chunk; using numpy
-		https://stackoverflow.com/questions/23312571/fast-xoring-bytes-in-python-3
-		"""
+        https://stackoverflow.com/questions/23312571/fast-xoring-bytes-in-python-3
+        """
         key = np.frombuffer(b'\xff'*len(chunk), dtype='uint8')
         chunk = np.frombuffer(chunk, dtype='uint8')
         return (key ^ chunk).tobytes()

--- a/mwdb/model/file.py
+++ b/mwdb/model/file.py
@@ -4,8 +4,8 @@ import os
 import shutil
 import tempfile
 
-import pyzipper
 import numpy as np
+import pyzipper
 from sqlalchemy import or_
 from sqlalchemy.dialects.postgresql.array import ARRAY
 from sqlalchemy.ext.mutable import MutableList
@@ -285,19 +285,18 @@ class File(Object):
         xor data with key equal 255 of length of chunk; using numpy
         https://stackoverflow.com/questions/23312571/fast-xoring-bytes-in-python-3
         """
-        key = np.frombuffer(b'\xff'*len(chunk), dtype='uint8')
-        chunk = np.frombuffer(chunk, dtype='uint8')
+        key = np.frombuffer(b"\xff" * len(chunk), dtype="uint8")
+        chunk = np.frombuffer(chunk, dtype="uint8")
         return (key ^ chunk).tobytes()
 
     def iterate_obfuscated(self, chunk_size=1024 * 256):
-        """
+        r"""
         Iterates over bytes in the file contents with xor applied
         The idea behind xoring before send is to prevent browsers
         from caching original samples (malware). Unxoring is provided
         in mwdb\web\src\components\ShowSample.js in SamplePreview
         """
         fh = self.open()
-        stream_type = hasattr(fh, "stream")
         try:
             if hasattr(fh, "stream"):
                 yield from map(self.negate_bits, fh.stream(chunk_size))

--- a/mwdb/resources/file.py
+++ b/mwdb/resources/file.py
@@ -381,123 +381,12 @@ class FileDownloadResource(Resource):
               description: |
                 File download token for direct link purpose
               required: false
-        responses:
-            200:
-                description: File contents
-                content:
-                  application/octet-stream:
-                    schema:
-                      type: string
-                      format: binary
-            403:
-                description: |
-                    When file download token is no longer valid
-                    or was generated for different object
-            404:
-                description: |
-                    When file doesn't exist, object is not a file
-                    or user doesn't have access to this object.
-            503:
-                description: |
-                    Request canceled due to database statement timeout.
-        """
-        access_token = request.args.get("token")
-
-        if access_token:
-            file_obj = File.get_by_download_token(access_token)
-            if not file_obj:
-                raise Forbidden("Download token expired, please re-request download.")
-            if not (
-                file_obj.sha1 == identifier
-                or file_obj.sha256 == identifier
-                or file_obj.sha512 == identifier
-                or file_obj.md5 == identifier
-            ):
-                raise Forbidden(
-                    "Download token doesn't apply to the chosen object. "
-                    "Please re-request download."
-                )
-        else:
-            if not g.auth_user:
-                raise Unauthorized("Not authenticated.")
-            file_obj = File.access(identifier)
-            if file_obj is None:
-                raise NotFound("Object not found")
-
-        return Response(
-            file_obj.iterate(),
-            content_type="application/octet-stream",
-            headers={"Content-disposition": f"attachment; filename={file_obj.sha256}"},
-        )
-
-    @requires_authorization
-    def post(self, identifier):
-        """
-        ---
-        summary: Generate file download token
-        description: |
-            Returns download token for given file.
-        security:
-            - bearerAuth: []
-        tags:
-            - file
-        parameters:
-            - in: path
-              name: identifier
-              description: Requested file identifier (SHA256/MD5/SHA1/SHA512)
-              schema:
-                type: string
-        responses:
-            200:
-                description: File download token, valid for 60 seconds
-                content:
-                  application/json:
-                    schema: FileDownloadTokenResponseSchema
-            404:
-                description: |
-                    When file doesn't exist, object is not a file
-                    or user doesn't have access to this object.
-            503:
-                description: |
-                    Request canceled due to database statement timeout.
-        """
-        file = File.access(identifier)
-        if file is None:
-            raise NotFound("Object not found")
-
-        download_token = file.generate_download_token()
-        schema = FileDownloadTokenResponseSchema()
-        return schema.dump({"token": download_token})
-
-
-@rate_limited_resource
-class FileDownloadResourceXored(Resource):
-    """copy of FileDownloadResource with file_obj.iterate_xored() in .get method"""
-    def get(self, identifier):
-        """
-        ---
-        summary: Download file
-        description: |
-            Returns file contents.
-
-            Optionally accepts file download token to get
-            the file via direct link (without Authorization header)
-        security:
-            - bearerAuth: []
-        tags:
-            - file
-        parameters:
-            - in: path
-              name: identifier
-              schema:
-                type: string
-              description: File identifier (SHA256/SHA512/SHA1/MD5)
             - in: query
-              name: token
+              name: obfuscate
               schema:
                 type: string
               description: |
-                File download token for direct link purpose
+                Obfuscated response flag
               required: false
         responses:
             200:
@@ -520,6 +409,7 @@ class FileDownloadResourceXored(Resource):
                     Request canceled due to database statement timeout.
         """
         access_token = request.args.get("token")
+        obfuscate = request.args.get("obfuscate")
 
         if access_token:
             file_obj = File.get_by_download_token(access_token)
@@ -542,11 +432,18 @@ class FileDownloadResourceXored(Resource):
             if file_obj is None:
                 raise NotFound("Object not found")
 
-        return Response(
-            file_obj.iterate_xored(),
-            content_type="application/octet-stream",
-            headers={"Content-disposition": f"attachment; filename={file_obj.sha256}"},
-        )
+        if obfuscate == "1":
+            return Response(
+                file_obj.iterate_obfuscated(),
+                content_type="application/octet-stream",
+                headers={"Content-disposition": f"attachment; filename={file_obj.sha256}"},
+            )
+        else:
+            return Response(
+                file_obj.iterate(),
+                content_type="application/octet-stream",
+                headers={"Content-disposition": f"attachment; filename={file_obj.sha256}"},
+            )
 
     @requires_authorization
     def post(self, identifier):

--- a/mwdb/resources/file.py
+++ b/mwdb/resources/file.py
@@ -436,13 +436,17 @@ class FileDownloadResource(Resource):
             return Response(
                 file_obj.iterate_obfuscated(),
                 content_type="application/octet-stream",
-                headers={"Content-disposition": f"attachment; filename={file_obj.sha256}"},
+                headers={
+                    "Content-disposition": f"attachment; filename={file_obj.sha256}"
+                },
             )
         else:
             return Response(
                 file_obj.iterate(),
                 content_type="application/octet-stream",
-                headers={"Content-disposition": f"attachment; filename={file_obj.sha256}"},
+                headers={
+                    "Content-disposition": f"attachment; filename={file_obj.sha256}"
+                },
             )
 
     @requires_authorization

--- a/mwdb/resources/file.py
+++ b/mwdb/resources/file.py
@@ -386,7 +386,7 @@ class FileDownloadResource(Resource):
               schema:
                 type: string
               description: |
-                Obfuscated response flag
+                Obfuscated response flag to avoid AV detection on preview
               required: false
         responses:
             200:

--- a/mwdb/resources/file.py
+++ b/mwdb/resources/file.py
@@ -471,6 +471,124 @@ class FileDownloadResource(Resource):
 
 
 @rate_limited_resource
+class FileDownloadResourceXored(Resource):
+    """copy of FileDownloadResource with file_obj.iterate_xored() in .get method"""
+    def get(self, identifier):
+        """
+        ---
+        summary: Download file
+        description: |
+            Returns file contents.
+
+            Optionally accepts file download token to get
+            the file via direct link (without Authorization header)
+        security:
+            - bearerAuth: []
+        tags:
+            - file
+        parameters:
+            - in: path
+              name: identifier
+              schema:
+                type: string
+              description: File identifier (SHA256/SHA512/SHA1/MD5)
+            - in: query
+              name: token
+              schema:
+                type: string
+              description: |
+                File download token for direct link purpose
+              required: false
+        responses:
+            200:
+                description: File contents
+                content:
+                  application/octet-stream:
+                    schema:
+                      type: string
+                      format: binary
+            403:
+                description: |
+                    When file download token is no longer valid
+                    or was generated for different object
+            404:
+                description: |
+                    When file doesn't exist, object is not a file
+                    or user doesn't have access to this object.
+            503:
+                description: |
+                    Request canceled due to database statement timeout.
+        """
+        access_token = request.args.get("token")
+
+        if access_token:
+            file_obj = File.get_by_download_token(access_token)
+            if not file_obj:
+                raise Forbidden("Download token expired, please re-request download.")
+            if not (
+                file_obj.sha1 == identifier
+                or file_obj.sha256 == identifier
+                or file_obj.sha512 == identifier
+                or file_obj.md5 == identifier
+            ):
+                raise Forbidden(
+                    "Download token doesn't apply to the chosen object. "
+                    "Please re-request download."
+                )
+        else:
+            if not g.auth_user:
+                raise Unauthorized("Not authenticated.")
+            file_obj = File.access(identifier)
+            if file_obj is None:
+                raise NotFound("Object not found")
+
+        return Response(
+            file_obj.iterate_xored(),
+            content_type="application/octet-stream",
+            headers={"Content-disposition": f"attachment; filename={file_obj.sha256}"},
+        )
+
+    @requires_authorization
+    def post(self, identifier):
+        """
+        ---
+        summary: Generate file download token
+        description: |
+            Returns download token for given file.
+        security:
+            - bearerAuth: []
+        tags:
+            - file
+        parameters:
+            - in: path
+              name: identifier
+              description: Requested file identifier (SHA256/MD5/SHA1/SHA512)
+              schema:
+                type: string
+        responses:
+            200:
+                description: File download token, valid for 60 seconds
+                content:
+                  application/json:
+                    schema: FileDownloadTokenResponseSchema
+            404:
+                description: |
+                    When file doesn't exist, object is not a file
+                    or user doesn't have access to this object.
+            503:
+                description: |
+                    Request canceled due to database statement timeout.
+        """
+        file = File.access(identifier)
+        if file is None:
+            raise NotFound("Object not found")
+
+        download_token = file.generate_download_token()
+        schema = FileDownloadTokenResponseSchema()
+        return schema.dump({"token": download_token})
+
+
+@rate_limited_resource
 class FileDownloadZipResource(Resource):
     def get(self, identifier):
         """

--- a/mwdb/web/src/commons/api/index.js
+++ b/mwdb/web/src/commons/api/index.js
@@ -411,7 +411,7 @@ function removeAttributePermission(key, group_name) {
     });
 }
 
-function downloadFile(id, obfuscate=0) {
+function downloadFile(id, obfuscate = 0) {
     return axios.get(`/file/${id}/download?obfuscate=${obfuscate}`, {
         responseType: "arraybuffer",
         responseEncoding: "binary",

--- a/mwdb/web/src/commons/api/index.js
+++ b/mwdb/web/src/commons/api/index.js
@@ -411,15 +411,8 @@ function removeAttributePermission(key, group_name) {
     });
 }
 
-function downloadFile(id) {
-    return axios.get(`/file/${id}/download`, {
-        responseType: "arraybuffer",
-        responseEncoding: "binary",
-    });
-}
-
-function downloadFileXored(id) {
-    return axios.get(`/file/${id}/download/xor`, {
+function downloadFile(id, obfuscate=0) {
+    return axios.get(`/file/${id}/download?obfuscate=${obfuscate}`, {
         responseType: "arraybuffer",
         responseEncoding: "binary",
     });

--- a/mwdb/web/src/commons/api/index.js
+++ b/mwdb/web/src/commons/api/index.js
@@ -418,6 +418,13 @@ function downloadFile(id) {
     });
 }
 
+function downloadFileXored(id) {
+    return axios.get(`/file/${id}/download/xor`, {
+        responseType: "arraybuffer",
+        responseEncoding: "binary",
+    });
+}
+
 async function requestFileDownloadLink(id) {
     const response = await axios.post(`/file/${id}/download`);
     const baseURL = getApiForEnvironment();
@@ -623,6 +630,7 @@ const api = {
     setAttributePermission,
     removeAttributePermission,
     downloadFile,
+    downloadFileXored,
     requestFileDownloadLink,
     requestZipFileDownloadLink,
     uploadFile,

--- a/mwdb/web/src/commons/api/index.js
+++ b/mwdb/web/src/commons/api/index.js
@@ -623,7 +623,6 @@ const api = {
     setAttributePermission,
     removeAttributePermission,
     downloadFile,
-    downloadFileXored,
     requestFileDownloadLink,
     requestZipFileDownloadLink,
     uploadFile,

--- a/mwdb/web/src/components/ShowSample.js
+++ b/mwdb/web/src/components/ShowSample.js
@@ -238,10 +238,7 @@ function SampleDetails() {
 function negateBuffer(buffer) {
     const uint8View = new Uint8Array(buffer);
     const xored = uint8View.map((item) => item ^ 0xff);
-    return xored.buffer.slice(
-        xored.byteOffset,
-        xored.byteLength + xored.byteOffset
-    );
+    return xored.buffer;
 }
 
 function SamplePreview() {

--- a/mwdb/web/src/components/ShowSample.js
+++ b/mwdb/web/src/components/ShowSample.js
@@ -234,6 +234,21 @@ function SampleDetails() {
     );
 }
 
+function xorArrayBuffer(buffer) {
+    /*
+    xor buffer with key equal 255
+	https://stackoverflow.com/questions/49885795/access-uint8array-in-javascript-arraybuffer
+	https://stackoverflow.com/questions/47891321/fastest-way-to-perform-xor-using-javascript-arraybuffer
+	https://stackoverflow.com/questions/29776996/applying-a-function-to-each-object-in-a-javascript-array
+	https://stackoverflow.com/questions/37228285/uint8array-to-arraybuffer
+    */
+    const uint8View = new Uint8Array(buffer);
+    const xored = uint8View.map(function(item) {
+        return (item ^ 255);
+    });
+    return xored.buffer.slice(xored.byteOffset, xored.byteLength + xored.byteOffset)
+}
+
 function SamplePreview() {
     const [content, setContent] = useState("");
     const api = useContext(APIContext);
@@ -243,8 +258,9 @@ function SamplePreview() {
     async function updateSample() {
         try {
             const fileId = objectContext.object.id;
-            const fileContentResponse = await api.downloadFile(fileId);
-            setContent(fileContentResponse.data);
+            const fileContentResponse = await api.downloadFileXored(fileId);
+            const fileContentResponseData = xorArrayBuffer(fileContentResponse.data);
+            setContent(fileContentResponseData);
         } catch (e) {
             objectContext.setObjectError(e);
         }

--- a/mwdb/web/src/components/ShowSample.js
+++ b/mwdb/web/src/components/ShowSample.js
@@ -234,18 +234,10 @@ function SampleDetails() {
     );
 }
 
-function xorArrayBuffer(buffer) {
-    /*
-    xor buffer with key equal 255
-	https://stackoverflow.com/questions/49885795/access-uint8array-in-javascript-arraybuffer
-	https://stackoverflow.com/questions/47891321/fastest-way-to-perform-xor-using-javascript-arraybuffer
-	https://stackoverflow.com/questions/29776996/applying-a-function-to-each-object-in-a-javascript-array
-	https://stackoverflow.com/questions/37228285/uint8array-to-arraybuffer
-    */
+// negate the buffer contents (xor with key equal 0xff)
+function negateBuffer(buffer) {
     const uint8View = new Uint8Array(buffer);
-    const xored = uint8View.map(function(item) {
-        return (item ^ 255);
-    });
+    const xored = uint8View.map(item => item ^ 0xFF);
     return xored.buffer.slice(xored.byteOffset, xored.byteLength + xored.byteOffset)
 }
 
@@ -258,8 +250,9 @@ function SamplePreview() {
     async function updateSample() {
         try {
             const fileId = objectContext.object.id;
-            const fileContentResponse = await api.downloadFileXored(fileId);
-            const fileContentResponseData = xorArrayBuffer(fileContentResponse.data);
+            const obfuscate = 1;
+            const fileContentResponse = await api.downloadFile(fileId, obfuscate);
+            const fileContentResponseData = negateBuffer(fileContentResponse.data);
             setContent(fileContentResponseData);
         } catch (e) {
             objectContext.setObjectError(e);

--- a/mwdb/web/src/components/ShowSample.js
+++ b/mwdb/web/src/components/ShowSample.js
@@ -237,8 +237,11 @@ function SampleDetails() {
 // negate the buffer contents (xor with key equal 0xff)
 function negateBuffer(buffer) {
     const uint8View = new Uint8Array(buffer);
-    const xored = uint8View.map(item => item ^ 0xFF);
-    return xored.buffer.slice(xored.byteOffset, xored.byteLength + xored.byteOffset)
+    const xored = uint8View.map((item) => item ^ 0xff);
+    return xored.buffer.slice(
+        xored.byteOffset,
+        xored.byteLength + xored.byteOffset
+    );
 }
 
 function SamplePreview() {
@@ -251,8 +254,13 @@ function SamplePreview() {
         try {
             const fileId = objectContext.object.id;
             const obfuscate = 1;
-            const fileContentResponse = await api.downloadFile(fileId, obfuscate);
-            const fileContentResponseData = negateBuffer(fileContentResponse.data);
+            const fileContentResponse = await api.downloadFile(
+                fileId,
+                obfuscate
+            );
+            const fileContentResponseData = negateBuffer(
+                fileContentResponse.data
+            );
             setContent(fileContentResponseData);
         } catch (e) {
             objectContext.setObjectError(e);

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ pyJWT==2.4.0
 Flask-Limiter==2.1.3
 python-dateutil==2.8.2
 pyzipper==0.3.5
+numpy==1.23.5


### PR DESCRIPTION
## Problem description
Browser downloads and caches original content file from `preview` tab. As consequence AV or EDR engine could raise an alert for malicious content.
Default path to Chrome cache on Windows (which is indicated as threat source by AV):
- `C:\Users\<USER>\AppData\Local\Google\Chrome\User Data\Default\Cache\Cache_Data`

## Solution
One of solutions could be that server send xored sample with known, fixed xor key (0xff), which is later unxored before showing it in details view. In that case cached sample will be bit-flipped file.

![preview](https://user-images.githubusercontent.com/103029515/204488326-d43ef383-9ae9-4ace-88d0-943a058206bc.PNG)

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
After preview tab is being activated, browser sends request to endpoint (`/file/<hash64:identifier>/download`). The endpoint serves a plaintext file using method `File.iterate`. Received response is cached as plaintext by browser and presented in the UI. AV detects malicious content in cache directory (e.g. `C:\Users\<USER>\AppData\Local\Google\Chrome\User Data\Default\Cache\Cache_Data`)

**What is the new behaviour?**
After preview tab is being activated, browser sends request to new endpoint (`/file/<hash64:identifier>/download/xor`). The endpoint serves a xored (bit-flipped) file using new method (`File.iterate_xored` in `\mwdb-core\mwdb\model\file.py`). Received response is cached as xored file by browser, then is being unxored (`SamplePreview()` in `\mwdb-core\mwdb\web\src\components\ShowSample.js`) and presented to user in original UI. In this approach AV doesnt raise an alert

**Test plan**
The file for testing caching and unxoring is attached. File is not malicious
1. Open sample
2. Inspect preview tab. 
3. AV doesnt raise an alert

[8e1b5a3e3eb4edbc75e7ec85e00c22efb618d5a487dcbd5172bf8a8b64eb4a9f.txt](https://github.com/CERT-Polska/mwdb-core/files/10111688/8e1b5a3e3eb4edbc75e7ec85e00c22efb618d5a487dcbd5172bf8a8b64eb4a9f.txt)
