### PR TITLE
Use pycryptodome instead of numpy for obfuscated download

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,4 @@ pyJWT==2.4.0
 Flask-Limiter==2.1.3
 python-dateutil==2.8.2
 pyzipper==0.3.5
-numpy==1.23.5
+pycryptodomex==3.16.0


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
`numpy` dependency was introduced by #721. Unfortunately, `numpy` highly extended build time because there are no pre-built wheels for musl (libc used in Alpine).

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
Replaced numpy with pycryptodome. This library is already used in other CERT.pl projects. I thought about lightweight alternative, but after quick searching I don't see any good candidate.

**Test plan**
<!-- Explain how to test your changes -->
Check if obfuscation still works correctly.
<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->
