### PR TITLE
Fix: Don't treat digits with leading zeroes as correct numbers

### DIFF
--- a/mwdb/core/search/parse_helpers.py
+++ b/mwdb/core/search/parse_helpers.py
@@ -305,7 +305,7 @@ def is_nonstring_object(value: str) -> bool:
     Checks if string value may be also a number or boolean,
     so JSON must be queried using both types
     """
-    return bool(re.match(r"^(false|true|null|\d+([.]\d+)?)$", value))
+    return bool(re.fullmatch(r"(false|true|null|(0|[1-9]\d*)([.]\d+)?)", value))
 
 
 def is_pattern_value(value) -> bool:


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

`attribute.virusshare:00005` is queried using the following JSONpath query: `$ ? (@ == \"00005\" || @ == 00005)` while 00005 is not correct number literal.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

Fixed regex that recognizes correct numbers and booleans.

