### PR TITLE
Simplified RecentView without preloading

### DIFF
--- a/mwdb/web/src/components/RecentView/Views/RecentViewList.tsx
+++ b/mwdb/web/src/components/RecentView/Views/RecentViewList.tsx
@@ -185,7 +185,8 @@ export function RecentViewList(props: Props) {
                     </tr>
                 ) : (
                     !listState.elements.length &&
-                    props.query !== null && (
+                    props.query !== null &&
+                    !listState.error && (
                         <tr key="empty" className="d-flex">
                             <td className="col-12 text-center">
                                 There are no elements to show.


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

When user submits a query, the first page of results is actually fetched twice in non-counting mode:

1. First time the list goes blurred and frontend sends a query for first 10 results
2. If there's no error, query is submitted into URI and frontend starts dynamic fetch of all results, including first page.

It makes the search slower, although not twice as slow because some data are already cached by database, so usually the second run is a bit faster.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

- Query is submitted as soon as user presses Enter, without "blurry" state
- Counting is done in parallel.

In the same time, I fixed some glitches that I found during testing.
