### PR TITLE
handle 'misc:' as a proper tag

### DIFF
--- a/mwdb/web/src/commons/ui/Tag.js
+++ b/mwdb/web/src/commons/ui/Tag.js
@@ -19,6 +19,7 @@ export function getStyleForTag(tag) {
             "document:",
             "archive",
             "dump",
+	    "misc:",
         ],
     };
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

The color of the tag for `misc` is the default green.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

Based on the fact that the `misc:` tag is added by https://github.com/CERT-Polska/karton-classifier/blob/master/karton/classifier/classifier.py#L41  one would expect the tag color to be grey, as that is the default for the other types of tags that the classifier adds, such as `document`, `runnable`, etc.

**Test plan**
<!-- Explain how to test your changes -->

Navigate to a sample and add a tag that starts with `misc:`, such as `misc:html`.

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->
