### PR TITLE
Fix: don't use joined relationship for 'favorite' parameter

### DIFF
--- a/mwdb/model/object.py
+++ b/mwdb/model/object.py
@@ -99,9 +99,7 @@ class Object(db.Model):
         cascade="save-update, merge, delete",
     )
 
-    followers = db.relationship(
-        "User", secondary=favorites, back_populates="favorites", lazy="joined"
-    )
+    followers = db.relationship("User", secondary=favorites, back_populates="favorites")
 
     comment_authors = db.relationship(
         "User",

--- a/mwdb/model/user.py
+++ b/mwdb/model/user.py
@@ -61,7 +61,7 @@ class User(db.Model):
         back_populates="related_user",
     )
     favorites = db.relationship(
-        "Object", secondary=favorites, back_populates="followers", lazy="joined"
+        "Object", secondary=favorites, back_populates="followers"
     )
 
     commented_objects = db.relationship(


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [x] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

Followers are joined for every Object instance and Favorites are joined for every User instance. It's completely unnecessary and has negative impact on query performance.

Joined relationships in objects should be used only for fields included in listing schemas like `ObjectListItemResponseSchema` to avoid N+1 problem.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

Favorites/Followers are loaded lazily.

