### PR TITLE
Fix renderTokens: options were not always passed to next recursive call

### DIFF
--- a/mwdb/web/src/commons/helpers/renderTokens.tsx
+++ b/mwdb/web/src/commons/helpers/renderTokens.tsx
@@ -114,12 +114,18 @@ export function renderTokens(tokens: Token[], options?: Option): any {
         list(token: Token) {
             return (
                 <ul key={uniqueId()} style={{ margin: "0" }}>
-                    {token.items?.map((item: Token) => renderTokens([item]))}
+                    {token.items?.map((item: Token) =>
+                        renderTokens([item], options)
+                    )}
                 </ul>
             );
         },
         list_item(token: Token) {
-            return <li key={uniqueId()}>{renderTokens(token.tokens ?? [])}</li>;
+            return (
+                <li key={uniqueId()}>
+                    {renderTokens(token.tokens ?? [], options)}
+                </li>
+            );
         },
         html(token: Token) {
             return token.text;


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
Searchable elements doesn't work correctly inside some structures like described in https://github.com/CERT-Polska/mwdb-core/issues/863

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
Fixed issue by ensuring that options are always passed to the next recursion

**Test plan**
<!-- Explain how to test your changes -->

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #863
