### PR TITLE
Fix problem with jwt token when resetting password in v2.9.0

### DIFF
--- a/mwdb/model/migrations/versions/d7725a4e500c_tag_model_flattening.py
+++ b/mwdb/model/migrations/versions/d7725a4e500c_tag_model_flattening.py
@@ -1,7 +1,7 @@
 """Tag model flattening
 
 Revision ID: d7725a4e500c
-Revises: b78affca7273
+Revises: 1b49fefdfcb0
 Create Date: 2022-09-01 16:18:42.355865
 
 """

--- a/mwdb/templates/mail/recover.txt
+++ b/mwdb/templates/mail/recover.txt
@@ -2,7 +2,7 @@ Hi {login},
 
 We received a request to change your password.
 
-Set password link: {base_url}/setpasswd/{set_password_token}
+Set password link: {base_url}/setpasswd/?token={set_password_token}
 
 If you didn't request a password change, you can ignore this message
 and continue to use your current password. Someone probably typed in

--- a/mwdb/templates/mail/register.txt
+++ b/mwdb/templates/mail/register.txt
@@ -5,4 +5,4 @@ Your mwdb-core account has been successfully registered.
 Here are your credentials:
 
 Login: {login}
-Set password link: {base_url}/setpasswd/{set_password_token}
+Set password link: {base_url}/setpasswd/?token={set_password_token}

--- a/mwdb/web/src/App.jsx
+++ b/mwdb/web/src/App.jsx
@@ -101,7 +101,7 @@ function AppRoutes() {
             <Route path="login" element={<UserLogin />} />
             <Route path="register" element={<UserRegister />} />
             <Route path="recover_password" element={<UserPasswordRecover />} />
-            <Route path="setpasswd/:token" element={<UserSetPassword />} />
+            <Route path="setpasswd" element={<UserSetPassword />} />
             <Route path="oauth/callback" element={<OAuthAuthorize />} />
             <Route element={<RequiresAuth />}>
                 <Route path="/" element={<RecentSamples />} />

--- a/mwdb/web/src/components/Settings/Views/UserResetPassword.jsx
+++ b/mwdb/web/src/components/Settings/Views/UserResetPassword.jsx
@@ -29,7 +29,9 @@ export default function UserResetPassword() {
     async function generatePasswordResetLink() {
         try {
             let getURLFromToken = (token) =>
-                encodeURI(`${window.location.origin}/setpasswd/${token}`);
+                encodeURI(
+                    `${window.location.origin}/setpasswd/?token=${token}`
+                );
             let response = await api.generateSetPasswordToken(user.login);
             setPasswordURL(getURLFromToken(response.data.token));
         } catch (error) {

--- a/mwdb/web/src/components/UserSetPassword.jsx
+++ b/mwdb/web/src/components/UserSetPassword.jsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { useParams } from "react-router-dom";
 import { useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as Yup from "yup";
@@ -8,9 +7,10 @@ import { View } from "@mwdb-web/commons/ui";
 import { api } from "@mwdb-web/commons/api";
 
 export default function UserSetPassword() {
-    const params = useParams();
     const [success, setSuccess] = useState(false);
     const [error, setError] = useState(false);
+    const token =
+        new URLSearchParams(window.location.search).get("token") || "";
 
     const validationSchema = Yup.object().shape({
         password: Yup.string()
@@ -30,10 +30,7 @@ export default function UserSetPassword() {
 
     async function onSubmit(form) {
         try {
-            let response = await api.authSetPassword(
-                params.token,
-                form.password
-            );
+            let response = await api.authSetPassword(token, form.password);
             setSuccess(
                 `Password successfully changed for ${response.data.login}`
             );


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [X] I've read the [contributing guideline](CONTRIBUTING.md).
- [X] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
When resetting password user is redirected to: i.e. mwdb.cert.pl/setpasswd/<jwt_token> (token is in path)
jwt token has `.` characters in it, which causes some browser to throw an error

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
Instead of passing jwt token in path, I pass it using SearchParams
i.e. mwdb.cert.pl/setpasswd/?token=<jwt_token> (token is in param)

**Test plan**
<!-- Explain how to test your changes -->
Try to reset password

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #748
