### PR TITLE
Fix: Try to load Karton lazily if can't be loaded eagerly

### DIFF
--- a/mwdb/core/karton.py
+++ b/mwdb/core/karton.py
@@ -40,8 +40,7 @@ def get_karton_producer() -> Optional[Producer]:
         except Exception:
             logger.exception("Failed to load Karton producer")
             _karton_producer = None
-        return _karton_producer
-    return None
+    return _karton_producer
 
 
 # Try to load as soon as possible, but don't give up


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

If MWDB can't load Karton producer on load time, it gives up completely and marks it as unavailable

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

When Karton is enabled, we try to load it on every request until it succeeds.

**Test plan**
<!-- Explain how to test your changes -->
<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

related with #891
