### PR TITLE
CI: Bump deprecated actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install dev dependencies
         working-directory: mwdb/web
         run: npm install --only dev
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
@@ -61,7 +61,7 @@ jobs:
       DOCKER_BUILDKIT: 1
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
@@ -88,7 +88,7 @@ jobs:
       DOCKER_BUILDKIT: 1
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
@@ -115,7 +115,7 @@ jobs:
       DOCKER_BUILDKIT: 1
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
@@ -143,7 +143,7 @@ jobs:
       DOCKER_BUILDKIT: 1
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Download all artifacts
         uses: actions/download-artifact@v2
       - name: Import images
@@ -181,7 +181,7 @@ jobs:
       DOCKER_BUILDKIT: 1
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Download all artifacts
         uses: actions/download-artifact@v2
       - name: Import images
@@ -218,7 +218,7 @@ jobs:
     if: ${{ github.event_name == 'push' }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
@@ -274,7 +274,7 @@ jobs:
       DOCKER_BUILDKIT: 1
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
             type=registry,ref=certpl/mwdb:buildcache
           outputs: type=docker,dest=./mwdb-image
       - name: Upload mwdb-core image
-        uses: actions/upload-artifact@v2 
+        uses: actions/upload-artifact@v3
         with:
           name: mwdb-image
           path: mwdb-image
@@ -77,7 +77,7 @@ jobs:
             type=registry,ref=certpl/mwdb-web:buildcache
           outputs: type=docker,dest=./mwdb-web-image
       - name: Upload mwdb-core web image
-        uses: actions/upload-artifact@v2 
+        uses: actions/upload-artifact@v3
         with:
           name: mwdb-web-image
           path: mwdb-web-image
@@ -104,7 +104,7 @@ jobs:
             type=registry,ref=certpl/mwdb-tests:buildcache
           outputs: type=docker,dest=./mwdb-tests-image
       - name: Upload test image
-        uses: actions/upload-artifact@v2 
+        uses: actions/upload-artifact@v3
         with:
           name: mwdb-tests-image
           path: mwdb-tests-image
@@ -131,7 +131,7 @@ jobs:
             type=registry,ref=certpl/mwdb-web-tests:buildcache
           outputs: type=docker,dest=./mwdb-web-tests-image
       - name: Upload test image
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: mwdb-web-tests-image
           path: mwdb-web-tests-image
@@ -145,7 +145,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
       - name: Download all artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
       - name: Import images
         run: |
           docker load --input ./mwdb-image/mwdb-image
@@ -169,7 +169,7 @@ jobs:
           docker-compose -f docker-compose-e2e.yml logs --no-color -t mwdb > ./mwdb-e2e-logs
       - name: Job failed - upload application logs
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: mwdb-e2e-logs
           path: mwdb-e2e-logs
@@ -183,7 +183,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
       - name: Download all artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
       - name: Import images
         run: |
           docker load --input ./mwdb-image/mwdb-image
@@ -207,7 +207,7 @@ jobs:
           docker cp mwdb_core_e2e_web_tests:/app/cypress/videos ./artifacts
       - name: Job failed - upload application logs
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: mwdb-e2e-web-videos
           path: artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,11 +35,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Build and push mwdb-core image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           file: ./deploy/docker/Dockerfile
           tags: |
@@ -63,11 +63,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Build and push mwdb-core web image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           file: ./deploy/docker/Dockerfile-web
           tags: |
@@ -90,11 +90,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Build and push mwdb-tests image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           file: ./tests/backend/Dockerfile
           context: tests/backend
@@ -117,11 +117,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Build and push mwdb-web-tests image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           file: ./tests/frontend/Dockerfile
           context: tests/frontend
@@ -220,16 +220,16 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build and push mwdb-core image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           file: ./deploy/docker/Dockerfile
           tags: |
@@ -241,7 +241,7 @@ jobs:
             type=registry,ref=certpl/mwdb:buildcache,mode=max
           push: true
       - name: Build and push mwdb-core web-source image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           file: ./deploy/docker/Dockerfile-web
           target: build
@@ -254,7 +254,7 @@ jobs:
             type=registry,ref=certpl/mwdb-web-source:buildcache,mode=max
           push: true
       - name: Build and push mwdb-core web image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           file: ./deploy/docker/Dockerfile-web
           tags: |
@@ -276,16 +276,16 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build and push mwdb-tests image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           file: ./tests/backend/Dockerfile
           context: tests/backend
@@ -298,7 +298,7 @@ jobs:
             type=registry,ref=certpl/mwdb-tests:buildcache,mode=max
           push: true
       - name: Build and push mwdb-web-tests image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           file: ./tests/frontend/Dockerfile
           context: tests/frontend

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,16 +32,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build and push mwdb-core image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           file: ./deploy/docker/Dockerfile
           tags: |
@@ -52,7 +52,7 @@ jobs:
           push: true
           context: .
       - name: Build and push mwdb-core web image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           file: ./deploy/docker/Dockerfile-web
           tags: |
@@ -63,7 +63,7 @@ jobs:
           push: true
           context: .
       - name: Build and push mwdb-core web-source image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           file: ./deploy/docker/Dockerfile-web
           target: build
@@ -75,7 +75,7 @@ jobs:
           push: true
           context: .
       - name: Build and push mwdb-tests image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           file: ./tests/backend/Dockerfile
           context: tests/backend
@@ -86,7 +86,7 @@ jobs:
             type=registry,ref=certpl/mwdb-tests:buildcache
           push: true
       - name: Build and push mwdb-web-tests image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           file: ./tests/frontend/Dockerfile
           context: tests/frontend

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
   release_pypi:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js 12.x
         uses: actions/setup-node@v1
         with:
@@ -30,7 +30,7 @@ jobs:
   release_docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the new behaviour?**

There are lots of deprecation warnings in Actions tab due to obsolete action versions. Bumped most of them to the latest version to fix that issue.

Not all of them are fixed, see https://github.com/CERT-Polska/lint-python-action/pull/6