### PR TITLE
Fix: don't forget diff= parameter while searching in diff mode

### DIFF
--- a/mwdb/web/src/components/RecentView/Views/RecentView.tsx
+++ b/mwdb/web/src/components/RecentView/Views/RecentView.tsx
@@ -67,6 +67,7 @@ export function RecentView(props: Props) {
                 if (query === prev.get("query"))
                     throw new Error("Tried to set the same query twice");
                 return {
+                    ...Object.fromEntries(prev.entries()),
                     q: query,
                     count: prev.get("count") === "1" ? "1" : "0",
                 };
@@ -233,6 +234,9 @@ export function RecentView(props: Props) {
                                         setSearchParams(
                                             (prev) => {
                                                 return {
+                                                    ...Object.fromEntries(
+                                                        prev.entries()
+                                                    ),
                                                     q: prev.get("q") || "",
                                                     count: countingEnabled
                                                         ? "0"


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

When "Diff with.." option is used, MWDB UI escapes from diff mode into standard mode when we use Search. It happens because setSearchParams forget about `diff=` argument in query parameters.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

Fixed setSearchParams invocation to not lose other arguments while updating search params

**Test plan**
<!-- Explain how to test your changes -->

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->
