### PR TITLE
Don't query ObjectPermission table when user has access_all_objects capability

### DIFF
--- a/docker-compose-e2e.yml
+++ b/docker-compose-e2e.yml
@@ -93,7 +93,7 @@ services:
     ports:
       - "127.0.0.1:8025:8025"
   karton-system:
-    image: certpl/karton-system:v5.0.0
+    image: certpl/karton-system:v5.1.0
     depends_on:
       - redis
       - minio
@@ -102,14 +102,14 @@ services:
     entrypoint: karton-system
     command: --setup-bucket
   karton-classifier:
-    image: certpl/karton-classifier:v1.4.0
+    image: certpl/karton-classifier:v2.0.0
     depends_on:
       - redis
       - minio
     volumes:
       - "./dev/karton.ini:/etc/karton/karton.ini"
   karton-dashboard:
-    image: certpl/karton-dashboard:v1.4.0
+    image: certpl/karton-dashboard:v1.5.0
     depends_on:
       - redis
       - minio
@@ -118,7 +118,7 @@ services:
     ports:
       - "127.0.0.1:8030:5000"
   karton-mwdb-reporter:
-    image: certpl/karton-mwdb-reporter:v1.2.0
+    image: certpl/karton-mwdb-reporter:v1.3.0
     depends_on:
       - redis
       - minio

--- a/mwdb/cli/database.py
+++ b/mwdb/cli/database.py
@@ -24,13 +24,6 @@ def _initialize(admin_password):
     )
     db.session.add(public_group)
 
-    everything_group = Group(
-        name=Group.DEFAULT_EVERYTHING_GROUP_NAME,
-        capabilities=[Capabilities.access_all_objects],
-        workspace=False,
-    )
-    db.session.add(everything_group)
-
     registered_group = Group(
         name=Group.DEFAULT_REGISTERED_GROUP_NAME,
         capabilities=[
@@ -52,7 +45,7 @@ def _initialize(admin_password):
         login=app_config.mwdb.admin_login,
         email="admin@mwdb.local",
         additional_info="MWDB built-in administrator account",
-        groups=[admin_group, everything_group, public_group, registered_group],
+        groups=[admin_group, public_group, registered_group],
     )
     admin_user.reset_sessions()
     admin_user.set_password(admin_password)

--- a/mwdb/model/group.py
+++ b/mwdb/model/group.py
@@ -47,7 +47,6 @@ class Group(db.Model):
 
     PUBLIC_GROUP_NAME = "public"
     # These groups are just pre-created for convenience by 'mwdb-core configure'
-    DEFAULT_EVERYTHING_GROUP_NAME = "everything"
     DEFAULT_REGISTERED_GROUP_NAME = "registered"
 
     @property

--- a/mwdb/model/migrations/versions/6a7aefae72d3_rolling_back_objectpermissions_from_.py
+++ b/mwdb/model/migrations/versions/6a7aefae72d3_rolling_back_objectpermissions_from_.py
@@ -1,0 +1,65 @@
+"""Rolling back ObjectPermissions from access_all_objects
+
+Revision ID: 6a7aefae72d3
+Revises: f02c42a17695
+Create Date: 2023-06-22 14:19:34.730831
+
+"""
+import logging
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql.array import ARRAY
+
+# revision identifiers, used by Alembic.
+revision = "6a7aefae72d3"
+down_revision = "f02c42a17695"
+branch_labels = None
+depends_on = None
+
+group_helper = sa.Table(
+    "group",
+    sa.MetaData(),
+    sa.Column("id", sa.Integer()),
+    sa.Column("name", sa.String(32)),
+    sa.Column("capabilities", ARRAY(sa.Text())),
+    sa.Column("private", sa.Boolean()),
+    sa.Column("default", sa.Boolean()),
+    sa.Column("workspace", sa.Boolean()),
+)
+
+object_perm_helper = sa.Table(
+    "permission",
+    sa.MetaData(),
+    sa.Column("object_id", sa.Integer()),
+    sa.Column("group_id", sa.Integer()),
+    sa.Column("reason_type", sa.String(32)),
+)
+
+logger = logging.getLogger("alembic")
+
+
+def upgrade():
+    connection = op.get_bind()
+    access_all_objects_groups = connection.execute(
+        group_helper.select().where(
+            group_helper.c.capabilities.any("access_all_objects")
+        )
+    )
+    for group in access_all_objects_groups:
+        logger.info(f"Removing unnecessary rows access_all_objects group: {group.name}")
+        rowcount = connection.execute(
+            object_perm_helper.delete(
+                sa.and_(
+                    object_perm_helper.c.group_id == group.id,
+                    object_perm_helper.c.reason_type == "shared",
+                )
+            )
+        ).rowcount
+        logger.info(f"{rowcount} rows removed")
+    logger.info("Running analyze...")
+    connection.execute("ANALYZE")
+
+
+def downgrade():
+    raise NotImplementedError("This migration is not downgradable")

--- a/mwdb/model/object.py
+++ b/mwdb/model/object.py
@@ -585,7 +585,7 @@ class Object(db.Model):
 
         We don't perform permission checks, all data needs to be validated by Resource.
         """
-        from .group import Group
+        # from .group import Group
 
         share_with = share_with or []
         attributes = attributes or []

--- a/mwdb/model/object.py
+++ b/mwdb/model/object.py
@@ -540,11 +540,14 @@ class Object(db.Model):
             )
         ).scalar()
 
-    def check_group_explicit_access(self, group):  # This function is not used anywhere
+    def check_group_explicit_access(self, group):
         """
         Check whether group has access via explicit ObjectPermissions
         Used by Object.access
         """
+        if Capabilities.access_all_objects in group.capabilities:
+            return True
+
         return db.session.query(
             exists().where(
                 and_(
@@ -585,7 +588,6 @@ class Object(db.Model):
 
         We don't perform permission checks, all data needs to be validated by Resource.
         """
-        # from .group import Group
 
         share_with = share_with or []
         attributes = attributes or []
@@ -645,16 +647,6 @@ class Object(db.Model):
                     g.auth_user,
                     commit=False,
                 )
