### PR TITLE
Fix AttributeAddModal to make JSON values less concerning

### DIFF
--- a/mwdb/web/src/components/AttributesAddModal.tsx
+++ b/mwdb/web/src/components/AttributesAddModal.tsx
@@ -4,7 +4,7 @@ import { toast } from "react-toastify";
 
 import { api } from "@mwdb-web/commons/api";
 import { ConfirmationModal } from "@mwdb-web/commons/ui";
-import { RichAttributeRenderer } from "./RichAttribute/RichAttributeRenderer";
+import { AttributeRenderer } from "@mwdb-web/components/ShowObject/common/AttributeRenderer";
 
 import AceEditor from "react-ace";
 
@@ -41,7 +41,7 @@ export function AttributesAddModal({ isOpen, onAdd, onRequestClose }: Props) {
         if (ev) ev.preventDefault();
         if (!attributeForm.current?.reportValidity()) return;
         let value = attributeValue;
-        if (attributeType === "object") {
+        if (attributeType === "json") {
             try {
                 value = JSON.parse(attributeValue);
             } catch (e: any) {
@@ -63,8 +63,6 @@ export function AttributesAddModal({ isOpen, onAdd, onRequestClose }: Props) {
                 attributeDefinitions[ev.target.value].example_value || ""
             );
         }
-        setAttributeType("object");
-
         setError(null);
     }
 
@@ -167,17 +165,17 @@ export function AttributesAddModal({ isOpen, onAdd, onRequestClose }: Props) {
                             <input
                                 className="form-check-input"
                                 type="radio"
-                                id="value-object"
+                                id="value-json"
                                 name="value-type"
-                                checked={attributeType === "object"}
-                                value="object"
+                                checked={attributeType === "json"}
+                                value="json"
                                 onChange={handleTypeChange}
                             />
                             <label
                                 className="form-check-label"
-                                htmlFor="value-object"
+                                htmlFor="value-json"
                             >
-                                Object
+                                JSON
                             </label>
                         </div>
                     </div>
@@ -206,9 +204,9 @@ export function AttributesAddModal({ isOpen, onAdd, onRequestClose }: Props) {
                             />
                         )}
                     </div>
-                    {richTemplate ? (
+                    {attributeDefinitions[attributeKey] ? (
                         <div className="form-group">
-                            <label>Rich attribute preview</label>
+                            <label>Attribute preview</label>
                             <table
                                 className="table table-striped table-bordered table-hover data-table"
                                 style={{
@@ -216,22 +214,18 @@ export function AttributesAddModal({ isOpen, onAdd, onRequestClose }: Props) {
                                 }}
                             >
                                 <tbody>
-                                    <tr>
-                                        <th>{"My attribute"}</th>
-                                        <td>
-                                            <RichAttributeRenderer
-                                                template={richTemplate}
-                                                value={
-                                                    attributeType === "string"
-                                                        ? JSON.stringify(
-                                                              attributeValue
-                                                          )
-                                                        : attributeValue
-                                                }
-                                                setInvalid={setInvalid}
-                                            />
-                                        </td>
-                                    </tr>
+                                    <AttributeRenderer
+                                        attributes={[
+                                            {
+                                                key: attributeKey,
+                                                id: 0,
+                                                value: attributeValue,
+                                            },
+                                        ]}
+                                        attributeDefinition={
+                                            attributeDefinitions[attributeKey]
+                                        }
+                                    />
                                 </tbody>
                             </table>
                         </div>

--- a/mwdb/web/src/components/ShowObject/common/AttributeRenderer.tsx
+++ b/mwdb/web/src/components/ShowObject/common/AttributeRenderer.tsx
@@ -7,7 +7,7 @@ import { AttributeDefinition } from "@mwdb-web/types/types";
 type Props = {
     attributes: Attribute[];
     attributeDefinition: AttributeDefinition;
-    onRemoveAttribute: (id: number) => void;
+    onRemoveAttribute?: (id: number) => void;
 };
 
 export function AttributeRenderer({

--- a/mwdb/web/src/components/ShowObject/common/AttributeValue.tsx
+++ b/mwdb/web/src/components/ShowObject/common/AttributeValue.tsx
@@ -14,7 +14,7 @@ type Props = {
         rich_template: string;
         key: string;
     };
-    onRemove: (id: number) => void;
+    onRemove?: (id: number) => void;
 };
 
 export function AttributeValue({

--- a/mwdb/web/src/components/ShowObject/common/AttributeValue.tsx
+++ b/mwdb/web/src/components/ShowObject/common/AttributeValue.tsx
@@ -7,7 +7,7 @@ import { useNavigate } from "react-router-dom";
 import { RichAttributeValue } from "../common/RichAttributeValue";
 
 type Props = {
-    value: string;
+    value: any;
     attributeId: number;
     attributeDefinition: {
         url_template: string;


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

- "Object" values should be actually called "JSON" values
- "JSON" value should not be a default, I'm not sure why we're actually switching to JSON every time someone wants to provide a value
- Attribute preview should be rendered always by reusing existing components, not only for Rich attributes. In addition, right now JSON values are not parsed at all and they're passed to preview as strings

Related with #907 

Before change it looks like that:

![image](https://github.com/CERT-Polska/mwdb-core/assets/8720367/654a0de3-e381-4d42-bfa1-6571da8e20d8)

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

After change it will look like that:

![image](https://github.com/CERT-Polska/mwdb-core/assets/8720367/39327b76-bedf-4e51-94e9-40a486d4d018)
