### PR TITLE
metrics: Indicate which user used legacy_api_key_v2

### DIFF
--- a/mwdb/core/deprecated.py
+++ b/mwdb/core/deprecated.py
@@ -49,8 +49,10 @@ def uses_deprecated_api(
     feature: DeprecatedFeature,
     endpoint: Optional[str] = None,
     method: Optional[str] = None,
+    user: Optional[str] = None,
 ):
-    user = g.auth_user.login if g.auth_user is not None else None
+    if user is None:
+        user = g.auth_user.login if g.auth_user is not None else None
     metric_deprecated_usage.inc(
         feature=str(feature.value), endpoint=endpoint, method=method, user=user
     )

--- a/mwdb/model/api_key.py
+++ b/mwdb/model/api_key.py
@@ -38,7 +38,9 @@ class APIKey(db.Model):
                 return None
             else:
                 # Note a deprecated usage
-                uses_deprecated_api(DeprecatedFeature.legacy_api_key_v2)
+                uses_deprecated_api(
+                    DeprecatedFeature.legacy_api_key_v2, user=data.get("login")
+                )
 
         try:
             api_key_obj = APIKey.query.filter(


### PR DESCRIPTION
Right now it shows only `None` because `g.auth_user` is not yet set.