-
-        # Share with all groups that access all objects
-        # for all_access_group in Group.all_access_groups():
-        #     created_object.give_access(
-        #         all_access_group.id,
-        #         AccessType.SHARED,
-        #         created_object,
-        #         g.auth_user,
-        #         commit=False,
-        #     )
 
         # Add parent to object if specified
         # Inherited share entries must be added AFTER we add share entries

--- a/mwdb/model/object.py
+++ b/mwdb/model/object.py
@@ -251,7 +251,7 @@ class ObjectPermission(db.Model):
         """
         if include_inherited_uploads:
             type_filter = or_(
-                ObjectPermission.reason_type != "added",
+                ObjectPermission.reason_type != AccessType.ADDED,
                 ObjectPermission.related_object_id != ObjectPermission.object_id,
             )
         else:

--- a/mwdb/model/object.py
+++ b/mwdb/model/object.py
@@ -251,7 +251,7 @@ class ObjectPermission(db.Model):
         """
         if include_inherited_uploads:
             type_filter = or_(
-                ObjectPermission.reason_type != "added",
+                ObjectPermission.reason_type != AccessType.ADDED,
                 ObjectPermission.related_object_id != ObjectPermission.object_id,
             )
         else:
@@ -528,6 +528,9 @@ class Object(db.Model):
         Check whether user has access via explicit ObjectPermissions
         Used by Object.access
         """
+        if user.has_rights(Capabilities.access_all_objects):
+            return True
+
         return db.session.query(
             exists().where(
                 and_(
@@ -537,7 +540,7 @@ class Object(db.Model):
             )
         ).scalar()
 
-    def check_group_explicit_access(self, group):
+    def check_group_explicit_access(self, group):  # This function is not used anywhere
         """
         Check whether group has access via explicit ObjectPermissions
         Used by Object.access

--- a/mwdb/model/object.py
+++ b/mwdb/model/object.py
@@ -281,7 +281,7 @@ class Object(db.Model):
                 ObjectPermission.reason_type == AccessType.ADDED,
             )
         ),
-        deferred=True,
+        deferred=False,
     )
 
     __mapper_args__ = {"polymorphic_identity": "object", "polymorphic_on": type}

