### PR TITLE
Use resolve.alias instead of custom resolver for @mwdb-web

### DIFF
--- a/mwdb/web/vite.config.ts
+++ b/mwdb/web/vite.config.ts
@@ -64,7 +64,7 @@ export default defineConfig({
     resolve: {
         alias: [
             {
-                find: /^@mwdb-web(?!\/plugins)/,
+                find: /^@mwdb-web(?!\/(plugins$|plugin-))/,
                 replacement: resolve(__dirname, "./src")
             }
         ]

--- a/mwdb/web/vite.config.ts
+++ b/mwdb/web/vite.config.ts
@@ -55,12 +55,19 @@ export default defineConfig({
             typescript: true,
         }),
     ],
-    // Expose mwdb/web/src as @mwdb-web to make it
-    // reachable for plugins
+    /**
+     * Expose mwdb/web/src as @mwdb-web to make it
+     * reachable for plugins. The only thing that must
+     * be excluded from that aliasing is @mwdb-web/plugins
+     * that is virtual package provided by pluginLoader.
+     */
     resolve: {
-        alias: {
-            "@mwdb-web": resolve(__dirname, "./src")
-        },
+        alias: [
+            {
+                find: /^@mwdb-web(?!\/plugins)/,
+                replacement: resolve(__dirname, "./src")
+            }
+        ]
     },
     server: {
         host: "0.0.0.0",

--- a/mwdb/web/vite.config.ts
+++ b/mwdb/web/vite.config.ts
@@ -3,7 +3,7 @@ import react from "@vitejs/plugin-react";
 import checker from "vite-plugin-checker";
 
 import fs from "fs";
-import { join } from "path";
+import { join, resolve } from "path";
 
 function findInstalledPlugins(namespace) {
     const modulesDir = join(__dirname, "node_modules", namespace);
@@ -47,46 +47,21 @@ function pluginLoader() {
     };
 }
 
-function pluginExposeCommons() {
-    /**
-     * Vite plugin that provides virtual module "@mwdb-web/commons/*".
-     *
-     * It maps src/commons modules to virtual package, so they're
-     * available for plugins via simple import.
-     */
-
-    return {
-        name: "expose-commons",
-        resolveId(id) {
-            if (id.startsWith("@mwdb-web/commons/")) {
-                return "\0" + id;
-            }
-        },
-        load(id) {
-            if (id.startsWith("\0@mwdb-web/commons/")) {
-                const modulesPath = id.split("/");
-                if (modulesPath.length !== 3) {
-                    throw new Error(
-                        `Incorrect commons import '${id}', only one level deep allowed`
-                    );
-                }
-                const submodule = modulesPath[2];
-                const submodulePath = join(__dirname, "src/commons", submodule);
-                return `export * from "${submodulePath}";`;
-            }
-        },
-    };
-}
-
 export default defineConfig({
     plugins: [
         react(),
         pluginLoader(),
-        pluginExposeCommons(),
         checker({
             typescript: true,
         }),
     ],
+    // Expose mwdb/web/src as @mwdb-web to make it
+    // reachable for plugins
+    resolve: {
+        alias: {
+            "@mwdb-web": resolve(__dirname, "./src")
+        },
+    },
     server: {
         host: "0.0.0.0",
         port: 3000,


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

I have written `@mwdb-web/commons` resolver myself and it's pretty limited (it allows only to import packages following specific export scheme)

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

I used `resolve.alias` to expose core modules under `@mwdb-web` alias making them available for plugins.

It needs to be documented in https://github.com/CERT-Polska/mwdb-core/pull/761 

**Test plan**
<!-- Explain how to test your changes -->

:heavy_check_mark: Checked for example plugin added to `docker/plugins`

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->
