### PR TITLE
Fix: Change object.tags eager-load strategy to select-in

### DIFF
--- a/mwdb/model/object.py
+++ b/mwdb/model/object.py
@@ -95,7 +95,7 @@ class Object(db.Model):
     tags = db.relationship(
         "Tag",
         back_populates="object",
-        lazy="joined",
+        lazy="selectin",
         cascade="save-update, merge, delete",
     )
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- ~~[ ] I've added automated tests for my change (if applicable, optional)~~
- ~~[ ] I've updated documentation to reflect my change (if applicable)~~

**What is the current behaviour?**
<!-- Explain how the code works currently -->

Current eager-load strategy for `Object.tags` in [joined load](https://docs.sqlalchemy.org/en/14/orm/loading_relationships.html#joined-eager-loading). It's the most basic eager-loading strategy in SQLAlchemy, but it doesn't combine well with loading relationships.

When user tries to `GET /object/<hash>`, object information is returned along with all children/parents hashes and their tags. When we load this information from database using `joined load`, it results in possibly excessive amount of rows: `count(object) x count(tags)` where object information is `count(tags)` repeated along the rows. We see in our instance that for objects with several tags each, it may even cause an OOM condition.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

`Object.tags` are switched to [select-in load strategy](https://docs.sqlalchemy.org/en/14/orm/loading_relationships.html#select-in-loading). Using this strategy, sqlalchemy generates two queries: one for objects and one for tags for these objects. Then it merges the information from two queries by itself.

This strategy generates much less heavy row set than the joined one.

**Test plan**

Checked manually if it is actually more efficient than previous strategy
