### PR TITLE
Add use_x_forwarded_for option that applies ProxyFix to correctly handle X-Forwarded-For header

### DIFF
--- a/docker/mwdb.ini
+++ b/docker/mwdb.ini
@@ -9,6 +9,6 @@ local_plugins_autodiscover = 1
 request_timeout = 20000
 file_upload_timeout = 60000
 statement_timeout = 15000
-
+use_x_forwarded_for = 1
 
 [mwdb_limiter]

--- a/docs/setup-and-configuration.rst
+++ b/docs/setup-and-configuration.rst
@@ -278,6 +278,7 @@ Web application settings:
 * ``flask_config_file`` (string) - additional file containing Flask configuration (.py)
 * ``admin_login`` (string) - administrator account name
 * ``admin_password`` (string) - initial password for administrator account
+* ``use_x_forwarded_for`` (0 or 1) - Set this to 1 if MWDB backend is behind reverse proxy, so X-Forwarded-For header is correctly translated to ``request.remote_addr`` value. Set by default to 1 in ``certpl/mwdb`` Docker image.
 
 
 Plugin settings:
@@ -366,3 +367,6 @@ Other endpoints are limited by default limits.
 .. note::
 
    Complete list of possible rate-limit parameters is placed in ``mwdb-core\mwdb\core\templates\mwdb.ini.tmpl`` file - section ``mwdb_limiter``.
+
+   If your MWDB instance uses standalone installation and MWDB backend is behind reverse proxy, make sure that use_x_forwarded_for is set to 1
+   and your reverse proxy correctly sets X-Forwarded-For header with real remote IP.

--- a/mwdb/app.py
+++ b/mwdb/app.py
@@ -154,6 +154,7 @@ def log_request(response):
             "status": response.status_code,
             "response_time": response_time,
             "response_size": response_size,
+            "remote_addr": request.remote_addr,
         },
     )
 

--- a/mwdb/core/app.py
+++ b/mwdb/core/app.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, Flask
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 from mwdb.core.config import app_config
 from mwdb.core.rate_limit import limiter
@@ -10,5 +11,8 @@ app.config["MAX_CONTENT_LENGTH"] = app_config.mwdb.max_upload_size
 api_blueprint = Blueprint("api", __name__, url_prefix="/api")
 api = Service(app, api_blueprint)
 app.register_blueprint(api_blueprint)
+
+if app_config.mwdb.use_x_forwarded_for:
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1)
 
 limiter.init_app(app)

--- a/mwdb/core/config.py
+++ b/mwdb/core/config.py
@@ -133,6 +133,7 @@ class MWDBConfig(Config):
     enable_json_logger = key(cast=intbool, required=False, default=False)
     enable_sql_profiler = key(cast=intbool, required=False, default=False)
     log_only_slow_sql = key(cast=intbool, required=False, default=False)
+    use_x_forwarded_for = key(cast=intbool, required=False, default=False)
 
 
 @section("karton")

--- a/mwdb/core/log.py
+++ b/mwdb/core/log.py
@@ -56,7 +56,7 @@ def setup_logger():
             " - %(message)s"
         )
     handler.setFormatter(formatter)
-    logger.addFilter(ContextFilter())
+    handler.addFilter(ContextFilter())
     logger.addHandler(handler)
     logger.setLevel(logging.INFO)
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- ~~I've added automated tests for my change (if applicable, optional)~~
- [x] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

MWDB backend ignores `X-Forwarded-For` header and `remote_addr` always points at the remote from direct connection.

It breaks rate limiting of unauthenticated requests.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

Added `use_x_forwarded_for` that optionally applies ProxyFix (https://flask.palletsprojects.com/en/2.3.x/deploying/proxy_fix/). It's set by default to 1 in `docker/mwdb.ini` file.

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #844 
