### PR TITLE
Use limits directly instead of Flask-Limiter

### DIFF
--- a/mwdb/app.py
+++ b/mwdb/app.py
@@ -12,6 +12,7 @@ from mwdb.core.deprecated import DeprecatedFeature, uses_deprecated_api
 from mwdb.core.log import getLogger, setup_logger
 from mwdb.core.metrics import metric_api_requests, metrics_enabled
 from mwdb.core.plugins import PluginAppContext, load_plugins
+from mwdb.core.rate_limit import apply_rate_limit_for_request
 from mwdb.core.static import static_blueprint
 from mwdb.core.util import token_hex
 from mwdb.model import APIKey, User, db
@@ -218,6 +219,11 @@ def require_auth():
 
         if g.auth_user.disabled:
             raise Forbidden("User has been disabled.")
+
+
+@app.before_request
+def apply_rate_limit():
+    apply_rate_limit_for_request()
 
 
 # Server health endpoints

--- a/mwdb/core/app.py
+++ b/mwdb/core/app.py
@@ -2,7 +2,6 @@ from flask import Blueprint, Flask
 from werkzeug.middleware.proxy_fix import ProxyFix
 
 from mwdb.core.config import app_config
-from mwdb.core.rate_limit import limiter
 
 from .service import Service
 
@@ -14,5 +13,3 @@ app.register_blueprint(api_blueprint)
 
 if app_config.mwdb.use_x_forwarded_for:
     app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1)
-
-limiter.init_app(app)

--- a/mwdb/core/rate_limit.py
+++ b/mwdb/core/rate_limit.py
@@ -19,12 +19,6 @@ DEFAULT_RATE_LIMITS = {
 }
 
 
-def is_rate_limit_disabled():
-    return g.auth_user is not None and g.auth_user.has_rights(
-        Capabilities.unlimited_requests
-    )
-
-
 if app_config.mwdb.enable_rate_limit:
     limit_storage = RedisStorage(app_config.mwdb.redis_uri)
     limiter = FixedWindowRateLimiter(limit_storage)
