### PR TITLE
Bump psycopg2-binary to 2.9.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask-SQLAlchemy==2.5.1
 Flask-Migrate==3.1.0
 SQLAlchemy==1.3.18
 marshmallow==3.20.2
-psycopg2-binary==2.8.5
+psycopg2-binary==2.9.9
 requests==2.31.0
 apispec[marshmallow,yaml]==6.4.0
 bcrypt==3.1.4


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

psycopg2-binary 2.8.5 is pretty obsolete and wheels are generated only up to Py 3.8

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

Bumped to psycopg2-binary 2.9.9

