### PR TITLE
Fix: Search links rendered rich attributes break when value contains space

### DIFF
--- a/mwdb/web/src/commons/helpers/renderTokens.tsx
+++ b/mwdb/web/src/commons/helpers/renderTokens.tsx
@@ -92,7 +92,10 @@ export function renderTokens(tokens: Token[], options?: Option): any {
             if (token.href && token.href.startsWith("search#")) {
                 const query = token.href.slice("search#".length);
                 const search =
-                    "?" + new URLSearchParams({ q: query }).toString();
+                    "?" +
+                    new URLSearchParams({
+                        q: decodeURIComponent(query),
+                    }).toString();
                 return (
                     <Link
                         key={uniqueId()}

--- a/mwdb/web/src/components/RichAttribute/MarkedMustache.tsx
+++ b/mwdb/web/src/components/RichAttribute/MarkedMustache.tsx
@@ -64,7 +64,7 @@ class SearchReference {
 
     toMarkdown() {
         return `[${escapeMarkdown(this.value)}](search#${escapeMarkdown(
-            this.query
+            encodeURIComponent(this.query)
         )})`;
     }
 }


### PR DESCRIPTION
…space

<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current/new behaviour?**
<!-- Explain how the code works currently -->
Yet another encoding maze:

Markdown doesn't render links that contain space `[name](/q=attr:"my value")`

It means we should use URI-encoding for these links, but React-Router's Link expects non-encoded part URI, so we need to decode it before passing to `Link`
