### PR TITLE
CI: Fix context in push_test_images workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -363,7 +363,6 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           file: ./deploy/docker/Dockerfile-web-unit-test
-          context: mwdb/web
           tags: |
             certpl/mwdb-web-unit-tests:${{ github.sha }}
             certpl/mwdb-web-unit-tests:master


### PR DESCRIPTION
**What is the current behaviour?**
<!-- Explain how the code works currently -->

- CI fails on `master` because of wrong context for one of push tasks

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- Removed `context` field to use source root as a context as expected
