### PR TITLE
Bump `python_requires` to >=3.8 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(name="mwdb-core",
       include_package_data=True,
       url="https://github.com/CERT-Polska/mwdb-core",
       install_requires=open("requirements.txt").read().splitlines(),
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       entry_points={
         'console_scripts': [
             'mwdb-core=mwdb.cli:cli'


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

Python 3.7 is no longer supported.
This PR is ultimately a followup to https://github.com/CERT-Polska/karton/pull/230.

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).

**What is the current behaviour?**
<!-- Explain how the code works currently -->
Project dependencies cannot be installed on Python 3.7.
