### PR TITLE
Fix: Update web_bundle_dir after changing build engine to Vite

### DIFF
--- a/mwdb/paths.py
+++ b/mwdb/paths.py
@@ -5,7 +5,7 @@ package_dir = os.path.dirname(os.path.realpath(__file__))
 migrations_dir = os.path.abspath(os.path.join(package_dir, "model/migrations"))
 
 web_package_dir = os.path.abspath(os.path.join(package_dir, "web"))
-web_bundle_dir = os.path.join(web_package_dir, "build")
+web_bundle_dir = os.path.join(web_package_dir, "dist")
 
 templates_dir = os.path.join(package_dir, "templates")
 mail_templates_dir = os.path.join(templates_dir, "mail")


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [x] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

MWDB Core webapp doesn't work after installation from PyPi (serve_web=1)

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
Default path to the web fiels was updated.