@@ -47,9 +41,13 @@ def apply_rate_limit_for_request() -> bool:
     Limits are login-based for authenticated users.
     If user is not authenticated then limit is IP-based.
     """
+    # If limiter is not available: rate limiting is turned off
     if not limiter:
         return False
-    if is_rate_limit_disabled():
+    # If rate limiting is disabled for current user: turned off
+    if g.auth_user is not None and g.auth_user.has_rights(
+        Capabilities.unlimited_requests
+    ):
         return False
     # Split blueprint name and resource name from endpoint
     _, resource_name = request.endpoint.split(".", 2)
@@ -60,22 +58,23 @@ def apply_rate_limit_for_request() -> bool:
     for limit_key in limit_keys:
         # Get limit values for key
         limit_values = get_limit_from_config("_".join(limit_key))
-        if limit_values:
-            # limits has parse_many, but we're separating values using space
-            for limit_value in limit_values.split(" "):
-                limit_item = parse(limit_value)
-                identifiers = [user, *limit_key]
-                if not limiter.hit(limit_item, *identifiers):
-                    reset_time = limiter.get_window_stats(
-                        limit_item, *identifiers
-                    ).reset_time
-                    # Limits' reset_time uses Redis TTL internally and
-                    # adds time.time to it, so we can safely subtract
-                    # the same value. There still should be a cutoff to
-                    # make clients wait at least few seconds.
-                    retry_after = max(5, reset_time - int(time.time()))
-                    raise TooManyRequests(
-                        retry_after=retry_after,
-                        description=f"Request limit: {limit_value} for "
-                        f"{method} method was exceeded!",
-                    )
+        if not limit_values:
+            continue
+        # limits has parse_many, but we're separating values using space
+        for limit_value in limit_values.split(" "):
+            limit_item = parse(limit_value)
+            identifiers = [user, *limit_key]
+            if not limiter.hit(limit_item, *identifiers):
+                reset_time = limiter.get_window_stats(
+                    limit_item, *identifiers
+                ).reset_time
+                # Limits' reset_time uses Redis TTL internally and
+                # adds time.time to it, so we can safely subtract
+                # the same value. There still should be a cutoff to
+                # make clients wait at least few seconds.
+                retry_after = max(5, reset_time - int(time.time()))
+                raise TooManyRequests(
+                    retry_after=retry_after,
+                    description=f"Request limit: {limit_value} for "
+                    f"{method} method was exceeded!",
+                )

--- a/mwdb/core/rate_limit.py
+++ b/mwdb/core/rate_limit.py
@@ -1,61 +1,67 @@
+import time
+from typing import Optional
+
 from flask import g, request
-from flask_limiter import Limiter
-from flask_limiter.util import get_remote_address
+from limits import parse
+from limits.storage import RedisStorage
+from limits.strategies import FixedWindowRateLimiter
+from werkzeug.exceptions import TooManyRequests
 
 from mwdb.core.capabilities import Capabilities
 from mwdb.core.config import app_config
 
+# default rate limit values
+DEFAULT_RATE_LIMITS = {
+    "get": "1000/10second 2000/minute 6000/5minute 10000/15minute",
+    "post": "100/10second 1000/minute 3000/5minute 6000/15minute",
+    "put": "100/10second 1000/minute 3000/5minute 6000/15minute",
+    "delete": "100/10second 1000/minute 3000/5minute 6000/15minute",
+}
+
 
 def is_rate_limit_disabled():
-    if not app_config.mwdb.enable_rate_limit:
-        return True
-    elif g.auth_user is not None and g.auth_user.has_rights(
+    return g.auth_user is not None and g.auth_user.has_rights(
         Capabilities.unlimited_requests
-    ):
-        return True
-    return False
+    )
 
 
-limiter = Limiter(
-    key_func=lambda: (
-        f"{g.auth_user.login}-{request.method}"
-        if g.auth_user
-        else f"{get_remote_address()}-{request.method}"
-    ),
-    storage_uri=app_config.mwdb.redis_uri,
-    headers_enabled=True,
-)
+if app_config.mwdb.enable_rate_limit:
+    limit_storage = RedisStorage(app_config.mwdb.redis_uri)
+    limiter = FixedWindowRateLimiter(limit_storage)
+else:
+    limiter = None
 
 
-def rate_limited_resource(resource_class):
-    # default rate limit values
-    rate_limits = {
-        "get": "1000/10second 2000/minute 6000/5minute 10000/15minute",
-        "post": "100/10second 1000/minute 3000/5minute 6000/15minute",
-        "put": "100/10second 1000/minute 3000/5minute 6000/15minute",
-        "delete": "100/10second 1000/minute 3000/5minute 6000/15minute",
-    }
-    limit_decorators = []
-    http_methods_in_resource = [func.lower() for func in resource_class.methods]
+def get_limit_from_config(key) -> Optional[str]:
+    return app_config.get_key("mwdb_limiter", key) or DEFAULT_RATE_LIMITS.get(key)
 
-    for method in http_methods_in_resource:
-        field = resource_class.__qualname__.split("Resource")[0].lower() + "_" + method
-        limits = app_config.get_key("mwdb_limiter", field)
 
-        if not limits:
-            limits = rate_limits[method]
-
-        for limit in limits.split():
-            limit_decorators.append(
-                limiter.limit(
-                    limit,
-                    methods=[method],
-                    error_message=(
-                        f"Request limit: {limit} for {method} method was exceeded!"
-                    ),
-                    exempt_when=is_rate_limit_disabled,
-                )
-            )
-    resource_class.decorators = limit_decorators
-
-    return resource_class
+def apply_rate_limit_for_request() -> bool:
+    if not limiter:
+        return False
+    if is_rate_limit_disabled():
+        return False
+    # Split blueprint name from resource name
+    _, resource_name = request.endpoint.split(".", 2)
+    method = request.method.lower()
+    user = g.auth_user.login if g.auth_user is not None else request.remote_addr
+    # Limit keys from most specific to the least specific
+    limit_keys = [[resource_name, method], [resource_name], [method]]
+    for limit_key in limit_keys:
+        # Get limit for key
+        limit_values = get_limit_from_config("_".join(limit_key))
+        if limit_values:
+            for limit_value in limit_values.split(" "):
+                limit_item = parse(limit_value)
+                identifiers = [user, *limit_key]
+                if not limiter.hit(limit_item, *identifiers):
+                    reset_time = limiter.get_window_stats(
+                        limit_item, *identifiers
+                    ).reset_time
+                    retry_after = max(5, reset_time - int(time.time()))
+                    print(reset_time, time.time(), flush=True)
+                    raise TooManyRequests(
+                        retry_after=retry_after,
+                        description=f"Request limit: {limit_value} for "
+                        f"{method} method was exceeded!",
+                    )

--- a/mwdb/resources/api_key.py
+++ b/mwdb/resources/api_key.py
@@ -7,7 +7,6 @@ from sqlalchemy.orm.exc import NoResultFound
 from werkzeug.exceptions import Forbidden, NotFound
 
 from mwdb.core.capabilities import Capabilities
-from mwdb.core.rate_limit import rate_limited_resource
 from mwdb.model import APIKey, User, db
 from mwdb.schema.api_key import (
     APIKeyIdentifierBase,
@@ -24,7 +23,6 @@ from . import (
 )
 
 
-@rate_limited_resource
 class APIKeyIssueResource(Resource):
     @requires_authorization
     @requires_capabilities(Capabilities.manage_profile)
@@ -109,7 +107,6 @@ class APIKeyIssueResource(Resource):
         )
 
 
-@rate_limited_resource
 class APIKeyResource(Resource):
     @requires_authorization
     @requires_capabilities(Capabilities.manage_profile)

--- a/mwdb/resources/attribute.py
+++ b/mwdb/resources/attribute.py
@@ -4,7 +4,6 @@ from werkzeug.exceptions import BadRequest, Conflict, Forbidden, NotFound
 
 from mwdb.core.capabilities import Capabilities
 from mwdb.core.plugins import hooks
-from mwdb.core.rate_limit import rate_limited_resource
 from mwdb.model import Attribute, AttributeDefinition, AttributePermission, Group, db
 from mwdb.schema.attribute import (
     AttributeDefinitionCreateRequestSchema,
@@ -31,7 +30,6 @@ from . import (
 )
 
 
-@rate_limited_resource
 class AttributeListResource(Resource):
     @requires_authorization
     def get(self, type, identifier):
@@ -174,7 +172,6 @@ class AttributeListResource(Resource):
         return schema.dump({"attributes": attributes})
 
 
-@rate_limited_resource
 class AttributeResource(Resource):
     @requires_authorization
     @requires_capabilities("removing_attributes")
@@ -238,7 +235,6 @@ class AttributeResource(Resource):
         hooks.on_changed_object(db_object)
 
 
-@rate_limited_resource
 class AttributeDefinitionListResource(Resource):
     @requires_authorization
     def get(self):
@@ -361,7 +357,6 @@ class AttributeDefinitionListResource(Resource):
         return schema.dump(attribute_definition)
 
 
-@rate_limited_resource
 class AttributeDefinitionResource(Resource):
     @requires_authorization
     @requires_capabilities(Capabilities.manage_users)
@@ -534,7 +529,6 @@ class AttributeDefinitionResource(Resource):
         hooks.on_removed_attribute_key(attribute_definition)
 
 
-@rate_limited_resource
 class AttributePermissionResource(Resource):
     @requires_authorization
     @requires_capabilities(Capabilities.manage_users)

--- a/mwdb/resources/auth.py
+++ b/mwdb/resources/auth.py
@@ -13,7 +13,6 @@ from mwdb.core.capabilities import Capabilities
 from mwdb.core.config import app_config
 from mwdb.core.mail import MailError, send_email_notification
 from mwdb.core.plugins import hooks
-from mwdb.core.rate_limit import rate_limited_resource
 from mwdb.model import Group, Member, User, db
 from mwdb.schema.auth import (
     AuthLoginRequestSchema,
@@ -47,7 +46,6 @@ def verify_recaptcha(recaptcha_token):
             raise Forbidden("Wrong ReCAPTCHA, please try again.")
 
 
-@rate_limited_resource
 class LoginResource(Resource):
     def post(self):
         """
