### PR TITLE
CI: Emit mwdb-web-source image and tag correctly images during release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -223,17 +223,32 @@ jobs:
         with:
           file: ./deploy/docker/Dockerfile
           tags: |
+            certpl/mwdb:${{ github.sha }}
             certpl/mwdb:master
           cache-from: |
             type=registry,ref=certpl/mwdb:buildcache
           cache-to: |
             type=registry,ref=certpl/mwdb:buildcache,mode=max
           push: true
+      - name: Build and push mwdb-core web-source image
+        uses: docker/build-push-action@v2
+        with:
+          file: ./deploy/docker/Dockerfile-web
+          target: build
+          tags: |
+            certpl/mwdb-web-source:${{ github.sha }}
+            certpl/mwdb-web-source:master
+          cache-from: |
+            type=registry,ref=certpl/mwdb-web-source:buildcache
+          cache-to: |
+            type=registry,ref=certpl/mwdb-web-source:buildcache,mode=max
+          push: true
       - name: Build and push mwdb-core web image
         uses: docker/build-push-action@v2
         with:
           file: ./deploy/docker/Dockerfile-web
           tags: |
+            certpl/mwdb-web:${{ github.sha }}
             certpl/mwdb-web:master
           cache-from: |
             type=registry,ref=certpl/mwdb-web:buildcache
@@ -265,6 +280,7 @@ jobs:
           file: ./tests/backend/Dockerfile
           context: tests/backend
           tags: |
+            certpl/mwdb-tests:${{ github.sha }}
             certpl/mwdb-tests:master
           cache-from: |
             type=registry,ref=certpl/mwdb-tests:buildcache
@@ -277,6 +293,7 @@ jobs:
           file: ./tests/frontend/Dockerfile
           context: tests/frontend
           tags: |
+            certpl/mwdb-web-tests:${{ github.sha }}
             certpl/mwdb-web-tests:master
           cache-from: |
             type=registry,ref=certpl/mwdb-web-tests:buildcache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,8 @@ jobs:
           tags: |
             certpl/mwdb:${{ github.event.release.tag_name }}
             certpl/mwdb:latest
+          cache-from: |
+            type=registry,ref=certpl/mwdb:buildcache
           push: true
           context: .
       - name: Build and push mwdb-core web image
@@ -55,6 +57,42 @@ jobs:
           file: ./deploy/docker/Dockerfile-web
           tags: |
             certpl/mwdb-web:${{ github.event.release.tag_name }}
-            certpl/mwdb:latest
+            certpl/mwdb-web:latest
+          cache-from: |
+            type=registry,ref=certpl/mwdb-web:buildcache
           push: true
           context: .
+      - name: Build and push mwdb-core web-source image
+        uses: docker/build-push-action@v2
+        with:
+          file: ./deploy/docker/Dockerfile-web
+          target: build
+          tags: |
+            certpl/mwdb-web-source:${{ github.event.release.tag_name }}
+            certpl/mwdb-web-source:latest
+          cache-from: |
+            type=registry,ref=certpl/mwdb-web-source:buildcache
+          push: true
+          context: .
+      - name: Build and push mwdb-tests image
+        uses: docker/build-push-action@v2
+        with:
+          file: ./tests/backend/Dockerfile
+          context: tests/backend
+          tags: |
+            certpl/mwdb-tests:${{ github.event.release.tag_name }}
+            certpl/mwdb-tests:latest
+          cache-from: |
+            type=registry,ref=certpl/mwdb-tests:buildcache
+          push: true
+      - name: Build and push mwdb-web-tests image
+        uses: docker/build-push-action@v2
+        with:
+          file: ./tests/frontend/Dockerfile
+          context: tests/frontend
+          tags: |
+            certpl/mwdb-web-tests:${{ github.event.release.tag_name }}
+            certpl/mwdb-web-tests:latest
+          cache-from: |
+            type=registry,ref=certpl/mwdb-web-tests:buildcache
+          push: true


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- Emit `mwdb-web-source` from `build` stage to allow users to additionally extend it and rebuild with plugins
- Tag all images as `vx.x.x` and `latest` while doing a release

