### PR TITLE
metrics: Fix bug in collecting metrics for /api/varz

### DIFF
--- a/mwdb/core/metrics/redis_counter.py
+++ b/mwdb/core/metrics/redis_counter.py
@@ -72,7 +72,7 @@ class RedisCounter:
         for key, value in counters.items():
             labelkwargs = self._labelkwargs_from_key(key)
             if labelkwargs is None:
-                return
+                continue
             self._gauge.labels(**labelkwargs).set(value)
 
 


### PR DESCRIPTION
Right now, `/api/varz` returns only a few or none metrics when there are at least two for different gauges.
