### PR TITLE
Bump werkzeug to 3.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Werkzeug==2.3.3
+Werkzeug==3.0.1
 gunicorn==20.1.0
 alembic==1.4.2
 Flask==2.3.2


### PR DESCRIPTION
Werkzeug >=2.0.0, <3.0.1 has a bug (in some cases, a security bug) that may result in excessive CPU usage and worker timeout when huge file (usually over 50MB) with specific layout is uploaded to MWDB.

The issue is when uploaded file contents are meaningful/random at the beginning (contain CR/LF bytes) and then are extensively padded with zeroes. This is common file pattern for bloated malware samples and memory dumps, so it may highly affect performance or even cause a denial of service if MWDB is flooded with such file uploads.

References:
- https://www.cve.org/CVERecord?id=CVE-2023-46136
- https://github.com/pallets/werkzeug/pull/2801
