### PR TITLE
Add 'count' field for object listing endpoints

### DIFF
--- a/docs/setup-and-configuration.rst
+++ b/docs/setup-and-configuration.rst
@@ -308,6 +308,7 @@ Extra features:
 * ``remotes`` (comma separated strings) - list of MWDB remotes (experimental)
 * ``enable_hooks`` (0 or 1) - enable plugin hooks
 * ``enable_oidc`` (0 or 1) - enable OIDC (experimental)
+* ``listing_endpoints_count_limit`` (integer) - Limits number of objects returned by listing endpoints. Default is ``1000``.
 
 Registration feature settings:
 

--- a/mwdb/core/config.py
+++ b/mwdb/core/config.py
@@ -89,6 +89,8 @@ class MWDBConfig(Config):
     s3_storage_bucket_name = key(cast=str, required=False)
     # S3 storage Authorize through IAM role (No credentials)
     s3_storage_iam_auth = key(cast=intbool, required=False)
+    # Limit number of objects returned by listing endpoints
+    listing_endpoints_count_limit = key(cast=int, required=False, default=1000)
 
     # Administrator account login
     admin_login = key(cast=str, required=False, default="admin")

--- a/mwdb/resources/blob.py
+++ b/mwdb/resources/blob.py
@@ -56,11 +56,13 @@ class TextBlobResource(ObjectResource, TextBlobUploader):
         description: |
             Returns list of text blobs matching provided query,
             ordered from the latest one.
+            If you want to fetch older blobs use `older_than` parameter.
 
-            Limited to 10 objects, use `older_than` parameter to fetch more.
+            Numer of returned blobs is limited by 'count' parameter
+            (default value is 10).
 
-            Don't rely on maximum count of returned objects
-            because it can be changed/parametrized in future.
+            `Note:` Maximal number of returned blobs is limited in
+            MWDB's configuration (default value is 1 000)
         security:
             - bearerAuth: []
         tags:
@@ -71,7 +73,7 @@ class TextBlobResource(ObjectResource, TextBlobUploader):
               schema:
                 type: string
               description: |
-                Fetch objects which are older than the object
+                Fetch text blobs which are older than the object
                 specified by identifier.
 
                 Used for pagination

--- a/mwdb/resources/config.py
+++ b/mwdb/resources/config.py
@@ -171,11 +171,13 @@ class ConfigResource(ObjectResource, ConfigUploader):
         description: |
             Returns list of configs matching provided query,
             ordered from the latest one.
+            If you want to fetch older configs use `older_than` parameter.
 
-            Limited to 10 objects, use `older_than` parameter to fetch more.
+            Numer of returned configs is limited by 'count' parameter
+            (default value is 10).
 
-            Don't rely on maximum count of returned objects because it
-            can be changed/parametrized in future.
+            `Note:` Maximal number of returned configs is limited in
+            MWDB's configuration (default value is 1 000)
         security:
             - bearerAuth: []
         tags:
@@ -186,7 +188,7 @@ class ConfigResource(ObjectResource, ConfigUploader):
               schema:
                 type: string
               description: |
-                Fetch objects which are older than the object specified by identifier.
+                Fetch configs which are older than the object specified by identifier.
                 Used for pagination
               required: false
             - in: query

--- a/mwdb/resources/file.py
+++ b/mwdb/resources/file.py
@@ -58,13 +58,15 @@ class FileResource(ObjectResource, FileUploader):
         ---
         summary: Search or list files
         description: |
-            Returns a list of files matching provided query,
+            Returns list of files matching provided query,
             ordered from the latest one.
+            If you want to fetch older files use `older_than` parameter.
 
-            Limited to 10 objects, use `older_than` parameter to fetch more.
+            Numer of returned files is limited by 'count' parameter
+            (default value is 10).
 
-            Don't rely on maximum count of returned objects because
-            it can be changed/parametrized in future.
+            `Note:` Maximal number of returned files is limited in
+            MWDB's configuration (default value is 1 000)
         security:
             - bearerAuth: []
         tags:
@@ -75,7 +77,7 @@ class FileResource(ObjectResource, FileUploader):
               schema:
                 type: string
               description: |
-                Fetch objects which are older than the object specified by identifier.
+                Fetch files which are older than the object specified by identifier.
 
                 Used for pagination
               required: false

--- a/mwdb/schema/object.py
+++ b/mwdb/schema/object.py
@@ -19,6 +19,7 @@ class ObjectListRequestSchema(Schema):
     page = fields.Int(missing=None)  # legacy, to be removed in future
     query = fields.Str(missing=None)
     older_than = fields.Str(missing=None)
+    count = fields.Int(missing=10)
 
     @validates_schema
     def validate_key(self, data, **kwargs):


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [X] I've read the [contributing guideline](CONTRIBUTING.md).
- [ ] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
Listing endpoints always limit number of returned objects to 10

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
When requesting list of objects, user can specify a new `count` field and set the limit manually.
If the field is not provided, value is set to 10 by default. 

Maximal number of returned objects is limited in MWDB's configuration (default value is 1 000).

**Test plan**
<!-- Explain how to test your changes -->
Manual test API
Automatic tests will be added later

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #754