@@ -125,7 +123,6 @@ class LoginResource(Resource):
         )
 
 
-@rate_limited_resource
 class RegisterResource(Resource):
     def post(self):
         """
@@ -199,7 +196,6 @@ class RegisterResource(Resource):
         return schema.dump({"login": user.login})
 
 
-@rate_limited_resource
 class ChangePasswordResource(Resource):
     def post(self):
         """
@@ -249,7 +245,6 @@ class ChangePasswordResource(Resource):
         return schema.dump({"login": user.login})
 
 
-@rate_limited_resource
 class RequestPasswordChangeResource(Resource):
     @requires_authorization
     @requires_capabilities(Capabilities.manage_profile)
@@ -308,7 +303,6 @@ class RequestPasswordChangeResource(Resource):
         return schema.dump({"login": login})
 
 
-@rate_limited_resource
 class RecoverPasswordResource(Resource):
     def post(self):
         """
@@ -390,7 +384,6 @@ class RecoverPasswordResource(Resource):
         return schema.dump({"login": user.login})
 
 
-@rate_limited_resource
 class RefreshTokenResource(Resource):
     @requires_authorization
     def post(self):
@@ -432,7 +425,6 @@ class RefreshTokenResource(Resource):
         )
 
 
-@rate_limited_resource
 class ValidateTokenResource(Resource):
     @requires_authorization
     def get(self):
@@ -464,7 +456,6 @@ class ValidateTokenResource(Resource):
         )
 
 
-@rate_limited_resource
 class AuthGroupListResource(Resource):
     @requires_authorization
     def get(self):

--- a/mwdb/resources/blob.py
+++ b/mwdb/resources/blob.py
@@ -4,7 +4,6 @@ from werkzeug.exceptions import Conflict
 from mwdb.core.capabilities import Capabilities
 from mwdb.core.deprecated import DeprecatedFeature, deprecated_endpoint
 from mwdb.core.plugins import hooks
-from mwdb.core.rate_limit import rate_limited_resource
 from mwdb.model import TextBlob
 from mwdb.model.object import ObjectTypeConflictError
 from mwdb.schema.blob import (
@@ -46,7 +45,6 @@ class TextBlobUploader(ObjectUploader):
             raise Conflict("Object already exists and is not a blob")
 
 
-@rate_limited_resource
 class TextBlobResource(ObjectResource, TextBlobUploader):
     ObjectType = TextBlob
     ListResponseSchema = BlobListResponseSchema
@@ -183,7 +181,6 @@ class TextBlobResource(ObjectResource, TextBlobUploader):
         return self.create_object(obj)
 
 
-@rate_limited_resource
 class TextBlobItemResource(ObjectItemResource, TextBlobUploader):
     ObjectType = TextBlob
     ItemResponseSchema = BlobItemResponseSchema

--- a/mwdb/resources/comment.py
+++ b/mwdb/resources/comment.py
@@ -4,7 +4,6 @@ from werkzeug.exceptions import NotFound
 
 from mwdb.core.capabilities import Capabilities
 from mwdb.core.plugins import hooks
-from mwdb.core.rate_limit import rate_limited_resource
 from mwdb.model import Comment, db
 from mwdb.schema.comment import CommentItemResponseSchema, CommentRequestSchema
 
@@ -17,7 +16,6 @@ from . import (
 )
 
 
-@rate_limited_resource
 class CommentResource(Resource):
     @requires_authorization
     def get(self, type, identifier):
@@ -136,7 +134,6 @@ class CommentResource(Resource):
         return schema.dump(comment)
 
 
-@rate_limited_resource
 class CommentDeleteResource(Resource):
     @requires_authorization
     @requires_capabilities(Capabilities.removing_comments)

--- a/mwdb/resources/config.py
+++ b/mwdb/resources/config.py
@@ -8,7 +8,6 @@ from werkzeug.exceptions import BadRequest, Conflict, Forbidden, NotFound
 from mwdb.core.capabilities import Capabilities
 from mwdb.core.deprecated import DeprecatedFeature, deprecated_endpoint
 from mwdb.core.plugins import hooks
-from mwdb.core.rate_limit import rate_limited_resource
 from mwdb.model import Config, TextBlob, db
 from mwdb.model.object import ObjectTypeConflictError
 from mwdb.schema.blob import BlobCreateSpecSchema
@@ -25,7 +24,6 @@ from . import load_schema, loads_schema, requires_authorization, requires_capabi
 from .object import ObjectItemResource, ObjectResource, ObjectUploader
 
 
-@rate_limited_resource
 class ConfigStatsResource(Resource):
     @requires_authorization
     def get(self):
@@ -161,7 +159,6 @@ class ConfigUploader(ObjectUploader):
             raise Conflict("Object already exists and is not a config")
 
 
-@rate_limited_resource
 class ConfigResource(ObjectResource, ConfigUploader):
 
     ObjectType = Config
@@ -305,7 +302,6 @@ class ConfigResource(ObjectResource, ConfigUploader):
         return self.create_object(obj)
 
 
-@rate_limited_resource
 class ConfigItemResource(ObjectItemResource, ConfigUploader):
 
     ObjectType = Config

--- a/mwdb/resources/download.py
+++ b/mwdb/resources/download.py
@@ -4,14 +4,12 @@ from werkzeug.exceptions import Forbidden, NotFound
 
 from mwdb.core.app import api
 from mwdb.core.deprecated import DeprecatedFeature, deprecated_endpoint
-from mwdb.core.rate_limit import rate_limited_resource
 from mwdb.model import File
 from mwdb.schema.download import DownloadURLResponseSchema
 
 from . import requires_authorization
 
 
-@rate_limited_resource
 class DownloadResource(Resource):
     @deprecated_endpoint(DeprecatedFeature.legacy_file_download)
     def get(self, access_token):
@@ -57,7 +55,6 @@ class DownloadResource(Resource):
         )
 
 
-@rate_limited_resource
 class RequestSampleDownloadResource(Resource):
     @deprecated_endpoint(DeprecatedFeature.legacy_file_download)
     @requires_authorization

--- a/mwdb/resources/file.py
+++ b/mwdb/resources/file.py
@@ -5,7 +5,6 @@ from werkzeug.exceptions import BadRequest, Conflict, Forbidden, NotFound, Unaut
 from mwdb.core.capabilities import Capabilities
 from mwdb.core.deprecated import DeprecatedFeature, deprecated_endpoint
 from mwdb.core.plugins import hooks
-from mwdb.core.rate_limit import rate_limited_resource
 from mwdb.model import File
 from mwdb.model.file import EmptyFileError
 from mwdb.model.object import ObjectTypeConflictError
@@ -50,7 +49,6 @@ class FileUploader(ObjectUploader):
             raise BadRequest("File cannot be empty")
 
 
-@rate_limited_resource
 class FileResource(ObjectResource, FileUploader):
     ObjectType = File
     ListResponseSchema = FileListResponseSchema
@@ -200,7 +198,6 @@ class FileResource(ObjectResource, FileUploader):
         return self.create_object(obj["options"])
 
 
-@rate_limited_resource
 class FileItemResource(ObjectItemResource, FileUploader):
     ObjectType = File
     ItemResponseSchema = FileItemResponseSchema
@@ -367,7 +364,6 @@ class FileItemResource(ObjectItemResource, FileUploader):
         return super().delete(identifier)
 
 
-@rate_limited_resource
 class FileDownloadResource(Resource):
     def get(self, identifier):
         """
