### PR TITLE
Web: types for plugins loader, removed circular dependency

### DIFF
--- a/mwdb/web/src/commons/plugins/Extension.tsx
+++ b/mwdb/web/src/commons/plugins/Extension.tsx
@@ -1,4 +1,4 @@
-import { fromPlugins } from ".";
+import { fromPlugins } from "./loader";
 
 type Props = {
     [extensionProp: string]: any;

--- a/mwdb/web/src/commons/plugins/index.jsx
+++ b/mwdb/web/src/commons/plugins/index.jsx
@@ -1,38 +1,3 @@
-import _ from "lodash";
-import pluginLoaders from "@mwdb-web/plugins";
-
 export { Extension } from "./Extension";
 export { Extendable } from "./Extendable";
-
-let loadedPlugins = {};
-let pluginsLoadedCallbacks = [];
-
-export async function loadPlugins() {
-    let plugins = {};
-    for (const [pluginName, pluginModulePromise] of Object.entries(
-        pluginLoaders
-    )) {
-        try {
-            // await import("@mwdb-core/plugin-xyz")
-            const pluginModule = (await pluginModulePromise).default;
-            plugins[pluginName] = pluginModule();
-        } catch (e) {
-            console.error(`Plugin ${pluginName} failed to load`, e);
-        }
-    }
-    // Hacky but I want to avoid top-level await
-    loadedPlugins = plugins;
-    pluginsLoadedCallbacks.map((callback) => callback());
-}
-
-export function afterPluginsLoaded(callback) {
-    pluginsLoadedCallbacks.push(callback);
-}
-
-export function fromPlugins(element) {
-    return _.flatten(
-        Object.keys(loadedPlugins).map(
-            (name) => loadedPlugins[name][element] || []
-        )
-    );
-}
+export { loadPlugins, afterPluginsLoaded, fromPlugins } from "./loader";

--- a/mwdb/web/src/commons/plugins/loader.tsx
+++ b/mwdb/web/src/commons/plugins/loader.tsx
@@ -1,0 +1,43 @@
+import _ from "lodash";
+// @ts-ignore
+import pluginLoaders from "@mwdb-web/plugins";
+
+type PluginSpec = { [element: string]: any[] };
+type Plugins = { [pluginName: string]: PluginSpec };
+
+type PluginLoader = { default: () => PluginSpec };
+type PluginLoaderPromise = Promise<PluginLoader>;
+type PluginLoaders = { [pluginName: string]: PluginLoaderPromise };
+
+let loadedPlugins: Plugins = {};
+let pluginsLoadedCallbacks: Array<() => void> = [];
+
+export async function loadPlugins(): Promise<void> {
+    let plugins: Plugins = {};
+    for (const [pluginName, pluginModulePromise] of Object.entries(
+        pluginLoaders as PluginLoaders
+    )) {
+        try {
+            // await import("@mwdb-core/plugin-xyz")
+            const pluginModule = (await pluginModulePromise).default;
+            plugins[pluginName] = pluginModule();
+        } catch (e) {
+            console.error(`Plugin ${pluginName} failed to load`, e);
+        }
+    }
+    // Hacky but I want to avoid top-level await
+    loadedPlugins = plugins;
+    pluginsLoadedCallbacks.map((callback) => callback());
+}
+
+export function afterPluginsLoaded(callback: () => void): void {
+    pluginsLoadedCallbacks.push(callback);
+}
+
+export function fromPlugins(element: string): any[] {
+    return _.flatten(
+        Object.keys(loadedPlugins).map(
+            (name) => loadedPlugins[name][element] || []
+        )
+    );
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the new behaviour?**
<!-- Explain how the code works currently -->

Fixed warning:
```
#23 47.02 ✓ 3132 modules transformed.
#23 47.16 Export "Extension" of module "src/commons/plugins/Extension.tsx" was reexported through module "src/commons/plugins/index.jsx" while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.
#23 47.16 Either change the import in "src/components/Views/UserLoginView.tsx" to point directly to the exporting module or do not use "preserveModules" to ensure these modules end up in the same chunk.
```

and added proper types to plugin loader

