### PR TITLE
Use Karton persistent headers for 'quality' and 'share_3rd_party'

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     depends_on:
       - postgres
       - redis
-    image: certpl/mwdb:v2.9.1
+    image: certpl/mwdb:v2.10.0
     restart: on-failure
     env_file:
       # NOTE: use gen_vars.sh in order to generate this file
@@ -22,7 +22,7 @@ services:
     build:
       context: .
       dockerfile: deploy/docker/Dockerfile-web
-    image: certpl/mwdb-web:v2.9.1
+    image: certpl/mwdb-web:v2.10.0
     ports:
       - "80:80"
     restart: on-failure

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ copyright = '2021, CERT Polska'
 author = 'CERT Polska'
 
 # The full version, including alpha/beta/rc tags
-release = '2.9.1'
+release = '2.10.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/mwdb/core/karton.py
+++ b/mwdb/core/karton.py
@@ -51,6 +51,8 @@ def send_file_to_karton(file) -> str:
             headers={
                 "type": "sample",
                 "kind": "raw",
+            },
+            headers_persistent={
                 "quality": feed_quality,
                 "share_3rd_party": file.share_3rd_party,
             },
@@ -81,6 +83,8 @@ def send_config_to_karton(config) -> str:
             "type": "config",
             "kind": config.config_type,
             "family": config.family,
+        },
+        headers_persistent={
             "share_3rd_party": config.share_3rd_party,
         },
         payload={
@@ -105,6 +109,8 @@ def send_blob_to_karton(blob) -> str:
         headers={
             "type": "blob",
             "kind": blob.blob_type,
+        },
+        headers_persistent={
             "share_3rd_party": blob.share_3rd_party,
         },
         payload={

--- a/mwdb/version.py
+++ b/mwdb/version.py
@@ -4,5 +4,5 @@ try:
 except IOError:
     git_revision = ""
 
-app_version = "2.9.1"
+app_version = "2.10.0"
 app_build_version = f"{app_version}+{git_revision}" if git_revision else app_version

--- a/mwdb/web/package-lock.json
+++ b/mwdb/web/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "mwdb-web",
-    "version": "2.9.1",
+    "version": "2.10.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "mwdb-web",
-            "version": "2.9.1",
+            "version": "2.10.0",
             "dependencies": {
                 "@fortawesome/fontawesome-svg-core": "^6.1.1",
                 "@fortawesome/free-regular-svg-icons": "^6.1.1",

--- a/mwdb/web/package.json
+++ b/mwdb/web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mwdb-web",
-    "version": "2.9.1",
+    "version": "2.10.0",
     "private": true,
     "scripts": {
         "dev": "vite",

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ PyYAML==6.0.1
 redis==4.5.4
 boto3==1.24.38
 typed-config==1.1.0
-karton-core==5.1.0
+karton-core==5.2.0
 Authlib==0.15.4
 prance==0.21.8.0  # apispec unpinned dependency
 pyJWT==2.4.0

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ Under the hood of mwdb.cert.pl service hosted by CERT.pl.
 """
 
 setup(name="mwdb-core",
-      version="2.9.1",
+      version="2.10.0",
       description="MWDB Core malware database",
       long_description=LONG_DESCRIPTION,
       author="CERT Polska",


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- `quality` and `share_3rd_party` headers must be explicitly proxied by all Karton services in pipeline

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- Using new Persistent headers feature from v5.2.0 to make headers that will apply to whole analysis.

