### PR TITLE
Passing tags to karton.

### DIFF
--- a/mwdb/core/karton.py
+++ b/mwdb/core/karton.py
@@ -94,6 +94,7 @@ def send_file_to_karton(file: "File", arguments: Dict[str, Any]) -> str:
                 "attributes": file.get_attributes(
                     as_dict=True, check_permissions=False
                 ),
+                "tags": [x.tag for x in file.tags],
             },
             priority=task_priority,
         )


### PR DESCRIPTION
Passing tags to karton can be extremly useful in some scenarios.

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
When a Task object is created for karton, currently only attributes and a Resource object are passed.

**What is the new behaviour?**
In addition tags will now be passed (as strings) to enable conditional processing by karton based on file tags.

**Test plan**
From within karton modules you should be able to access file tags by ```task.get_payload("tags")```.
