### PR TITLE
OIDC: Refactor to expose OIDC client object

### DIFF
--- a/mwdb/core/oauth.py
+++ b/mwdb/core/oauth.py
@@ -7,54 +7,79 @@ authlib/integrations/base_client/sync_openid.py
 
 from authlib.common.security import generate_token
 from authlib.integrations.requests_client import OAuth2Session
-from authlib.jose import JsonWebKey, JsonWebToken, jwt
+from authlib.jose import JsonWebKey, JsonWebToken
 from authlib.oidc.core import CodeIDToken, ImplicitIDToken, UserInfo
 
 
-class OpenIDSession(OAuth2Session):
-    def fetch_jwk_set(self, force=True):
-        jwk_set = self.metadata.get("jwks")
-        if jwk_set and not force:
-            return jwk_set
+class OpenIDClient:
+    supported_algorithms = ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512"]
 
-        uri = self.metadata.get("jwks_uri")
-        if not uri:
+    def __init__(
+        self,
+        client_id,
+        client_secret,
+        authorization_endpoint,
+        token_endpoint,
+        userinfo_endpoint,
+        jwks_uri,
+        **kwargs,
+    ):
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.authorization_endpoint = authorization_endpoint
+        self.token_endpoint = token_endpoint
+        self.userinfo_endpoint = userinfo_endpoint
+        self.jwks_uri = jwks_uri
+
+        self.session = OAuth2Session(
+            client_id=client_id,
+            client_secret=client_secret,
+            authorization_endpoint=authorization_endpoint,
+            token_endpoint=token_endpoint,
+            userinfo_endpoint=userinfo_endpoint,
+            jwks_uri=jwks_uri,
+            **kwargs,
+        )
+
+    def create_authorization_url(self, redirect_uri):
+        nonce = generate_token()
+        return (
+            *self.session.create_authorization_url(
+                self.authorization_endpoint, nonce=nonce, redirect_uri=redirect_uri
+            ),
+            nonce,
+        )
+
+    def load_key(self, header, _):
+        alg = header.get("alg")
+        if alg in ["HS256", "HS384", "HS512"]:
+            # For HS256: client secret is used for id_token signing
+            return self.client_secret
+        elif alg in ["RS256", "RS384", "RS512"]:
+            jwk_set = JsonWebKey.import_key_set(self.fetch_jwk_set())
+            return jwk_set.find_by_kid(header.get("kid"))
+        else:
+            raise RuntimeError(f"Unsupported id_token algorithm: '{alg}'")
+
+    def fetch_jwk_set(self):
+        if not self.jwks_uri:
             raise RuntimeError('Missing "jwks_uri" in metadata')
 
-        resp = self.request("GET", uri, withhold_token=True)
+        resp = self.session.request("GET", self.jwks_uri, withhold_token=True)
         resp.raise_for_status()
         jwk_set = resp.json()
-
-        self.metadata["jwks"] = jwk_set
         return jwk_set
 
-    def userinfo(self, **kwargs):
-        """Fetch user info from ``userinfo_endpoint``."""
-        resp = self.get(self.metadata["userinfo_endpoint"], **kwargs)
-        resp.raise_for_status()
-        data = resp.json()
-        return UserInfo(data)
+    def fetch_id_token(self, code, state, nonce, redirect_uri):
+        token = self.session.fetch_token(
+            code=code, state=state, redirect_uri=redirect_uri
+        )
+        return self.parse_id_token(token, nonce)
 
     def parse_id_token(self, token, nonce, claims_options=None, leeway=120):
         """Return an instance of UserInfo from token's ``id_token``."""
         if "id_token" not in token:
             return None
-
-        def load_key(header, _):
-            alg = header.get("alg")
-            if alg in ["HS256", "HS384", "HS512"]:
-                # For HS256: client secret is used for id_token signing
-                return self.client_secret
-            elif alg in ["RS256", "RS384", "RS512"]:
-                jwk_set = JsonWebKey.import_key_set(self.fetch_jwk_set())
-                try:
-                    return jwk_set.find_by_kid(header.get("kid"))
-                except ValueError:
-                    # re-try with new jwk set
-                    jwk_set = JsonWebKey.import_key_set(self.fetch_jwk_set(force=True))
-                    return jwk_set.find_by_kid(header.get("kid"))
-            else:
-                raise RuntimeError(f"Unsupported id_token algorithm: '{alg}'")
 
         claims_params = dict(nonce=nonce, client_id=self.client_id)
         if "access_token" in token:
@@ -63,18 +88,10 @@ class OpenIDSession(OAuth2Session):
         else:
             claims_cls = ImplicitIDToken
 
-        if claims_options is None and "issuer" in self.metadata:
-            claims_options = {"iss": {"values": [self.metadata["issuer"]]}}
-
-        alg_values = self.metadata.get("id_token_signing_alg_values_supported")
-        if alg_values:
-            _jwt = JsonWebToken(alg_values)
-        else:
-            _jwt = jwt
-
-        claims = _jwt.decode(
+        jwt = JsonWebToken(self.supported_algorithms)
+        claims = jwt.decode(
             token["id_token"],
-            key=load_key,
+            key=self.load_key,
             claims_cls=claims_cls,
             claims_options=claims_options,
             claims_params=claims_params,
@@ -86,5 +103,9 @@ class OpenIDSession(OAuth2Session):
         claims.validate(leeway=leeway)
         return UserInfo(claims)
 
-    def generate_nonce(self):
-        return generate_token()
+    def userinfo(self, **kwargs):
+        """Fetch user info from ``userinfo_endpoint``."""
+        resp = self.session.get(self.userinfo_endpoint, **kwargs)
+        resp.raise_for_status()
+        data = resp.json()
+        return UserInfo(data)

--- a/mwdb/resources/oauth.py
+++ b/mwdb/resources/oauth.py
@@ -351,7 +351,8 @@ class OpenIDAuthenticateResource(Resource):
             raise NotFound(f"Requested provider name '{provider_name}' not found")
 
         redirect_uri = f"{app_config.mwdb.base_url}/oauth/callback"
-        url, state, nonce = provider.create_authorization_url(redirect_uri)
+        oidc_client = provider.get_oidc_client()
+        url, state, nonce = oidc_client.create_authorization_url(redirect_uri)
 
         schema = OpenIDLoginResponseSchema()
         return schema.dump({"authorization_url": url, "state": state, "nonce": nonce})
@@ -370,7 +371,8 @@ class OpenIDAuthorizeResource(Resource):
         schema = OpenIDAuthorizeRequestSchema()
         obj = loads_schema(request.get_data(as_text=True), schema)
         redirect_uri = f"{app_config.mwdb.base_url}/oauth/callback"
-        userinfo = provider.fetch_id_token(
+        oidc_client = provider.get_oidc_client()
+        userinfo = oidc_client.fetch_id_token(
             obj["code"], obj["state"], obj["nonce"], redirect_uri
         )
         # 'sub' bind should be used instead of 'name'
@@ -432,7 +434,8 @@ class OpenIDRegisterUserResource(Resource):
         schema = OpenIDAuthorizeRequestSchema()
         obj = loads_schema(request.get_data(as_text=True), schema)
         redirect_uri = f"{app_config.mwdb.base_url}/oauth/callback"
-        userinfo = provider.fetch_id_token(
+        oidc_client = provider.get_oidc_client()
+        userinfo = oidc_client.fetch_id_token(
             obj["code"], obj["state"], obj["nonce"], redirect_uri
         )
         # register user with information from provider
@@ -563,7 +566,8 @@ class OpenIDBindAccountResource(Resource):
         schema = OpenIDAuthorizeRequestSchema()
         obj = loads_schema(request.get_data(as_text=True), schema)
         redirect_uri = f"{app_config.mwdb.base_url}/oauth/callback"
-        userinfo = provider.fetch_id_token(
+        oidc_client = provider.get_oidc_client()
+        userinfo = oidc_client.fetch_id_token(
             obj["code"], obj["state"], obj["nonce"], redirect_uri
         )
         if db.session.query(


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**Description of changes**
<!-- Explain how the code works currently -->

I don't really like the documentation of authlib and the current design of mixins. That's why I think it's a bit unsafe to mix with OAuth2Session and it's much better to make a wrapper that will be exposed via `OpenIDProvider.get_oidc_client` method.

Additional thing is that in future PRs we need to make a series of calls to the provider using fetched access token, we can't do that with current `_get_client` method that creates `OpenIDSession` object internally and disposes it right after the call.

The third thing is that we need to strip `OpenIDClient` methods from unused code paths, copied from `OpenIDMixin`.

**Test plan**
<!-- Explain how to test your changes -->
Right now it needs to be tested manually using `docker-compose-oidc-dev`
<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->