@@ -503,7 +499,6 @@ class FileDownloadResource(Resource):
         return schema.dump({"token": download_token})
 
 
-@rate_limited_resource
 class FileDownloadZipResource(Resource):
     def get(self, identifier):
         """

--- a/mwdb/resources/group.py
+++ b/mwdb/resources/group.py
@@ -6,7 +6,6 @@ from werkzeug.exceptions import Conflict, Forbidden, NotFound
 
 from mwdb.core.capabilities import Capabilities
 from mwdb.core.plugins import hooks
-from mwdb.core.rate_limit import rate_limited_resource
 from mwdb.model import Group, Member, User, db
 from mwdb.schema.group import (
     GroupCreateRequestSchema,
@@ -28,7 +27,6 @@ from . import (
 )
 
 
-@rate_limited_resource
 class GroupListResource(Resource):
     @requires_authorization
     @requires_capabilities(Capabilities.manage_users)
@@ -65,7 +63,6 @@ class GroupListResource(Resource):
         return schema.dump({"groups": objs})
 
 
-@rate_limited_resource
 class GroupResource(Resource):
     @requires_authorization
     @requires_capabilities(Capabilities.manage_users)
@@ -310,7 +307,6 @@ class GroupResource(Resource):
         return schema.dump({"name": name})
 
 
-@rate_limited_resource
 class GroupMemberResource(Resource):
     @requires_authorization
     @requires_capabilities(Capabilities.manage_users)

--- a/mwdb/resources/karton.py
+++ b/mwdb/resources/karton.py
@@ -3,7 +3,6 @@ from flask_restful import Resource
 from werkzeug.exceptions import BadRequest, NotFound
 
 from mwdb.core.capabilities import Capabilities
-from mwdb.core.rate_limit import rate_limited_resource
 from mwdb.model import KartonAnalysis, Object
 from mwdb.schema.karton import (
     KartonItemResponseSchema,
@@ -21,7 +20,6 @@ from . import (
 )
 
 
-@rate_limited_resource
 class KartonObjectResource(Resource):
     @requires_authorization
     def get(self, type, identifier):
@@ -131,7 +129,6 @@ class KartonObjectResource(Resource):
         return schema.dump(analysis)
 
 
-@rate_limited_resource
 class KartonAnalysisResource(Resource):
     @requires_authorization
     def get(self, type, identifier, analysis_id):

--- a/mwdb/resources/metakey.py
+++ b/mwdb/resources/metakey.py
@@ -4,7 +4,6 @@ from werkzeug.exceptions import BadRequest, Forbidden, NotFound
 
 from mwdb.core.capabilities import Capabilities
 from mwdb.core.deprecated import DeprecatedFeature, deprecated_endpoint
-from mwdb.core.rate_limit import rate_limited_resource
 from mwdb.model import AttributeDefinition, AttributePermission, Group, db
 from mwdb.schema.metakey import (
     MetakeyDefinitionItemRequestArgsSchema,
@@ -34,7 +33,6 @@ from . import (
 )
 
 
-@rate_limited_resource
 class MetakeyResource(Resource):
     @deprecated_endpoint(DeprecatedFeature.legacy_metakey_api)
     @requires_authorization
@@ -263,7 +261,6 @@ class MetakeyResource(Resource):
         db.session.commit()
 
 
-@rate_limited_resource
 class MetakeyListDefinitionResource(Resource):
     @deprecated_endpoint(DeprecatedFeature.legacy_metakey_api)
     @requires_authorization
@@ -312,7 +309,6 @@ class MetakeyListDefinitionResource(Resource):
         return schema.dump({"metakeys": metakeys})
 
 
-@rate_limited_resource
 class MetakeyListDefinitionManageResource(Resource):
     @deprecated_endpoint(DeprecatedFeature.legacy_metakey_api)
     @requires_authorization
@@ -353,7 +349,6 @@ class MetakeyListDefinitionManageResource(Resource):
         return schema.dump({"metakeys": metakeys})
 
 
-@rate_limited_resource
 class MetakeyDefinitionManageResource(Resource):
     @deprecated_endpoint(DeprecatedFeature.legacy_metakey_api)
     @requires_authorization
@@ -592,7 +587,6 @@ class MetakeyDefinitionManageResource(Resource):
         db.session.commit()
 
 
-@rate_limited_resource
 class MetakeyPermissionResource(Resource):
     @deprecated_endpoint(DeprecatedFeature.legacy_metakey_api)
     @requires_authorization

--- a/mwdb/resources/oauth.py
+++ b/mwdb/resources/oauth.py
@@ -10,7 +10,6 @@ from werkzeug.exceptions import Conflict, Forbidden, NotFound
 from mwdb.core.capabilities import Capabilities
 from mwdb.core.config import app_config
 from mwdb.core.plugins import hooks
-from mwdb.core.rate_limit import rate_limited_resource
 from mwdb.model import Group, OpenIDProvider, OpenIDUserIdentity, User, db
 from mwdb.schema.auth import AuthSuccessResponseSchema
 from mwdb.schema.group import GroupNameSchemaBase
@@ -35,7 +34,6 @@ from . import (
 )
 
 
-@rate_limited_resource
 class OpenIDProviderResource(Resource):
     def get(self):
         """
