### PR TITLE
Fix: deleting user that authored some comments

### DIFF
--- a/mwdb/model/user.py
+++ b/mwdb/model/user.py
@@ -65,7 +65,10 @@ class User(db.Model):
     )
 
     commented_objects = db.relationship(
-        "Object", secondary="comment", back_populates="comment_authors"
+        "Object",
+        secondary="comment",
+        back_populates="comment_authors",
+        passive_deletes=True,
     )
 
     comments = db.relationship(

--- a/mwdb/schema/comment.py
+++ b/mwdb/schema/comment.py
@@ -18,5 +18,5 @@ class CommentRequestSchema(CommentSchemaBase):
 
 class CommentItemResponseSchema(CommentSchemaBase):
     id = fields.Int(required=True, allow_none=False)
-    author = fields.Str(required=True, allow_none=False, attribute="author_login")
+    author = fields.Str(required=True, default=None, attribute="author_login")
     timestamp = UTCDateTime(required=True, allow_none=False)

--- a/tests/backend/test_api.py
+++ b/tests/backend/test_api.py
@@ -247,4 +247,4 @@ def test_user_delete(admin_session):
     comments = admin_session.get_comments(sample.dhash)
     assert len(comments) == 1
     assert comments[0]["comment"] == "random comment"
-    assert comments[0]["author"] is None
+    assert comments[0].get("author") is None

--- a/tests/backend/test_api.py
+++ b/tests/backend/test_api.py
@@ -242,9 +242,9 @@ def test_user_delete(admin_session):
     # Then try to remove that user
     admin_session.remove_user(alice.identity)
     # Object should be still reachable
-    admin_session.get_sample(sample.identity)
+    admin_session.get_sample(sample.dhash)
     # And should still have one comment (with nulled author)
-    comments = admin_session.get_comments(sample.identity)
+    comments = admin_session.get_comments(sample.dhash)
     assert len(comments) == 1
     assert comments[0]["comment"] == "random comment"
     assert comments[0]["author"] is None

--- a/tests/backend/test_api.py
+++ b/tests/backend/test_api.py
@@ -247,4 +247,4 @@ def test_user_delete(admin_session):
     comments = admin_session.get_comments(sample.dhash)
     assert len(comments) == 1
     assert comments[0]["comment"] == "random comment"
-    assert comments[0].get("author") is None
+    assert comments[0]["author"] is None

--- a/tests/backend/test_api.py
+++ b/tests/backend/test_api.py
@@ -235,7 +235,7 @@ def test_zero_starting_crc32(admin_session):
 def test_user_delete(admin_session):
     # Make user and use it to comment new sample
     case = RelationTestCase(admin_session)
-    alice = case.new_user("Alice")
+    alice = case.new_user("Alice", capabilities=["adding_comments"])
     sample = case.new_sample("Sample")
     sample.create(alice)
     alice.session.add_comment(sample.dhash, "random comment")


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [x] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- Deleting user that is an author of object comment results in ISE 500

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- We can delete users with comments and author field for these comments is just set to NULL.

**Test plan**
<!-- Explain how to test your changes -->

1. Create user
2. Log in to that user, upload file, comment it
3. Log in back to admin account and try to delete a sample

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->


