### PR TITLE
CI: Fixed e2e container names and Cypress videos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,7 +200,7 @@ jobs:
         run: |
           docker-compose -f docker-compose-e2e.yml up -d web-tests
           docker-compose -f docker-compose-e2e.yml logs -f -t web-tests
-          ([ $(docker wait mwdb_core_web_tests) == 0 ])
+          ([ $(docker wait mwdb_core_e2e_web_tests) == 0 ])
       - name: Job failed - storing videos from e2e tests
         if: ${{ failure() }}
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,7 +162,7 @@ jobs:
         run: |
           docker-compose -f docker-compose-e2e.yml up -d mwdb-tests
           docker-compose -f docker-compose-e2e.yml logs -f -t mwdb-tests
-          ([ $(docker wait mwdb-core_mwdb-tests_1) == 0 ])
+          ([ $(docker wait mwdb_core_e2e_tests) == 0 ])
       - name: Job failed - storing application logs
         if: ${{ failure() }}
         run: |
@@ -200,7 +200,17 @@ jobs:
         run: |
           docker-compose -f docker-compose-e2e.yml up -d web-tests
           docker-compose -f docker-compose-e2e.yml logs -f -t web-tests
-          ([ $(docker wait mwdb-core_web-tests_1) == 0 ])
+          ([ $(docker wait mwdb_core_web_tests) == 0 ])
+      - name: Job failed - storing videos from e2e tests
+        if: ${{ failure() }}
+        run: |
+          docker cp mwdb_core_e2e_web_tests:/app/cypress/videos ./artifacts
+      - name: Job failed - upload application logs
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: mwdb-e2e-web-videos
+          path: artifacts
   push_images:
     needs: [test_backend_e2e, test_frontend_e2e]
     name: Push images on Docker Hub

--- a/docker-compose-e2e.yml
+++ b/docker-compose-e2e.yml
@@ -40,12 +40,14 @@ services:
   postgres:
     image: postgres
     restart: always
+    container_name: mwdb_core_e2e_postgres
     environment:
       POSTGRES_USER: mwdb
       POSTGRES_DB: mwdb
       POSTGRES_PASSWORD: e2e-postgres-password
   mwdb-tests:
     build: tests/backend
+    container_name: mwdb_core_e2e_tests
     depends_on:
       - mwdb
       - mwdb-web
@@ -61,6 +63,7 @@ services:
       MWDB_URL: http://mwdb-web./api
   web-tests:
     build: tests/frontend
+    container_name: mwdb_core_e2e_web_tests
     depends_on:
       - mwdb
       - mwdb-web

--- a/tests/frontend/cypress/integration/blob.js
+++ b/tests/frontend/cypress/integration/blob.js
@@ -32,7 +32,7 @@ describe("Blob view test - mwdb-core", function () {
 
     browserLogin(Cypress.env("user"), Cypress.env("password"));
 
-    cy.contains("Blobs").click({ force: true });
+    cy.contains("Blobs").click({ timeout: 10000 });
 
     cy.get("@blobId").then((blobId) => {
       cy.get('.d-none a[href*="' + blobId + '"] > div').click();


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).

**What is behaviour?**
<!-- Explain how the code works currently -->
- Cypress videos are extracted into CI artifacts when web-tests fail
- Added fixed `container_name`s for e2e postgres, tests and web-tests containers