@@ -141,7 +139,6 @@ class OpenIDProviderResource(Resource):
         hooks.on_created_group(group)
 
 
-@rate_limited_resource
 class OpenIDSingleProviderResource(Resource):
     @requires_authorization
     @requires_capabilities(Capabilities.manage_users)
@@ -318,7 +315,6 @@ class OpenIDSingleProviderResource(Resource):
         return schema.dump({"name": provider_name})
 
 
-@rate_limited_resource
 class OpenIDAuthenticateResource(Resource):
     def post(self, provider_name):
         """
@@ -361,7 +357,6 @@ class OpenIDAuthenticateResource(Resource):
         return schema.dump({"authorization_url": url, "state": state, "nonce": nonce})
 
 
-@rate_limited_resource
 class OpenIDAuthorizeResource(Resource):
     def post(self, provider_name):
         provider = (
@@ -422,7 +417,6 @@ class OpenIDAuthorizeResource(Resource):
         )
 
 
-@rate_limited_resource
 class OpenIDRegisterUserResource(Resource):
     def post(self, provider_name):
         provider = (
@@ -522,7 +516,6 @@ class OpenIDRegisterUserResource(Resource):
         )
 
 
-@rate_limited_resource
 class OpenIDBindAccountResource(Resource):
     @requires_authorization
     def post(self, provider_name):
@@ -605,7 +598,6 @@ class OpenIDBindAccountResource(Resource):
         )
 
 
-@rate_limited_resource
 class OpenIDAccountIdentitiesResource(Resource):
     @requires_authorization
     def get(self):
@@ -634,7 +626,6 @@ class OpenIDAccountIdentitiesResource(Resource):
         return OpenIDProviderListResponseSchema().dump({"providers": identities})
 
 
-@rate_limited_resource
 class OpenIDLogoutResource(Resource):
     @requires_authorization
     def get(self, provider_name):

--- a/mwdb/resources/object.py
+++ b/mwdb/resources/object.py
@@ -9,7 +9,6 @@ from mwdb.core.capabilities import Capabilities
 from mwdb.core.config import app_config
 from mwdb.core.deprecated import DeprecatedFeature, uses_deprecated_api
 from mwdb.core.plugins import hooks
-from mwdb.core.rate_limit import rate_limited_resource
 from mwdb.core.search import QueryBaseException, build_query
 from mwdb.model import AttributeDefinition, Object, db
 from mwdb.model.tag import Tag
@@ -154,7 +153,6 @@ class ObjectUploader:
         return schema.dump(item)
 
 
-@rate_limited_resource
 class ObjectResource(Resource):
     ObjectType = Object
     ListResponseSchema = ObjectListResponseSchema
@@ -255,7 +253,6 @@ class ObjectResource(Resource):
         return schema.dump(objects, many=True)
 
 
-@rate_limited_resource
 class ObjectItemResource(Resource, ObjectUploader):
     ObjectType = Object
     ItemResponseSchema = ObjectItemResponseSchema
@@ -381,7 +378,6 @@ class ObjectItemResource(Resource, ObjectUploader):
         hooks.on_removed_object(obj)
 
 
-@rate_limited_resource
 class ObjectCountResource(Resource):
     @requires_authorization
     def get(self, type):
@@ -441,7 +437,6 @@ class ObjectCountResource(Resource):
         return schema.dump({"count": result})
 
 
-@rate_limited_resource
 class ObjectFavoriteResource(Resource):
     @requires_authorization
     @requires_capabilities(Capabilities.personalize)
@@ -552,7 +547,6 @@ class ObjectFavoriteResource(Resource):
             )
 
 
-@rate_limited_resource
 class ObjectShare3rdPartyResource(Resource):
     @requires_authorization
     @requires_capabilities(Capabilities.modify_3rd_party_sharing)

--- a/mwdb/resources/quick_query.py
+++ b/mwdb/resources/quick_query.py
@@ -3,14 +3,12 @@ from flask_restful import Resource
 from werkzeug.exceptions import NotFound
 
 from mwdb.core.capabilities import Capabilities
-from mwdb.core.rate_limit import rate_limited_resource
 from mwdb.model import QuickQuery, db
 from mwdb.schema.quick_query import QuickQueryResponseSchema, QuickQuerySchemaBase
 
 from . import loads_schema, logger, requires_authorization, requires_capabilities
 
 
-@rate_limited_resource
 class QuickQueryResource(Resource):
     @requires_authorization
     @requires_capabilities(Capabilities.personalize)
@@ -99,7 +97,6 @@ class QuickQueryResource(Resource):
         return schema.dump(quick_queries)
 
 
-@rate_limited_resource
 class QuickQueryItemResource(Resource):
     @requires_authorization
     @requires_capabilities(Capabilities.personalize)

--- a/mwdb/resources/relations.py
+++ b/mwdb/resources/relations.py
@@ -3,14 +3,12 @@ from werkzeug.exceptions import NotFound
 
 from mwdb.core.capabilities import Capabilities
 from mwdb.core.plugins import hooks
-from mwdb.core.rate_limit import rate_limited_resource
 from mwdb.model import Object, db
 from mwdb.schema.relations import RelationsResponseSchema
 
 from . import access_object, logger, requires_authorization, requires_capabilities
 
 
-@rate_limited_resource
 class RelationsResource(Resource):
     @requires_authorization
     def get(self, type, identifier):
@@ -59,7 +57,6 @@ class RelationsResource(Resource):
         return relations.dump(db_object)
 
 
-@rate_limited_resource
 class ObjectChildResource(Resource):
     @requires_authorization
     @requires_capabilities(Capabilities.adding_parents)

--- a/mwdb/resources/remotes.py
+++ b/mwdb/resources/remotes.py
@@ -9,7 +9,6 @@ from werkzeug.exceptions import BadRequest, Conflict, Forbidden, NotFound
 from mwdb.core.capabilities import Capabilities
 from mwdb.core.config import app_config
 from mwdb.core.plugins import hooks
-from mwdb.core.rate_limit import rate_limited_resource
 from mwdb.model import Config, File, TextBlob, db
 from mwdb.model.object import ObjectTypeConflictError
 from mwdb.schema.blob import BlobItemResponseSchema
@@ -21,7 +20,6 @@ from mwdb.version import app_build_version
 from . import get_shares_for_upload, loads_schema, logger, requires_authorization
 
 
-@rate_limited_resource
 class RemoteListResource(Resource):
     @requires_authorization
     def get(self):
@@ -87,7 +85,6 @@ class RemoteAPI:
         return response
 
 
-@rate_limited_resource
 class RemoteAPIResource(Resource):
     def do_request(self, method, remote_name, remote_path):
         remote = RemoteAPI(remote_name)
@@ -140,7 +137,6 @@ class RemotePullResource(Resource):
         return schema.dump(item)
 
 
-@rate_limited_resource
 class RemoteFilePullResource(RemotePullResource):
     ObjectType = File
     ItemResponseSchema = FileItemResponseSchema
@@ -219,7 +215,6 @@ class RemoteFilePullResource(RemotePullResource):
         return self.create_pulled_object(item, is_new)
 
 
-@rate_limited_resource
 class RemoteConfigPullResource(RemotePullResource):
     ObjectType = Config
     ItemResponseSchema = ConfigItemResponseSchema
@@ -326,7 +321,6 @@ class RemoteConfigPullResource(RemotePullResource):
         return self.create_pulled_object(item, is_new)
 
 
-@rate_limited_resource
 class RemoteTextBlobPullResource(RemotePullResource):
     ObjectType = TextBlob
     ItemResponseSchema = BlobItemResponseSchema
@@ -399,7 +393,6 @@ class RemoteTextBlobPullResource(RemotePullResource):
         return self.create_pulled_object(item, is_new)
 
 
-@rate_limited_resource
 class RemoteFilePushResource(RemotePullResource):
     @requires_authorization
     def post(self, remote_name, identifier):
@@ -463,7 +456,6 @@ class RemoteFilePushResource(RemotePullResource):
         return response
 
 
-@rate_limited_resource
 class RemoteConfigPushResource(RemotePullResource):
     @requires_authorization
     def post(self, remote_name, identifier):
@@ -544,7 +536,6 @@ class RemoteConfigPushResource(RemotePullResource):
         return response
 
 
-@rate_limited_resource
 class RemoteTextBlobPushResource(RemotePullResource):
     @requires_authorization
     def post(self, remote_name, identifier):

--- a/mwdb/resources/search.py
+++ b/mwdb/resources/search.py
@@ -3,7 +3,6 @@ from flask_restful import Resource
 from werkzeug.exceptions import BadRequest
 
 from mwdb.core.deprecated import DeprecatedFeature, deprecated_endpoint
-from mwdb.core.rate_limit import rate_limited_resource
 from mwdb.core.search import QueryBaseException, build_query
 from mwdb.model import Object
 from mwdb.schema.object import ObjectListItemResponseSchema
@@ -12,7 +11,6 @@ from mwdb.schema.search import SearchRequestSchema
 from . import loads_schema, requires_authorization
 
 
-@rate_limited_resource
 class SearchResource(Resource):
     @deprecated_endpoint(DeprecatedFeature.legacy_search)
     @requires_authorization

--- a/mwdb/resources/server.py
+++ b/mwdb/resources/server.py
@@ -5,7 +5,6 @@ from mwdb.core.app import api
 from mwdb.core.capabilities import Capabilities
 from mwdb.core.config import app_config
 from mwdb.core.plugins import get_plugin_info
-from mwdb.core.rate_limit import rate_limited_resource
 from mwdb.schema.server import (
     ServerAdminInfoResponseSchema,
     ServerInfoResponseSchema,
@@ -16,7 +15,6 @@ from mwdb.version import app_build_version
 from . import requires_authorization, requires_capabilities
 
 
-@rate_limited_resource
 class PingResource(Resource):
     def get(self):
         """
