### PR TITLE
add new field in config, check upload size

### DIFF
--- a/docs/setup-and-configuration.rst
+++ b/docs/setup-and-configuration.rst
@@ -287,6 +287,7 @@ Plugin settings:
 Storage settings:
 
 
+* ``max_upload_size`` (integer) - Maximal upload size in bytes. Keep in mind that this value refers to whole upload request (``Content-Lenght`` from request header), so the maximal file size is smaller than that by +/- 500B. Default is ``None``, which means there is no limit.
 * ``storage_provider`` (disk or s3) - If you want to use S3-compatible object storage instead of local file system, set this option to ``s3``. Default is ``disk``.
 * ``hash_pathing`` (0 or 1) - Should we break up the uploads into different folders. If you use S3-compatible storage, recommended option is ``0`` (default: ``1``).
 * ``s3_storage_endpoint`` (string) - S3 API endpoint for object storage. Required if you use S3-compatible storage.

--- a/docs/setup-and-configuration.rst
+++ b/docs/setup-and-configuration.rst
@@ -287,7 +287,7 @@ Plugin settings:
 Storage settings:
 
 
-* ``max_upload_size`` (integer) - Maximal upload size in bytes. Keep in mind that this value refers to whole upload request (``Content-Lenght`` from request header), so the maximal file size is smaller than that by +/- 500B. Default is ``None``, which means there is no limit.
+* ``max_upload_size`` (integer) - Maximum upload size in bytes. Keep in mind that this value refers to whole upload request (``Content-Length`` from request header), so the maximum file size is smaller than that by +/- 500B (because of additional payload with metadata). Default is ``None``, which means there is no limit.
 * ``storage_provider`` (disk or s3) - If you want to use S3-compatible object storage instead of local file system, set this option to ``s3``. Default is ``disk``.
 * ``hash_pathing`` (0 or 1) - Should we break up the uploads into different folders. If you use S3-compatible storage, recommended option is ``0`` (default: ``1``).
 * ``s3_storage_endpoint`` (string) - S3 API endpoint for object storage. Required if you use S3-compatible storage.

--- a/mwdb/core/app.py
+++ b/mwdb/core/app.py
@@ -1,10 +1,12 @@
 from flask import Blueprint, Flask
 
+from mwdb.core.config import app_config
 from mwdb.core.rate_limit import limiter
 
 from .service import Service
 
 app = Flask(__name__, static_folder=None)
+app.config["MAX_CONTENT_LENGTH"] = app_config.mwdb.max_upload_size
 api_blueprint = Blueprint("api", __name__, url_prefix="/api")
 api = Service(app, api_blueprint)
 app.register_blueprint(api_blueprint)

--- a/mwdb/core/config.py
+++ b/mwdb/core/config.py
@@ -70,6 +70,10 @@ class MWDBConfig(Config):
     )
     # File upload timeout
     file_upload_timeout = key(cast=int, required=False, default=60000)
+    # Maximal upload size, default is None (no limit)
+    # This value refers to whole upload request ('Content-Lenght' from request header)
+    # Maximal file size is smaller than that by +/- 500 B
+    max_upload_size = key(cast=int, required=False, default=None)
     # Folder for uploads
     uploads_folder = key(cast=path, required=False)
     # Should we break up the uploads into different folders for example:

--- a/mwdb/core/config.py
+++ b/mwdb/core/config.py
@@ -70,9 +70,9 @@ class MWDBConfig(Config):
     )
     # File upload timeout
     file_upload_timeout = key(cast=int, required=False, default=60000)
-    # Maximal upload size, default is None (no limit)
-    # This value refers to whole upload request ('Content-Lenght' from request header)
-    # Maximal file size is smaller than that by +/- 500 B
+    # Maximum upload size, default is None (no limit)
+    # This value refers to whole upload request ('Content-Length' from request header)
+    # Maximum file size is smaller than that by +/- 500 B
     max_upload_size = key(cast=int, required=False, default=None)
     # Folder for uploads
     uploads_folder = key(cast=path, required=False)

--- a/mwdb/resources/file.py
+++ b/mwdb/resources/file.py
@@ -1,8 +1,16 @@
 from flask import Response, g, request
 from flask_restful import Resource
-from werkzeug.exceptions import BadRequest, Conflict, Forbidden, NotFound, Unauthorized
+from werkzeug.exceptions import (
+    BadRequest,
+    Conflict,
+    Forbidden,
+    NotAcceptable,
+    NotFound,
+    Unauthorized,
+)
 
 from mwdb.core.capabilities import Capabilities
+from mwdb.core.config import app_config
 from mwdb.core.plugins import hooks
 from mwdb.core.rate_limit import rate_limited_resource
 from mwdb.model import File
@@ -183,6 +191,16 @@ class FileResource(ObjectResource, FileUploader):
         """
         schema = FileCreateRequestSchema()
         obj = load_schema(request.form.to_dict(), schema)
+
+        if app_config.mwdb.max_upload_size:
+            if (
+                int(request.headers.get("Content-Length"))
+                > app_config.mwdb.max_upload_size
+            ):
+                raise NotAcceptable(
+                    f"File you are trying to upload is bigger "
+                    f"than the configured limit: {app_config.mwdb.max_upload_size}B"
+                )
 
         return self.create_object(obj["options"])
 

--- a/mwdb/resources/file.py
+++ b/mwdb/resources/file.py
@@ -1,16 +1,8 @@
 from flask import Response, g, request
 from flask_restful import Resource
-from werkzeug.exceptions import (
-    BadRequest,
-    Conflict,
-    Forbidden,
-    NotAcceptable,
-    NotFound,
-    Unauthorized,
-)
+from werkzeug.exceptions import BadRequest, Conflict, Forbidden, NotFound, Unauthorized
 
 from mwdb.core.capabilities import Capabilities
-from mwdb.core.config import app_config
 from mwdb.core.plugins import hooks
 from mwdb.core.rate_limit import rate_limited_resource
 from mwdb.model import File
@@ -191,16 +183,6 @@ class FileResource(ObjectResource, FileUploader):
         """
         schema = FileCreateRequestSchema()
         obj = load_schema(request.form.to_dict(), schema)
-
-        if app_config.mwdb.max_upload_size:
-            if (
-                int(request.headers.get("Content-Length"))
-                > app_config.mwdb.max_upload_size
-            ):
-                raise NotAcceptable(
-                    f"File you are trying to upload is bigger "
-                    f"than the configured limit: {app_config.mwdb.max_upload_size}B"
-                )
 
         return self.create_object(obj["options"])
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [X] I've read the [contributing guideline](CONTRIBUTING.md).
- [X] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [x] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
Users can upload as big file as they want and administrator doesn't have any tools (inside MWDB) to prevent that.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
Administrator can configure limit for uploaded files
Checking file's size is not precise. In order to simplify the code, I check `Content-Length` field in request header. This value is bigger that actual file size by +/- 500B.
In my opinion this error margin is acceptable - in most scenarios the limit will be set to megabytes, so even if the other values in request were 1 kB, the margin of error would be less that 0.1%

**Test plan**
<!-- Explain how to test your changes -->
Change values of `max_upload_size` in config and try to upload a file.

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #9 
