### PR TITLE
Fix: ISE 500 when non-numerical value appears in range search in JSON column

### DIFF
--- a/tests/backend/test_attributes.py
+++ b/tests/backend/test_attributes.py
@@ -217,3 +217,12 @@ def test_attribute_falsy_values(admin_session, random_attribute):
         admin_session.add_attribute(sample_id, attr_name, "")
     admin_session.add_attribute(sample_id, attr_name, ["nonempty"])
     admin_session.add_attribute(sample_id, attr_name, {"nonempty": None})
+
+
+def test_attribute_json_string_range(admin_session, random_attribute):
+    sample_id, attr_name = random_attribute
+    admin_session.add_attribute(sample_id, attr_name, {"creation-time": "2024-06-01 12:00:00"})
+    assert len(admin_session.search(f'attribute.{attr_name}.creation-time:>="2024-05"')) == 1
+    assert len(admin_session.search(f'attribute.{attr_name}.creation-time:>="2024-07"')) == 0
+    assert len(admin_session.search(f'attribute.{attr_name}.creation-time:["2024-07" TO "2024-08"]')) == 0
+    assert len(admin_session.search(f'attribute.{attr_name}.creation-time:["2024-06" TO "2024-07"]')) == 1


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [x] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
When we try to use non-numerical value in range search, query fails with Internal server error because of incorrectly formatted jsonpath.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

When value doesn't look like a number or known JSON literal, value is properly quoted and escaped before put in the jsonpath query.

**Test plan**
<!-- Explain how to test your changes -->

Added automated test to fulfill use-case mentioned in related issue

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #952 
