### PR TITLE
Simplify wildcard JSON searching

### DIFF
--- a/mwdb/core/search/fields.py
+++ b/mwdb/core/search/fields.py
@@ -6,7 +6,7 @@ from typing import Any, Optional, Type
 from dateutil.relativedelta import relativedelta
 from flask import g
 from luqum.tree import FieldGroup, Item, OpenRange, Range, Term
-from sqlalchemy import String, Text, and_, any_, cast, column, exists, func, or_, select
+from sqlalchemy import String, Text, and_, cast, column, exists, func, or_, select
 from sqlalchemy.dialects.postgresql import ARRAY, array
 from sqlalchemy.dialects.postgresql.array import CONTAINS
 from sqlalchemy.dialects.postgresql.json import JSONPATH_ASTEXT
@@ -36,6 +36,7 @@ from .node_to_value import node_is_range, range_from_node, string_from_node
 from .parse_helpers import (
     PathSelector,
     ensure_inner_match_pattern,
+    is_inner_match_pattern,
     is_pattern_value,
     jsonpath_config_string_equals,
     jsonpath_range_equals,
@@ -188,14 +189,6 @@ class JSONBaseField(ColumnField):
         """
         return transform_for_quoted_like_statement(value)
 
-    def _get_nested_value_for_like_statement(self, value: str) -> str:
-        return self._get_value_for_like_statement(ensure_inner_match_pattern(value))
-
-    def _get_quoted_nested_value_for_like_statement(self, value: str) -> str:
-        return self._get_quoted_value_for_like_statement(
-            ensure_inner_match_pattern(value)
-        )
-
     def _get_jsonpath_for_range_equals(
         self,
         path_selector: PathSelector,
@@ -233,56 +226,50 @@ class JSONBaseField(ColumnField):
         else:
             string_value = string_from_node(node, escaped=True)
             if is_pattern_value(string_value):
-                node = self._get_value_for_like_statement(string_value)
-                stringified_value = self._get_quoted_value_for_like_statement(
+                pattern_value = self._get_value_for_like_statement(string_value)
+                quoted_pattern_value = self._get_quoted_value_for_like_statement(
                     string_value
                 )
-                if (
-                    string_value.startswith("*")
-                    and string_value.endswith("*")
-                    and node != stringified_value
-                ):
-                    node = any_([node, stringified_value])
+
                 jsonpath_selector = make_jsonpath_selector(path_selector)
                 json_elements = func.jsonb_path_query(
                     self.column, jsonpath_selector
                 ).alias("json_element")
-                json_element = column(json_elements.name).operate(
-                    JSONPATH_ASTEXT, "{}", result_type=Text
-                )
-                # Hack: these queries perform very slow full table scan
+
+                if is_inner_match_pattern(string_value):
+                    # If pattern starts and ends with *, we are searching
+                    # inside quoted string values and nested objects
+                    json_element = cast(column(json_elements.name), Text)
+                    value_condition = exists(
+                        select([1])
+                        .select_from(json_elements)
+                        .where(json_element.like(quoted_pattern_value))
+                    )
+                else:
+                    # If not, we need to cast the element to unquoted value
+                    # using #>> '{}' operator and assume that we're looking
+                    # for literal value under specific key
+                    json_element = column(json_elements.name).operate(
+                        JSONPATH_ASTEXT, "{}", result_type=Text
+                    )
+                    value_condition = exists(
+                        select([1])
+                        .select_from(json_elements)
+                        .where(json_element.like(pattern_value))
+                    )
+                # Hack: queries above perform very slow full table scan
                 # because we can't directly index JSONB for quick wildcard
                 # searches. That's why we combine query with another
                 # LIKE condition over object.cfg::text column that is
                 # less expensive. We hope that it will be used by
                 # query planner to pre-filter results before applying
                 # function scan.
-                # Ensure wildcards are at the beginning and the end to make query like:
-                # object.cfg::text LIKE '{*<pattern>*}'
-                inner_match_value = self._get_quoted_nested_value_for_like_statement(
-                    string_value
+                whole_config_match_condition = cast(self.column, Text).like(
+                    ensure_inner_match_pattern(quoted_pattern_value)
                 )
-                # But if we are looking for part of JSON instead of string value,
-                # we shouldn't double escape backslashes. This feature is very obsolete
-                # and will be dropped in future versions of MWDB
-                inner_match_json_part = self._get_nested_value_for_like_statement(
-                    string_value
-                )
-                if inner_match_value == inner_match_json_part:
-                    string_in_json_condition = cast(self.column, Text).like(
-                        inner_match_value
-                    )
-                else:
-                    string_in_json_condition = cast(self.column, Text).like(
-                        any_([inner_match_value, inner_match_json_part])
-                    )
                 return and_(
-                    exists(
-                        select([1])
-                        .select_from(json_elements)
-                        .where(json_element.like(node))
-                    ),
-                    string_in_json_condition,
+                    value_condition,
+                    whole_config_match_condition,
                 )
             else:
                 jsonpath_condition = self._get_jsonpath_for_string_equals(
@@ -338,15 +325,6 @@ class ConfigField(JSONBaseField):
 
     def _get_quoted_value_for_like_statement(self, value: str) -> str:
         return transform_for_quoted_config_like_statement(value)
-
-    def _get_nested_value_for_like_statement(self, value: str) -> str:
-        # Configs are always dicts so we can't add additional brackets
-        # to deduplicate any(array['{*query*}', '*query*'])
-        return (
-            "{"
-            + self._get_value_for_like_statement(ensure_inner_match_pattern(value))
-            + "}"
-        )
 
     def _get_jsonpath_for_range_equals(
         self,

--- a/mwdb/core/search/fields.py
+++ b/mwdb/core/search/fields.py
@@ -230,6 +230,9 @@ class JSONBaseField(ColumnField):
                 quoted_pattern_value = self._get_quoted_value_for_like_statement(
                     string_value
                 )
+                inner_match_pattern_value = self._get_quoted_value_for_like_statement(
+                    ensure_inner_match_pattern(string_value)
+                )
 
                 jsonpath_selector = make_jsonpath_selector(path_selector)
                 json_elements = func.jsonb_path_query(
@@ -265,7 +268,7 @@ class JSONBaseField(ColumnField):
                 # query planner to pre-filter results before applying
                 # function scan.
                 whole_config_match_condition = cast(self.column, Text).like(
-                    ensure_inner_match_pattern(quoted_pattern_value)
+                    inner_match_pattern_value
                 )
                 return and_(
                     value_condition,

--- a/mwdb/core/search/parse_helpers.py
+++ b/mwdb/core/search/parse_helpers.py
@@ -152,7 +152,7 @@ def transform_for_like_statement(escaped_value: str) -> str:
 def transform_for_quoted_like_statement(escaped_value: str) -> str:
     """
     Transforms Lucene value to pattern for LIKE condition
-    against stringified JSON
+    against stringified JSON values
     """
 
     def transform_token(token: StringToken) -> StringToken:
@@ -271,7 +271,7 @@ def transform_for_quoted_config_like_statement(escaped_value: str) -> str:
         tokenize_string(escaped_value, "*?", control_escapes="tnrxuU")
     )
     transformed_string = list(transform_token(token) for token in tokenized_string)
-    return "{" + join_tokenized_string(transformed_string) + "}"
+    return join_tokenized_string(transformed_string)
 
 
 def jsonpath_quote(value: str) -> str:
@@ -306,6 +306,18 @@ def is_nonstring_object(value: str) -> bool:
     so JSON must be queried using both types
     """
     return bool(re.fullmatch(r"(false|true|null|(0|[1-9]\d*)([.]\d+)?)", value))
+
+
+def is_inner_match_pattern(value: str) -> bool:
+    """
+    Checks if pattern starts and ends with unescaped wildcard '*'
+    """
+    wildcard_pattern = r"((?<=[^\\])[*]|\\\\[*]|^[*])"  # non escaped *
+    if not re.search("^" + wildcard_pattern, value):
+        return False
+    if not re.search(wildcard_pattern + "$", value):
+        return False
+    return True
 
 
 def ensure_inner_match_pattern(value: str) -> str:

--- a/mwdb/core/search/parse_helpers.py
+++ b/mwdb/core/search/parse_helpers.py
@@ -149,7 +149,9 @@ def transform_for_like_statement(escaped_value: str) -> str:
     return join_tokenized_string(transformed_string)
 
 
-def transform_for_quoted_like_statement(escaped_value: str) -> str:
+def transform_for_quoted_like_statement(
+    escaped_value: str, escape_quotes: bool = True
+) -> str:
     """
     Transforms Lucene value to pattern for LIKE condition
     against stringified JSON values
@@ -165,7 +167,9 @@ def transform_for_quoted_like_statement(escaped_value: str) -> str:
         elif token_type is TokenType.STRING:
             # Escape all backslashes and quotes to correctly represent
             # these characters in quoted string
-            value = re.sub(r'(["\\])', r"\\\1", token_value)
+            value = re.sub(
+                r'(["\\])' if escape_quotes else r"([\\])", r"\\\1", token_value
+            )
             # Then escape SQL wildcards (for LIKE) and
             # once again escape all backslashes
             value = re.sub(r"([%_\\])", r"\\\1", value)
@@ -236,7 +240,9 @@ def transform_for_config_like_statement(escaped_value: str) -> str:
     return join_tokenized_string(transformed_string)
 
 
-def transform_for_quoted_config_like_statement(escaped_value: str) -> str:
+def transform_for_quoted_config_like_statement(
+    escaped_value: str, escape_quotes: bool = True
+) -> str:
     """
     Transforms Lucene value to pattern for LIKE condition against
     "unicode-escape"-escaped stringified JSON value
@@ -262,7 +268,8 @@ def transform_for_quoted_config_like_statement(escaped_value: str) -> str:
             # and second level for JSON string
             value = value.replace("\\", "\\" * 4)
             # Escape inner quotes
-            value = value.replace('"', ("\\" * 2) + '"')
+            if escape_quotes:
+                value = value.replace('"', ("\\" * 2) + '"')
             # Finally escape all SQL wildcards with only LIKE-level backslashes
             value = re.sub(r"([%_])", r"\\\1", value)
             return TokenType.STRING, value


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [x] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

JSON search code is pretty complicated because it assumes that wildcard search that is not a full-text search (with wildcards on both sides `*value*`) can also search for nested objects, so it needs to look for two possible combinations of escaping: 

- quoted values `{"key": {"current_dir": "C:\\Windows"}}` so `cfg.key:*C:\\Windows*` needs to search for `LIKE '%C:\\\\Windows'` as the value returned by `json_path_query(cfg, '$.key') #>> '{}'` is `{"current_dir": "C:\\Windows"}`
- unquoted values `{"key": "C:\Windows"}` so `cfg.key:"C:\\Windows*"`  needs to search for `LIKE "C:\\Windows%"` as the value returned by `json_path_query(cfg, '$.key') #>> '{}'` is `C:\Windows`

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

We just assume that nested objects can be searched only with full-text search. When search is not full-text, we assume that we match only against literal, which simplifies query.
