### PR TITLE
Fix: ISE 500 on concurrent tag addition

### DIFF
--- a/mwdb/model/object.py
+++ b/mwdb/model/object.py
@@ -570,6 +570,7 @@ class Object(db.Model):
             is_new = True
         except IntegrityError:
             db.session.rollback()
+            # If there is still no tag, something went wrong
             if not self.get_tag(tag_name):
                 raise
 
@@ -595,6 +596,7 @@ class Object(db.Model):
             is_removed = True
         except IntegrityError:
             db.session.rollback()
+            # If there is still a tag, something went wrong
             if self.get_tag(tag_name):
                 raise
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- When tag is added concurrently: MWDB incorrectly recovers from conflict and re-raises IntegrityError due to incorrect sanity check.
- `db_tag in self.tags` doesn't work when db_tag is transient object and doesn't have primary key which is used for comparison.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

`Object.add_tag` correctly returns False in case of IntegrityError indicating that tag was already added (by concurrent transaction).