--- a/mwdb/model/object.py
+++ b/mwdb/model/object.py
@@ -251,7 +251,7 @@ class ObjectPermission(db.Model):
         """
         if include_inherited_uploads:
             type_filter = or_(
-                ObjectPermission.reason_type != AccessType.ADDED,
+                ObjectPermission.reason_type != "added",
                 ObjectPermission.related_object_id != ObjectPermission.object_id,
             )
         else:

--- a/mwdb/model/object.py
+++ b/mwdb/model/object.py
@@ -647,14 +647,14 @@ class Object(db.Model):
                 )
 
         # Share with all groups that access all objects
-        for all_access_group in Group.all_access_groups():
-            created_object.give_access(
-                all_access_group.id,
-                AccessType.SHARED,
-                created_object,
-                g.auth_user,
-                commit=False,
-            )
+        # for all_access_group in Group.all_access_groups():
+        #     created_object.give_access(
+        #         all_access_group.id,
+        #         AccessType.SHARED,
+        #         created_object,
+        #         g.auth_user,
+        #         commit=False,
+        #     )
 
         # Add parent to object if specified
         # Inherited share entries must be added AFTER we add share entries

--- a/mwdb/model/object.py
+++ b/mwdb/model/object.py
@@ -281,7 +281,7 @@ class Object(db.Model):
                 ObjectPermission.reason_type == AccessType.ADDED,
             )
         ),
-        deferred=False,
+        deferred=True,
     )
 
     __mapper_args__ = {"polymorphic_identity": "object", "polymorphic_on": type}

--- a/mwdb/model/user.py
+++ b/mwdb/model/user.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm.exc import NoResultFound
 
 from mwdb.core.auth import AuthScope, generate_token, verify_legacy_token, verify_token
+from mwdb.core.capabilities import Capabilities
 
 from . import db
 from .group import Group, Member
@@ -257,6 +258,9 @@ class User(db.Model):
         """
         Query filter for objects visible by this user
         """
+        if self.has_rights(Capabilities.access_all_objects):
+            return True
+
         return object_id.in_(
             db.session.query(ObjectPermission.object_id).filter(
                 self.is_member(ObjectPermission.group_id)

--- a/mwdb/model/user.py
+++ b/mwdb/model/user.py
@@ -10,7 +10,6 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from mwdb.core.auth import AuthScope, generate_token, verify_legacy_token, verify_token
 from mwdb.core.capabilities import Capabilities
-from mwdb.core.log import getLogger
 
 from . import db
 from .group import Group, Member
@@ -259,9 +258,7 @@ class User(db.Model):
         """
         Query filter for objects visible by this user
         """
-        getLogger().warning(f"\nAAA {self.login}\n")
         if self.has_rights(Capabilities.access_all_objects):
-            getLogger().warning(f"\nBBB {self.login}\n")
             return True
 
         return object_id.in_(

--- a/mwdb/model/user.py
+++ b/mwdb/model/user.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from mwdb.core.auth import AuthScope, generate_token, verify_legacy_token, verify_token
 from mwdb.core.capabilities import Capabilities
+from mwdb.core.log import getLogger
 
 from . import db
 from .group import Group, Member
@@ -258,7 +259,9 @@ class User(db.Model):
         """
         Query filter for objects visible by this user
         """
+        getLogger().warning(f"\nAAA {self.login}\n")
         if self.has_rights(Capabilities.access_all_objects):
+            getLogger().warning(f"\nBBB {self.login}\n")
             return True
 
         return object_id.in_(

--- a/mwdb/resources/tag.py
+++ b/mwdb/resources/tag.py
@@ -1,12 +1,11 @@
 from flask import g, request
 from flask_restful import Resource
-from sqlalchemy.sql import and_
 from werkzeug.exceptions import NotFound
 
 from mwdb.core.capabilities import Capabilities
 from mwdb.core.plugins import hooks
 from mwdb.core.rate_limit import rate_limited_resource
-from mwdb.model import ObjectPermission, Tag, db
+from mwdb.model import Object, Tag, db
 from mwdb.schema.tag import (
     TagItemResponseSchema,
     TagListRequestSchema,
@@ -61,17 +60,11 @@ class TagListResource(Resource):
         schema = TagListRequestSchema()
         obj = load_schema(request.args, schema)
 
-        # changes here?
         tags = (
             db.session.query(Tag.tag)
             .distinct(Tag.tag)
-            .join(
-                ObjectPermission,
-                and_(
-                    ObjectPermission.object_id == Tag.object_id,
-                    g.auth_user.is_member(ObjectPermission.group_id),
-                ),
-            )
+            .join(Tag.object)
+            .filter(g.auth_user.has_access_to_object(Object.id))
         )
 
         tag_prefix = obj["query"]

--- a/mwdb/resources/tag.py
+++ b/mwdb/resources/tag.py
@@ -61,6 +61,7 @@ class TagListResource(Resource):
         schema = TagListRequestSchema()
         obj = load_schema(request.args, schema)
 
+        # changes here?
         tags = (
             db.session.query(Tag.tag)
             .distinct(Tag.tag)

--- a/mwdb/resources/tag.py
+++ b/mwdb/resources/tag.py
@@ -5,7 +5,7 @@ from werkzeug.exceptions import NotFound
 from mwdb.core.capabilities import Capabilities
 from mwdb.core.plugins import hooks
 from mwdb.core.rate_limit import rate_limited_resource
-from mwdb.model import Object, Tag, db
+from mwdb.model import Tag, db
 from mwdb.schema.tag import (
     TagItemResponseSchema,
     TagListRequestSchema,
@@ -63,8 +63,7 @@ class TagListResource(Resource):
         tags = (
             db.session.query(Tag.tag)
             .distinct(Tag.tag)
-            .join(Tag.object)
-            .filter(g.auth_user.has_access_to_object(Object.id))
+            .filter(g.auth_user.has_access_to_object(Tag.object_id))
         )
 
         tag_prefix = obj["query"]

--- a/tests/backend/test_blobs.py
+++ b/tests/backend/test_blobs.py
@@ -1,6 +1,5 @@
 from .relations import *
 from .utils import random_name, rand_string
-from mwdb.core.log import getLogger
 
 
 def test_adding_blobs(admin_session):
@@ -116,7 +115,6 @@ def test_blob_search_multi(admin_session):
 
 
 def test_blob_search_upload_count(admin_session):
-    getLogger().warning("\ntest_blob_search_upload_count\n")
     blob_name = rand_string(15)
     blob_content = """
     TESTTESTTESTTESTTESTTESTTESTTESTTESTTEST
