### PR TITLE
Allow to set limit of tags returned by TagListResource

### DIFF
--- a/mwdb/resources/tag.py
+++ b/mwdb/resources/tag.py
@@ -42,6 +42,12 @@ class TagListResource(Resource):
                 type: string
               description: Tag prefix
               required: false
+            - in: query
+              name: count
+              schema:
+                type: integer
+              description: Number of objects to return
+              required: false
         responses:
             200:
                 description: List of tags
@@ -67,6 +73,11 @@ class TagListResource(Resource):
         tag_prefix = obj["query"]
         if tag_prefix:
             tags = tags.filter(Tag.tag.startswith(tag_prefix, autoescape=True))
+
+        tag_count = obj.get("count")
+        if tag_count:
+            tags = tags.limit(tag_count)
+
         tags = tags.all()
         schema = TagItemResponseSchema(many=True)
         return schema.dump(tags)

--- a/mwdb/schema/tag.py
+++ b/mwdb/schema/tag.py
@@ -19,6 +19,7 @@ class TagSchemaBase(Schema):
 
 class TagListRequestSchema(Schema):
     query = fields.Str(missing="")
+    count = fields.Int()
 
 
 class TagRequestSchema(TagSchemaBase):

--- a/mwdb/web/src/commons/api/index.tsx
+++ b/mwdb/web/src/commons/api/index.tsx
@@ -267,9 +267,9 @@ function getObjectCount(
     });
 }
 
-function getTags(query: string): GetTagsResponse {
+function getTags(query: string, count: number): GetTagsResponse {
     return axios.get(`/tag`, {
-        params: { query },
+        params: { query, count },
     });
 }
 

--- a/mwdb/web/src/components/ShowObject/common/TagForm.tsx
+++ b/mwdb/web/src/components/ShowObject/common/TagForm.tsx
@@ -30,7 +30,7 @@ export function TagForm(props: Props) {
             return;
         }
         try {
-            const response = await api.getTags(value);
+            const response = await api.getTags(value, 20);
             setTags(response.data.map((t) => t.tag));
         } catch (error) {
             context.setObjectError(error);


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

TagListResource returns all tags matching provided prefix without any limitation. It's especially expensive when we provide a very common prefix e.g. "feed:" or "ripped:"

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

- Added `count` argument to the endpoint
- `count` is set by default to 20 in "Add tag" autocompletion list


