### PR TITLE
Allow to set custom upload size limit via NGINX_MAX_UPLOAD_SIZE env var in mwdb-web Docker image

### DIFF
--- a/deploy/docker/Dockerfile-web
+++ b/deploy/docker/Dockerfile-web
@@ -16,6 +16,7 @@ FROM nginx:stable
 LABEL maintainer="info@cert.pl"
 
 ENV PROXY_BACKEND_URL http://mwdb.:8080
+ENV NGINX_MAX_UPLOAD_SIZE 50M
 
 COPY docker/nginx.conf.template /etc/nginx/conf.d/default.conf.template
 COPY docker/start-web.sh /start-web.sh

--- a/deploy/docker/Dockerfile-web
+++ b/deploy/docker/Dockerfile-web
@@ -18,8 +18,7 @@ LABEL maintainer="info@cert.pl"
 ENV PROXY_BACKEND_URL http://mwdb.:8080
 ENV NGINX_MAX_UPLOAD_SIZE 50M
 
-COPY docker/nginx.conf.template /etc/nginx/conf.d/default.conf.template
-COPY docker/start-web.sh /start-web.sh
+COPY docker/nginx.conf.template /etc/nginx/templates/default.conf.template
 COPY --from=build /app/dist /usr/share/nginx/html
 
 # Give +r to everything in /usr/share/nginx/html and +x for directories
@@ -27,5 +26,3 @@ RUN chmod u=rX,go= -R /usr/share/nginx/html
 
 # By default everything is owned by root - change owner to nginx
 RUN chown nginx:nginx -R /usr/share/nginx/html
-
-CMD ["/bin/sh", "/start-web.sh"]

--- a/deploy/docker/Dockerfile-web-dev
+++ b/deploy/docker/Dockerfile-web-dev
@@ -12,6 +12,7 @@ RUN cd /app \
     && npm cache clean --force
 
 ENV PROXY_BACKEND_URL http://mwdb.:8080
+ENV NGINX_MAX_UPLOAD_SIZE 50M
 
 WORKDIR /app
 CMD ["npm", "run", "dev"]

--- a/deploy/docker/Dockerfile-web-dev
+++ b/deploy/docker/Dockerfile-web-dev
@@ -12,7 +12,6 @@ RUN cd /app \
     && npm cache clean --force
 
 ENV PROXY_BACKEND_URL http://mwdb.:8080
-ENV NGINX_MAX_UPLOAD_SIZE 50M
 
 WORKDIR /app
 CMD ["npm", "run", "dev"]

--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -3,7 +3,7 @@ server {
     server_name  mwdb-web;
     root         /usr/share/nginx/html;
 
-    client_max_body_size "${NGINX_MAX_UPLOAD_SIZE}";
+    client_max_body_size ${NGINX_MAX_UPLOAD_SIZE};
 
     location /api/ {
         proxy_pass ${PROXY_BACKEND_URL}/api/;

--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -3,7 +3,7 @@ server {
     server_name  mwdb-web;
     root         /usr/share/nginx/html;
 
-    client_max_body_size ${NGINX_MAX_UPLOAD_SIZE};
+    client_max_body_size "${NGINX_MAX_UPLOAD_SIZE}";
 
     location /api/ {
         proxy_pass ${PROXY_BACKEND_URL}/api/;

--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -3,7 +3,7 @@ server {
     server_name  mwdb-web;
     root         /usr/share/nginx/html;
 
-    client_max_body_size 50M;
+    client_max_body_size ${NGINX_MAX_UPLOAD_SIZE};
 
     location /api/ {
         proxy_pass ${PROXY_BACKEND_URL}/api/;

--- a/docker/start-web.sh
+++ b/docker/start-web.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-envsubst '\$PROXY_BACKEND_URL' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
-nginx -g "daemon off;"

--- a/docs/setup-and-configuration.rst
+++ b/docs/setup-and-configuration.rst
@@ -246,6 +246,18 @@ If you use Docker-based setup, all the configuration can be set using environmen
    If you are using ``karton``, we highly recommend creating a separate bucket for it.
    Failing to do so might result in data loss caused by ``karton's`` garbage collector. 
 
+Setting higher upload size limit in Docker
+------------------------------------------
+
+mwdb-core allows to set maximum upload size via ``max_upload_size`` parameter in configuration (see also :ref:`Advanced configuration` section).
+
+mwdb-core package doesn't enforce any limitation by default, but if you use Docker images: nginx configuration in mwdb-web image have set 50M limit
+using `client_max_body_size <http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size>`_ option. If you want to set different
+limitation for Docker environment, use ``NGINX_MAX_UPLOAD_SIZE`` environment variable to set ``client_max_body_size`` option.
+
+If you want to customize other nginx settings (e.g. timeouts), you can also provide your own ``nginx.conf.template`` by building your own image
+based on ``certpl/mwdb-web``. More information can be found in `#927 issue discussion on Github <https://github.com/CERT-Polska/mwdb-core/issues/927>`_.
+
 Advanced configuration
 ----------------------
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- ~~[ ] I've added automated tests for my change (if applicable, optional)~~
- [x] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

- we can't easily set client_max_body_size without building own image
- `nginx` Docker image provides correct `start-web.sh` on its own which is then unnecessarily overridden by our Dockerfile

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- Added `NGINX_MAX_UPLOAD_SIZE` env reference to `client_max_body_size` option in `nginx.conf.template`
- Set correct path for `nginx.conf.template` (`/etc/nginx/templates/default.conf.template` instead of `/etc/nginx/conf.d/default.conf.template`) and added default `50M` in `ENV` directive.

**Test plan**
<!-- Explain how to test your changes -->
- Check if setting works with no env value set and with custom value (I've done it during manual test of my changes)
<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #927 