@@ -141,7 +139,8 @@ def test_blob_search_upload_count(admin_session):
         blob = users_session.add_blob(None, blobname=blob_name, blobtype="inject", content=blob_content)
         users_session.add_tag(blob["id"], tag)
 
-    getLogger().warning("\n" + str(found_configs) + "\n")
+    found_configs = admin_session.search(f'tag:{tag}')
+    assert len(found_configs) == 1
 
     found_configs = admin_session.search(f'tag:{tag} AND blob.upload_count:{len(test_users)}')
     assert len(found_configs) == 1

--- a/tests/backend/test_blobs.py
+++ b/tests/backend/test_blobs.py
@@ -1,6 +1,5 @@
 from .relations import *
 from .utils import random_name, rand_string
-from time import sleep
 
 
 def test_adding_blobs(admin_session):
@@ -142,8 +141,6 @@ def test_blob_search_upload_count(admin_session):
 
     found_configs = admin_session.search(f'tag:{tag}')
     assert len(found_configs) == 1
-
-    sleep(1)
 
     found_configs = admin_session.search(f'tag:{tag} AND blob.upload_count:{len(test_users)}')
     assert len(found_configs) == 1

--- a/tests/backend/test_blobs.py
+++ b/tests/backend/test_blobs.py
@@ -139,7 +139,7 @@ def test_blob_search_upload_count(admin_session):
         blob = users_session.add_blob(None, blobname=blob_name, blobtype="inject", content=blob_content)
         users_session.add_tag(blob["id"], tag)
 
