### PR TITLE
Fix: faster wildcard queries for JSONB fields

### DIFF
--- a/mwdb/core/search/fields.py
+++ b/mwdb/core/search/fields.py
@@ -35,6 +35,7 @@ from .exceptions import (
 from .node_to_value import node_is_range, range_from_node, string_from_node
 from .parse_helpers import (
     PathSelector,
+    ensure_inner_match_pattern,
     is_pattern_value,
     jsonpath_config_string_equals,
     jsonpath_range_equals,
@@ -244,8 +245,11 @@ class JSONBaseField(ColumnField):
                 # less expensive. We hope that it will be used by
                 # query planner to pre-filter results before applying
                 # function scan.
+                inner_match_value = self._get_quoted_value_for_like_statement(
+                    ensure_inner_match_pattern(string_value)
+                )
                 string_in_json_condition = cast(self.column, Text).like(
-                    stringified_value
+                    inner_match_value
                 )
                 return and_(
                     exists(

--- a/mwdb/core/search/fields.py
+++ b/mwdb/core/search/fields.py
@@ -250,8 +250,18 @@ class JSONBaseField(ColumnField):
                 inner_match_value = self._get_quoted_value_for_like_statement(
                     ensure_inner_match_pattern(string_value)
                 )
+                # But if we are looking for part of JSON instead of string value,
+                # we shouldn't double escape backslashes. This feature is very obsolete
+                # and will be dropped in future versions of MWDB
+                inner_match_json_part = (
+                    "{"
+                    + self._get_value_for_like_statement(
+                        ensure_inner_match_pattern(string_value)
+                    )
+                    + "}"
+                )
                 string_in_json_condition = cast(self.column, Text).like(
-                    inner_match_value
+                    any_([inner_match_value, inner_match_json_part])
                 )
                 return and_(
                     exists(

--- a/mwdb/core/search/fields.py
+++ b/mwdb/core/search/fields.py
@@ -245,6 +245,8 @@ class JSONBaseField(ColumnField):
                 # less expensive. We hope that it will be used by
                 # query planner to pre-filter results before applying
                 # function scan.
+                # Ensure wildcards are at the beginning and the end to make query like:
+                # object.cfg::text LIKE '{*<pattern>*}'
                 inner_match_value = self._get_quoted_value_for_like_statement(
                     ensure_inner_match_pattern(string_value)
                 )

--- a/mwdb/core/search/parse_helpers.py
+++ b/mwdb/core/search/parse_helpers.py
@@ -308,6 +308,19 @@ def is_nonstring_object(value: str) -> bool:
     return bool(re.fullmatch(r"(false|true|null|(0|[1-9]\d*)([.]\d+)?)", value))
 
 
+def ensure_inner_match_pattern(value: str) -> str:
+    """
+    Ensures that pattern starts and ends with unescaped wildcard '*'
+    """
+    wildcard_pattern = r"((?<=[^\\])[*]|\\\\[*]|^[*])"  # non escaped *
+    pattern = value
+    if not re.search("^" + wildcard_pattern, value):
+        pattern = "*" + pattern
+    if not re.search(wildcard_pattern + "$", value):
+        pattern = pattern + "*"
+    return pattern
+
+
 def is_pattern_value(value) -> bool:
     """
     Returns True if value contains wildcards


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

JSONB wildcard queries are very slow because there is no supported JSONB "LIKE" operator that works with current implementation of GIN index. In the same time, LIKE on `jsonb_path_query` function result is very expensive.

So queries like:

```
cfg:"*/content/*"
```

may take minutes, especially when matching rows are really far in config table, which is far more than usual request timeout setting.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

Configs are too long to be indexed by simple btree, but we found that simple `object.cfg::text LIKE "%...%"` works much faster even if it performs a full table scan. It's not exactly what we want if we use key predicate (`cfg.urls:*/content/*`) so it's still combined with the original `jsonb_path_query`-based solution with hope that PostgreSQL will use simple LIKE to pre-filter the rows before using function-based query. On our database data it usually does. 

In future PRs I plan to optimize it further to avoid full scan at all.

**Test plan**

**Closing issues**