@@ -38,7 +36,6 @@ class PingResource(Resource):
         return schema.dump({"status": "ok"})
 
 
-@rate_limited_resource
 class ServerInfoResource(Resource):
     def get(self):
         """
@@ -75,7 +72,6 @@ class ServerInfoResource(Resource):
         )
 
 
-@rate_limited_resource
 class ServerAdminInfoResource(Resource):
     @requires_authorization
     @requires_capabilities(Capabilities.manage_users)
@@ -111,7 +107,6 @@ class ServerAdminInfoResource(Resource):
         )
 
 
-@rate_limited_resource
 class ServerDocsResource(Resource):
     @requires_authorization
     def get(self):

--- a/mwdb/resources/share.py
+++ b/mwdb/resources/share.py
@@ -3,7 +3,6 @@ from flask_restful import Resource
 from werkzeug.exceptions import Forbidden, NotFound
 
 from mwdb.core.capabilities import Capabilities
-from mwdb.core.rate_limit import rate_limited_resource
 from mwdb.model import Group, User, db
 from mwdb.model.object import AccessType
 from mwdb.schema.share import (
@@ -16,7 +15,6 @@ from mwdb.schema.share import (
 from . import access_object, loads_schema, logger, requires_authorization
 
 
-@rate_limited_resource
 class ShareGroupListResource(Resource):
     @requires_authorization
     def get(self):
@@ -61,7 +59,6 @@ class ShareGroupListResource(Resource):
         return schema.dump({"groups": group_names})
 
 
-@rate_limited_resource
 class ShareResource(Resource):
     @requires_authorization
     def get(self, type, identifier):

--- a/mwdb/resources/tag.py
+++ b/mwdb/resources/tag.py
@@ -4,7 +4,6 @@ from werkzeug.exceptions import NotFound
 
 from mwdb.core.capabilities import Capabilities
 from mwdb.core.plugins import hooks
-from mwdb.core.rate_limit import rate_limited_resource
 from mwdb.model import Tag, db
 from mwdb.schema.tag import (
     TagItemResponseSchema,
@@ -22,7 +21,6 @@ from . import (
 )
 
 
-@rate_limited_resource
 class TagListResource(Resource):
     @requires_authorization
     def get(self):
@@ -74,7 +72,6 @@ class TagListResource(Resource):
         return schema.dump(tags)
 
 
-@rate_limited_resource
 class TagResource(Resource):
     @requires_authorization
     def get(self, type, identifier):

--- a/mwdb/resources/user.py
+++ b/mwdb/resources/user.py
@@ -11,7 +11,6 @@ from mwdb.core.capabilities import Capabilities
 from mwdb.core.config import app_config
 from mwdb.core.mail import MailError, send_email_notification
 from mwdb.core.plugins import hooks
-from mwdb.core.rate_limit import rate_limited_resource
 from mwdb.model import Group, Member, User, db
 from mwdb.schema.user import (
     UserCreateRequestSchema,
@@ -35,7 +34,6 @@ from . import (
 )
 
 
-@rate_limited_resource
 class UserListResource(Resource):
     @requires_authorization
     @requires_capabilities(Capabilities.manage_users)
@@ -79,7 +77,6 @@ class UserListResource(Resource):
         return schema.dump({"users": objs})
 
 
-@rate_limited_resource
 class UserPendingResource(Resource):
     @requires_capabilities(Capabilities.manage_users)
     def post(self, login):
@@ -241,7 +238,6 @@ class UserPendingResource(Resource):
         return schema.dump({"login": user_login_obj["login"]})
 
 
-@rate_limited_resource
 class UserRequestPasswordChangeResource(Resource):
     @requires_authorization
     @requires_capabilities(Capabilities.manage_users)
@@ -317,7 +313,6 @@ class UserRequestPasswordChangeResource(Resource):
         return schema.dump({"login": login})
 
 
-@rate_limited_resource
 class UserGetPasswordChangeTokenResource(Resource):
     @requires_authorization
     @requires_capabilities(Capabilities.manage_users)
@@ -365,7 +360,6 @@ class UserGetPasswordChangeTokenResource(Resource):
         return schema.dump({"login": login, "token": token})
 
 
-@rate_limited_resource
 class UserResource(Resource):
     @requires_authorization
     @requires_capabilities(Capabilities.manage_users)
@@ -645,7 +639,6 @@ class UserResource(Resource):
         return schema.dump({"login": login})
 
 
-@rate_limited_resource
 class UserProfileResource(Resource):
     @requires_authorization
     def get(self, login):

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ karton-core==5.3.2
 Authlib==0.15.4
 prance==0.21.8.0  # apispec unpinned dependency
 pyJWT==2.4.0
-Flask-Limiter==2.1.3
+limits==3.9.0
 python-dateutil==2.8.2
 pyzipper==0.3.5
 pycryptodomex==3.19.1


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

I tried to modify something around limits and feel that Flask-Limiter is not exactly a good fit to our needs. `rate_limited_resource` decorator is awfully hacky and Flask-Limiter doesn't provide a good way to make more dynamic configuration of limits.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

In the same time: Flask-Limiter is just a wrapper on [limits library](https://limits.readthedocs.io/en/stable/#). I found we can use it directly and implement rate limiting in `before_request` instead of relying on decorators

**Test plan**
<!-- Explain how to test your changes -->
1. Enabled rate limits and set pretty low limit for method and resource
2. Hit the limit and checked if `Rate-Limit` header looks good

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->
