### PR TITLE
Fix: Don't treat 0 number as an empty attribute value

### DIFF
--- a/mwdb/schema/attribute.py
+++ b/mwdb/schema/attribute.py
@@ -27,8 +27,8 @@ class AttributeValueSchema(Schema):
 
     @validates("value")
     def validate_value(self, value):
-        # Currently only truthy values and False are allowed as values
-        if not value and value is not False:
+        # 0 and False are not empty values
+        if value in ["", {}, [], None]:
             raise ValidationError("Value shouldn't be empty")
 
 

--- a/tests/backend/test_attributes.py
+++ b/tests/backend/test_attributes.py
@@ -201,3 +201,19 @@ def test_json_attribute_uniqueness(admin_session, attr_session, random_attribute
         and attr["value"] == first_value == second_value
     ]
     assert len(stored_attributes) == 1
+
+
+def test_attribute_falsy_values(admin_session, random_attribute):
+    sample_id, attr_name = random_attribute
+    admin_session.add_attribute(sample_id, attr_name, 0)
+    admin_session.add_attribute(sample_id, attr_name, False)
+    with ShouldRaise(400):
+        admin_session.add_attribute(sample_id, attr_name, [])
+    with ShouldRaise(400):
+        admin_session.add_attribute(sample_id, attr_name, {})
+    with ShouldRaise(400):
+        admin_session.add_attribute(sample_id, attr_name, None)
+    with ShouldRaise(400):
+        admin_session.add_attribute(sample_id, attr_name, "")
+    admin_session.add_attribute(sample_id, attr_name, ["nonempty"])
+    admin_session.add_attribute(sample_id, attr_name, {"nonempty": None})


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [x] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

Mentioned in #907, if we try to set `0` value in JSON/object mode, we get ValidationError as value is considered empty

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

The only empty values are `"", {}, [], null`

**Test plan**
<!-- Explain how to test your changes -->

Covered by automated test

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->
