### PR TITLE
CI: Bump docker gh actions, use Compose v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,11 +38,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Build and push mwdb-core image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           file: ./deploy/docker/Dockerfile
           tags: |
@@ -60,17 +60,15 @@ jobs:
     needs: [lint_web]
     name: Build mwdb-core web image
     runs-on: ubuntu-latest
-    env:
-      DOCKER_BUILDKIT: 1
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Build and push mwdb-core web image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           file: ./deploy/docker/Dockerfile-web
           tags: |
@@ -87,17 +85,15 @@ jobs:
   build_backend_e2e:
     name: Build backend e2e test image
     runs-on: ubuntu-latest
-    env:
-      DOCKER_BUILDKIT: 1
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Build and push mwdb-tests image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           file: ./tests/backend/Dockerfile
           context: tests/backend
@@ -114,17 +110,15 @@ jobs:
   build_frontend_e2e:
     name: Build frontend e2e test image
     runs-on: ubuntu-latest
-    env:
-      DOCKER_BUILDKIT: 1
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Build and push mwdb-web-tests image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           file: ./tests/frontend/Dockerfile
           context: tests/frontend
@@ -141,17 +135,15 @@ jobs:
   build_frontend_unit_test:
     name: Build frontend unit test image
     runs-on: ubuntu-latest
-    env:
-      DOCKER_BUILDKIT: 1
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Build and push mwdb-web-unit-tests image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           file: ./deploy/docker/Dockerfile-web-unit-test
           tags: |
@@ -168,8 +160,6 @@ jobs:
     needs: [build_core, build_frontend, build_backend_e2e]
     name: Perform backend e2e tests
     runs-on: ubuntu-latest
-    env:
-      DOCKER_BUILDKIT: 1
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -189,13 +179,13 @@ jobs:
           ./gen_vars.sh test
       - name: Perform tests
         run: |
-          docker-compose -f docker-compose-e2e.yml up -d mwdb-tests
-          docker-compose -f docker-compose-e2e.yml logs -f -t mwdb-tests
+          docker compose -f docker-compose-e2e.yml up -d mwdb-tests
+          docker compose -f docker-compose-e2e.yml logs -f -t mwdb-tests
           ([ $(docker wait mwdb_core_e2e_tests) == 0 ])
       - name: Job failed - storing application logs
         if: ${{ failure() }}
         run: |
-          docker-compose -f docker-compose-e2e.yml logs --no-color -t mwdb > ./mwdb-e2e-logs
+          docker compose -f docker-compose-e2e.yml logs --no-color -t mwdb > ./mwdb-e2e-logs
       - name: Job failed - upload application logs
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3
@@ -206,8 +196,6 @@ jobs:
     needs: [build_core, build_frontend, build_frontend_e2e]
     name: Perform frontend e2e tests
     runs-on: ubuntu-latest
-    env:
-      DOCKER_BUILDKIT: 1
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -227,8 +215,8 @@ jobs:
           ./gen_vars.sh test
       - name: Perform tests
         run: |
-          docker-compose -f docker-compose-e2e.yml up -d web-tests
-          docker-compose -f docker-compose-e2e.yml logs -f -t web-tests
+          docker compose -f docker-compose-e2e.yml up -d web-tests
+          docker compose -f docker-compose-e2e.yml logs -f -t web-tests
           ([ $(docker wait mwdb_core_e2e_web_tests) == 0 ])
       - name: Job failed - storing videos from e2e tests
         if: ${{ failure() }}
@@ -244,8 +232,6 @@ jobs:
     needs: [ build_frontend_unit_test ]
     name: Perform frontend unit tests
     runs-on: ubuntu-latest
-    env:
-      DOCKER_BUILDKIT: 1
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -261,8 +247,8 @@ jobs:
           ./gen_vars.sh test
       - name: Perform tests
         run: |
-          docker-compose -f docker-compose-unit-test.yml up -d
-          docker-compose -f docker-compose-unit-test.yml logs -f -t
+          docker compose -f docker-compose-unit-test.yml up -d
+          docker compose -f docker-compose-unit-test.yml logs -f -t
   push_images:
     needs: [test_backend_e2e, test_frontend_e2e, test_frontend_unit]
     name: Push images on Docker Hub
@@ -272,16 +258,16 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build and push mwdb-core image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           file: ./deploy/docker/Dockerfile
           tags: |
@@ -293,7 +279,7 @@ jobs:
             type=registry,ref=certpl/mwdb:buildcache,mode=max
           push: true
       - name: Build and push mwdb-core web-source image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           file: ./deploy/docker/Dockerfile-web
           target: build
@@ -306,7 +292,7 @@ jobs:
             type=registry,ref=certpl/mwdb-web-source:buildcache,mode=max
           push: true
       - name: Build and push mwdb-core web image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           file: ./deploy/docker/Dockerfile-web
           tags: |
@@ -322,22 +308,20 @@ jobs:
     name: Push test images on Docker Hub
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' }}
-    env:
-      DOCKER_BUILDKIT: 1
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build and push mwdb-tests image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           file: ./tests/backend/Dockerfile
           context: tests/backend
@@ -350,7 +334,7 @@ jobs:
             type=registry,ref=certpl/mwdb-tests:buildcache,mode=max
           push: true
       - name: Build and push mwdb-web-tests image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           file: ./tests/frontend/Dockerfile
           context: tests/frontend
@@ -363,7 +347,7 @@ jobs:
             type=registry,ref=certpl/mwdb-web-tests:buildcache,mode=max
           push: true
       - name: Build and push mwdb-web-unit-tests image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           file: ./deploy/docker/Dockerfile-web-unit-test
           tags: |


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [ ] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- `docker-compose` (Compose v1) is no longer available on Github Actions

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- It's good time to bump other Docker actions as well
