### PR TITLE
Fix: Revert self-remove of manage_users capability

### DIFF
--- a/mwdb/resources/group.py
+++ b/mwdb/resources/group.py
@@ -228,8 +228,6 @@ class GroupResource(Resource):
             db.session.query(Group).filter(Group.name == group_name_obj["name"]).first()
         )
 
-        user = g.auth_user
-
         if group is None:
             raise NotFound("No such group")
 
@@ -243,13 +241,6 @@ class GroupResource(Resource):
             group.name = obj["name"]
 
         if obj["capabilities"] is not None:
-            if (
-                user.login == group.name
-                and Capabilities.manage_users not in obj["capabilities"]
-            ):
-                raise Forbidden(
-                    f"Can't remove '{Capabilities.manage_users }', yourself"
-                )
             group.capabilities = obj["capabilities"]
 
         if obj["default"] is not None:


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

Described https://github.com/CERT-Polska/mwdb-core/issues/839.

Current permission model is too complex to check if user actually removes `manage_users` permission from themselves.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

Restriction is removed.

**Test plan**
<!-- Explain how to test your changes -->

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #839
