### PR TITLE
Frontend: add warning banner when server version is different than client version

### DIFF
--- a/mwdb/web/src/App.tsx
+++ b/mwdb/web/src/App.tsx
@@ -5,6 +5,9 @@ import { ConfigContext } from "./commons/config";
 import { Extendable } from "./commons/plugins";
 import { ErrorBoundary } from "./commons/ui";
 import { AppRoutes } from "./commons/navigation/AppRoutes";
+import { VersionMismatchWarning } from "@mwdb-web/components/VersionMismatchWarning";
+
+import { version as clientVersion } from "../package.json";
 
 export function App() {
     const config = useContext(ConfigContext);
@@ -12,6 +15,14 @@ export function App() {
         <div className="App">
             <Navigation />
             <div className="content">
+                {config.isReady ? (
+                    <VersionMismatchWarning
+                        clientVersion={clientVersion}
+                        serverVersion={config.config.server_version}
+                    />
+                ) : (
+                    []
+                )}
                 <ErrorBoundary>
                     <Extendable ident="main">
                         {config.isReady ? <AppRoutes /> : []}

--- a/mwdb/web/src/components/VersionMismatchWarning.tsx
+++ b/mwdb/web/src/components/VersionMismatchWarning.tsx
@@ -11,8 +11,8 @@ export function VersionMismatchWarning({
     return (
         <div className="alert alert-warning" role="alert">
             Server version was recently updated to {serverVersion} while
-            currently loaded web application is {clientVersion}. Press
-            CTRL+F5 to clear cache and reload the webpage.
+            currently loaded web application is {clientVersion}. Press CTRL+F5
+            to clear cache and reload the webpage.
         </div>
     );
 }

--- a/mwdb/web/src/components/VersionMismatchWarning.tsx
+++ b/mwdb/web/src/components/VersionMismatchWarning.tsx
@@ -1,0 +1,18 @@
+type VersionMismatchWarningProps = {
+    serverVersion?: string;
+    clientVersion: string;
+};
+
+export function VersionMismatchWarning({
+    serverVersion,
+    clientVersion,
+}: VersionMismatchWarningProps) {
+    if (!serverVersion || clientVersion == serverVersion) return <></>;
+    return (
+        <div className="alert alert-warning" role="alert">
+            Server version was recently updated to {serverVersion} while
+            currently loaded web application is {clientVersion}. Press
+            CTRL+F5 to clear cache and reload the webpage.
+        </div>
+    );
+}

--- a/mwdb/web/src/components/VersionMismatchWarning.tsx
+++ b/mwdb/web/src/components/VersionMismatchWarning.tsx
@@ -3,11 +3,21 @@ type VersionMismatchWarningProps = {
     clientVersion: string;
 };
 
+function stripVersionTag(version: string): string {
+    // Strips possible version tag with Git revision
+    // e.g. 2.0.0-rc1+6b2f1c1a is converted to 2.0.0-rc1
+    return version.split("+")[0];
+}
+
 export function VersionMismatchWarning({
     serverVersion,
     clientVersion,
 }: VersionMismatchWarningProps) {
-    if (!serverVersion || clientVersion == serverVersion) return <></>;
+    if (
+        !serverVersion ||
+        stripVersionTag(clientVersion) === stripVersionTag(serverVersion)
+    )
+        return <></>;
     return (
         <div className="alert alert-warning" role="alert">
             Server version was recently updated to {serverVersion} while


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

When MWDB Core is updated, users usually still have cached older version of a client which may lead to glitches and errors.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

Added warning that recommends to force reload webpage using CTRL+F5 when version mismatch is detected.
