### PR TITLE
Bump version: v2.13.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     depends_on:
       - postgres
       - redis
-    image: certpl/mwdb:v2.12.0
+    image: certpl/mwdb:v2.13.0
     restart: on-failure
     env_file:
       # NOTE: use gen_vars.sh in order to generate this file
@@ -22,7 +22,7 @@ services:
     build:
       context: .
       dockerfile: deploy/docker/Dockerfile-web
-    image: certpl/mwdb-web:v2.12.0
+    image: certpl/mwdb-web:v2.13.0
     ports:
       - "80:80"
     restart: on-failure

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ copyright = '2021, CERT Polska'
 author = 'CERT Polska'
 
 # The full version, including alpha/beta/rc tags
-release = '2.12.0'
+release = '2.13.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/whats-changed.rst
+++ b/docs/whats-changed.rst
@@ -7,6 +7,15 @@ have compatibility problems after minor mwdb-core upgrade.
 
 For upgrade instructions, see :ref:`Upgrading mwdb-core to latest version`.
 
+v2.13.0
+-------
+
+This release is focused on further improvements of search performance and bugfixes.
+
+It's recommended to upgrade your karton-system to v5.4.0 before applying this upgrade.
+
+Complete changelog can be found here: `v2.13.0 changelog <https://github.com/CERT-Polska/mwdb-core/releases/tag/v2.13.0>`_.
+
 v2.12.0
 -------
 

--- a/mwdb/version.py
+++ b/mwdb/version.py
@@ -4,5 +4,5 @@ try:
 except IOError:
     git_revision = ""
 
-app_version = "2.12.0"
+app_version = "2.13.0"
 app_build_version = f"{app_version}+{git_revision}" if git_revision else app_version

--- a/mwdb/web/package-lock.json
+++ b/mwdb/web/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "mwdb-web",
-    "version": "2.12.0",
+    "version": "2.13.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "mwdb-web",
-            "version": "2.12.0",
+            "version": "2.13.0",
             "dependencies": {
                 "@fortawesome/fontawesome-svg-core": "^6.1.1",
                 "@fortawesome/free-regular-svg-icons": "^6.1.1",

--- a/mwdb/web/package.json
+++ b/mwdb/web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mwdb-web",
-    "version": "2.12.0",
+    "version": "2.13.0",
     "private": true,
     "scripts": {
         "dev": "vite",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ Under the hood of mwdb.cert.pl service hosted by CERT.pl.
 """
 
 setup(name="mwdb-core",
-      version="2.12.0",
+      version="2.13.0",
       description="MWDB Core malware database",
       long_description=LONG_DESCRIPTION,
       author="CERT Polska",


### PR DESCRIPTION
This release is focused on further improvements of search performance and bugfixes.

It's recommended to upgrade your karton-system to v5.4.0 before applying this upgrade.

**New features and improvements:**

* Improved performance of object lists in Web UI (https://github.com/CERT-Polska/mwdb-core/pull/949)
* Improved performance of wildcard queries for JSONB fields by @psrok1 in https://github.com/CERT-Polska/mwdb-core/pull/943
* Karton is upgraded to v5.4.0 with much faster analysis status lookup method  (https://github.com/CERT-Polska/mwdb-core/pull/938)
* Tags are passed to Karton tasks (by @aBUDmdBQ in https://github.com/CERT-Polska/mwdb-core/pull/934)
* Frontend: added warning banner when server version is different than client version, so user needs to clear cache (https://github.com/CERT-Polska/mwdb-core/pull/950)
* Allow to set custom upload size limit via NGINX_MAX_UPLOAD_SIZE env var in mwdb-web Docker image 
(https://github.com/CERT-Polska/mwdb-core/pull/930)

**Bugfixes:**

* Fix: ISE 500 on concurrent tag addition (https://github.com/CERT-Polska/mwdb-core/pull/926)
* Fix: ISE 500 when non-numerical value appears in range search in JSON column by @psrok1 in https://github.com/CERT-Polska/mwdb-core/pull/953
* Fix possible issues with plugins after replacing Flask-RESTful with own implementation (https://github.com/CERT-Polska/mwdb-core/pull/937)
* Fix searching in diff mode (https://github.com/CERT-Polska/mwdb-core/pull/941)
* Fix too eager schema for FileItemResponseSchema.latest_config field that affected performance of getting file items (https://github.com/CERT-Polska/mwdb-core/pull/942)
* Fix unnecessary joined relationship for 'favorite' parameter affecting performance of searching and getting object lists (https://github.com/CERT-Polska/mwdb-core/pull/948)

## New Contributors
* @aBUDmdBQ made their first contribution in https://github.com/CERT-Polska/mwdb-core/pull/934

**Full Changelog**: https://github.com/CERT-Polska/mwdb-core/compare/v2.12.0...v2.13.0