### PR TITLE
Fix: Too eager schema for FileItemResponseSchema.latest_config field

### DIFF
--- a/mwdb/schema/config.py
+++ b/mwdb/schema/config.py
@@ -41,6 +41,19 @@ class ConfigListResponseSchema(
     __envelope_key__ = "configs"
 
 
+class ConfigLatestItemResponseSchema(ObjectListItemResponseSchema):
+    """
+    Limited ConfigItemResponseSchema that doesn't fetch relationships
+    and other extra metadata.
+
+    Used by FileItemResponseSchema.latest_config field.
+    """
+
+    family = fields.Str(required=True, allow_none=False)
+    config_type = fields.Str(required=True, allow_none=False)
+    cfg = fields.Dict(required=True, allow_none=False)
+
+
 class ConfigItemResponseSchema(ObjectItemResponseSchema):
     family = fields.Str(required=True, allow_none=False)
     config_type = fields.Str(required=True, allow_none=False)

--- a/mwdb/schema/file.py
+++ b/mwdb/schema/file.py
@@ -2,7 +2,7 @@ import json
 
 from marshmallow import Schema, fields, pre_load
 
-from .config import ConfigItemResponseSchema
+from .config import ConfigLatestItemResponseSchema
 from .object import (
     ObjectCreateRequestSchemaBase,
     ObjectItemResponseSchema,
@@ -67,7 +67,7 @@ class FileItemResponseSchema(ObjectItemResponseSchema):
     ssdeep = fields.Str(required=True, allow_none=True)
 
     latest_config = fields.Nested(
-        ConfigItemResponseSchema, required=True, allow_none=True
+        ConfigLatestItemResponseSchema, required=True, allow_none=True
     )
 
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

`latest_config` field returned by `/api/file/<hash>` endpoint returns all fields for config item including relationships and attributes. This makes file response unnecessarily large, especially when config has lots of relationships to other objects.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

`latest_config` field returns limited information, similar to ConfigListItemResponseSchema but including configuration contents.

**Test plan**
<!-- Explain how to test your changes -->

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**