-    found_configs = admin_session.search(f'name:{blob_name} AND blob.upload_count:{len(test_users)}')
+    found_configs = admin_session.search(f'blob.name:{blob_name} AND blob.upload_count:{len(test_users)}')
     assert len(found_configs) == 1
 
     found_configs = users_session.search(f'tag:{tag} AND blob.upload_count:[{len(test_users)} TO *]')

--- a/tests/backend/test_blobs.py
+++ b/tests/backend/test_blobs.py
@@ -139,7 +139,7 @@ def test_blob_search_upload_count(admin_session):
         blob = users_session.add_blob(None, blobname=blob_name, blobtype="inject", content=blob_content)
         users_session.add_tag(blob["id"], tag)
 
-    found_configs = admin_session.search(f'blob.name:{blob_name} AND blob.upload_count:{len(test_users)}')
+    found_configs = admin_session.search(f'tag:{tag} AND blob.upload_count:{len(test_users)}')
     assert len(found_configs) == 1
 
     found_configs = users_session.search(f'tag:{tag} AND blob.upload_count:[{len(test_users)} TO *]')

--- a/tests/backend/test_blobs.py
+++ b/tests/backend/test_blobs.py
@@ -1,5 +1,6 @@
 from .relations import *
 from .utils import random_name, rand_string
+from mwdb.core.log import getLogger
 
 
 def test_adding_blobs(admin_session):
@@ -115,6 +116,7 @@ def test_blob_search_multi(admin_session):
 
 
 def test_blob_search_upload_count(admin_session):
+    getLogger().warning("\ntest_blob_search_upload_count\n")
     blob_name = rand_string(15)
     blob_content = """
     TESTTESTTESTTESTTESTTESTTESTTESTTESTTEST
@@ -138,6 +140,8 @@ def test_blob_search_upload_count(admin_session):
         users_session.login_as(user['user_name'], user['user_password'])
         blob = users_session.add_blob(None, blobname=blob_name, blobtype="inject", content=blob_content)
         users_session.add_tag(blob["id"], tag)
+
+    getLogger().warning("\n" + str(found_configs) + "\n")
 
     found_configs = admin_session.search(f'tag:{tag} AND blob.upload_count:{len(test_users)}')
     assert len(found_configs) == 1

--- a/tests/backend/test_blobs.py
+++ b/tests/backend/test_blobs.py
@@ -139,7 +139,7 @@ def test_blob_search_upload_count(admin_session):
         blob = users_session.add_blob(None, blobname=blob_name, blobtype="inject", content=blob_content)
         users_session.add_tag(blob["id"], tag)
 
-    found_configs = admin_session.search(f'tag:{tag} AND blob.upload_count:{len(test_users)}')
+    found_configs = admin_session.search(f'name:{blob_name} AND blob.upload_count:{len(test_users)}')
     assert len(found_configs) == 1
 
     found_configs = users_session.search(f'tag:{tag} AND blob.upload_count:[{len(test_users)} TO *]')

--- a/tests/backend/test_blobs.py
+++ b/tests/backend/test_blobs.py
@@ -1,5 +1,6 @@
 from .relations import *
 from .utils import random_name, rand_string
+from time import sleep
 
 
 def test_adding_blobs(admin_session):
@@ -141,6 +142,8 @@ def test_blob_search_upload_count(admin_session):
 
     found_configs = admin_session.search(f'tag:{tag}')
     assert len(found_configs) == 1
+
+    sleep(1)
 
     found_configs = admin_session.search(f'tag:{tag} AND blob.upload_count:{len(test_users)}')
     assert len(found_configs) == 1


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [X] I've read the [contributing guideline](CONTRIBUTING.md).
- [ ] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
When new sample is added, we add new entry in `ObjectPermission` table for every user with `access_all_objects` capability
This causes that we have many unnecessary rows in this table and MWDB works slower
Additionally, it's harder to revoke access to objects, when user loses the `access_all_objects` capability

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
Instead of adding new rows in `ObjectPermission`, check if user has `access_all_objects` capability when querying
When user loses `access_all_objects` capability, they lose access to them (applies only in cases, when access to object is granted only by this capability) 

**Test plan**
<!-- Explain how to test your changes -->
Under development

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #758 
