### PR TITLE
Set level of repetable logs to debug

### DIFF
--- a/mwdb/app.py
+++ b/mwdb/app.py
@@ -136,7 +136,7 @@ if app_config.mwdb.serve_web:
 def assign_request_id():
     g.request_id = token_hex(16)
     g.request_start_time = datetime.utcnow()
-    getLogger().info(
+    getLogger().debug(
         "before_request",
         extra={
             "path": request.path,
@@ -156,7 +156,7 @@ def log_request(response):
         response_time = None
     response_size = response.calculate_content_length()
 
-    getLogger().info(
+    getLogger().debug(
         "request",
         extra={
             "path": request.path,
@@ -195,7 +195,7 @@ def require_auth():
         if g.auth_user is None:
             g.auth_user = User.verify_legacy_token(token)
             if g.auth_user is not None:
-                getLogger().warning(
+                getLogger().debug(
                     "'%s' used legacy auth token for authentication", g.auth_user.login
                 )
 

--- a/mwdb/core/config.py
+++ b/mwdb/core/config.py
@@ -134,6 +134,7 @@ class MWDBConfig(Config):
     enable_sql_profiler = key(cast=intbool, required=False, default=False)
     log_only_slow_sql = key(cast=intbool, required=False, default=False)
     use_x_forwarded_for = key(cast=intbool, required=False, default=False)
+    enable_debug_log = key(cast=intbool, required=False, default=False)
 
 
 @section("karton")

--- a/mwdb/core/log.py
+++ b/mwdb/core/log.py
@@ -45,7 +45,7 @@ def setup_logger():
 
     if enable_json_logger:
         formatter = jsonlogger.JsonFormatter(
-            fmt="%(filename) %(funcName) %(levelname) %(message)",
+            fmt="%(funcName) %(levelname) %(message)",
             timestamp=True,
         )
     else:

--- a/mwdb/core/log.py
+++ b/mwdb/core/log.py
@@ -45,12 +45,12 @@ def setup_logger():
 
     if enable_json_logger:
         formatter = jsonlogger.JsonFormatter(
-            fmt="%(filename) %(funcName) %(levelname) " "%(lineno) %(message)",
+            fmt="%(filename) %(funcName) %(levelname) %(message)",
             timestamp=True,
         )
     else:
         formatter = InlineFormatter(
-            fmt="[%(levelname)s] " "- %(funcName)s:%(lineno)s" " - %(message)s"
+            fmt="[%(levelname)s] " "- %(funcName)s - %(message)s"
         )
     handler.setFormatter(formatter)
     handler.addFilter(ContextFilter())

--- a/mwdb/core/log.py
+++ b/mwdb/core/log.py
@@ -45,20 +45,17 @@ def setup_logger():
 
     if enable_json_logger:
         formatter = jsonlogger.JsonFormatter(
-            fmt="%(filename) %(funcName) %(levelname) "
-            "%(lineno) %(module) %(threadName) %(message)",
+            fmt="%(filename) %(funcName) %(levelname) " "%(lineno) %(message)",
             timestamp=True,
         )
     else:
         formatter = InlineFormatter(
-            fmt="[%(levelname)s] %(threadName)s "
-            "- %(module)s.%(funcName)s:%(lineno)s"
-            " - %(message)s"
+            fmt="[%(levelname)s] " "- %(funcName)s:%(lineno)s" " - %(message)s"
         )
     handler.setFormatter(formatter)
     handler.addFilter(ContextFilter())
     logger.addHandler(handler)
-    logger.setLevel(logging.INFO)
+    logger.setLevel(logging.DEBUG if app_config.mwdb.enable_debug_log else logging.INFO)
 
 
 def getLogger():

--- a/mwdb/core/log.py
+++ b/mwdb/core/log.py
@@ -49,9 +49,7 @@ def setup_logger():
             timestamp=True,
         )
     else:
-        formatter = InlineFormatter(
-            fmt="[%(levelname)s] " "- %(funcName)s - %(message)s"
-        )
+        formatter = InlineFormatter(fmt="[%(levelname)s] - %(funcName)s - %(message)s")
     handler.setFormatter(formatter)
     handler.addFilter(ContextFilter())
     logger.addHandler(handler)

--- a/mwdb/resources/__init__.py
+++ b/mwdb/resources/__init__.py
@@ -56,7 +56,7 @@ def deprecated(f):
 
     @wraps(f)
     def endpoint(*args, **kwargs):
-        logger.warning("Used deprecated endpoint: %s", request.path)
+        logger.debug("Used deprecated endpoint: %s", request.path)
         return f(*args, **kwargs)
 
     return endpoint

--- a/mwdb/resources/auth.py
+++ b/mwdb/resources/auth.py
@@ -419,7 +419,7 @@ class RefreshTokenResource(Resource):
         user.logged_on = datetime.datetime.now()
         db.session.commit()
 
-        logger.info("Session token refreshed", extra={"user": user.login})
+        logger.debug("Session token refreshed", extra={"user": user.login})
         schema = AuthSuccessResponseSchema()
         return schema.dump(
             {
@@ -453,7 +453,7 @@ class ValidateTokenResource(Resource):
         """
         user = g.auth_user
 
-        logger.info("Token validated", extra={"user": user.login})
+        logger.debug("Token validated", extra={"user": user.login})
         schema = AuthValidateTokenResponseSchema()
         return schema.dump(
             {


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

We're buried in tons of non-meaningful logs without any option to set the verbosity. Non-meaningful logs are:
- information about usage of deprecated endpoints
- 'before_request'/'request' logs which are useful for debugging hanging or slow endpoints, but only for debugging
- threadName, moduleName, lineNo which doesn't carry any useful information that can't be read from the log itself

Missing `request` logs can be easily replaced with metrics introduced by https://github.com/CERT-Polska/mwdb-core/pull/908

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

- introducing DEBUG level that can be turned on via `enable_debug_log` option in configuration
- setting verbosity level of logs mentioned above to DEBUG