### PR TITLE
Fix: don't jsonify view method result in Resource

### DIFF
--- a/mwdb/core/service.py
+++ b/mwdb/core/service.py
@@ -14,7 +14,6 @@ from werkzeug.exceptions import (
     MethodNotAllowed,
     ServiceUnavailable,
 )
-from werkzeug.wrappers import Response
 
 from mwdb.version import app_version
 
@@ -45,10 +44,7 @@ class Resource(MethodView):
                 valid_methods=self.methods,
                 description="Method is not allowed for this endpoint",
             )
-        response = getattr(self, method)(*args, **kwargs)
-        if isinstance(response, Response):
-            return response
-        return jsonify(response)
+        return getattr(self, method)(*args, **kwargs)
 
 
 class Service:

--- a/mwdb/core/service.py
+++ b/mwdb/core/service.py
@@ -44,7 +44,10 @@ class Resource(MethodView):
                 valid_methods=self.methods,
                 description="Method is not allowed for this endpoint",
             )
-        return getattr(self, method)(*args, **kwargs)
+        response = getattr(self, method)(*args, **kwargs)
+        if response is None:
+            return jsonify(None), 200
+        return response
 
 
 class Service:


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

Change introduced in https://github.com/CERT-Polska/mwdb-core/pull/916 was calling `jsonify` on all view method results that were not Response objects.

It was found that plugins are using other response formats accepted by Flask e.g. `{"data": ...}, 200` which were incorrectly jsonified into array `[{"data": ...}, 200]` instead being treated as `<payload>, <status_code>)` structure

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

Responses from view methods are directly passed to the Flask. The only exception is `None` that is returned as jsonified `null` (Flask explicitly rejects None with exception "TypeError: The view function for '...' did not return a valid response. The function either returned None or ended without a return statement.").


**Test plan**
<!-- Explain how to test your changes -->

Tested on our internal set of plugins that things are working correctly

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

none
