### PR TITLE
Don't load filtered-out parents eagerly on every Object.access

### DIFF
--- a/mwdb/model/object.py
+++ b/mwdb/model/object.py
@@ -150,6 +150,19 @@ class Object(db.Model):
     def favorite(self):
         return g.auth_user in self.followers
 
+    @property
+    def accessible_parents(self):
+        """
+        Parent objects that are accessible for current user
+        """
+        return (
+            db.session.query(Object)
+            .join(relation, relation.c.parent_id == Object.id)
+            .filter(relation.c.child_id == self.id)
+            .order_by(relation.c.creation_time.desc())
+            .filter(g.auth_user.has_access_to_object(Object.id))
+        )
+
     def add_parent(self, parent, commit=True):
         """
         Adding parent with permission inheritance

--- a/mwdb/model/object.py
+++ b/mwdb/model/object.py
@@ -7,7 +7,7 @@ from flask import g
 from sqlalchemy import and_, cast, distinct, exists, func, select
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import aliased, column_property, contains_eager
+from sqlalchemy.orm import column_property
 from sqlalchemy.sql.expression import true
 
 from mwdb.core.capabilities import Capabilities
@@ -467,34 +467,10 @@ class Object(db.Model):
         if requestor is None:
             requestor = g.auth_user
 
-        obj = cls.get(identifier)
+        obj = cls.get(identifier).first()
         # If object doesn't exist - it doesn't exist
-        if obj.first() is None:
+        if obj is None:
             return None
-
-        # In that case we want only those parents to which requestor has access.
-        stmtp = (
-            db.session.query(Object)
-            .join(relation, relation.c.parent_id == Object.id)
-            .filter(
-                Object.id.in_(
-                    db.session.query(relation.c.parent_id).filter(
-                        relation.c.child_id == obj.first().id
-                    )
-                )
-            )
-            .order_by(relation.c.creation_time.desc())
-            .filter(requestor.has_access_to_object(Object.id))
-        )
-        stmtp = stmtp.subquery()
-
-        parent = aliased(Object, stmtp)
-
-        obj = (
-            obj.outerjoin(parent, Object.parents)
-            .options(contains_eager(Object.parents, alias=parent))
-            .all()[0]
-        )
 
         # Ok, now let's check whether requestor has explicit access
         if obj.has_explicit_access(requestor):

--- a/mwdb/schema/object.py
+++ b/mwdb/schema/object.py
@@ -104,7 +104,11 @@ class ObjectItemResponseSchema(Schema):
     favorite = fields.Boolean(required=True, allow_none=False)
 
     parents = fields.Nested(
-        ObjectListItemResponseSchema, many=True, required=True, allow_none=False
+        ObjectListItemResponseSchema,
+        many=True,
+        required=True,
+        allow_none=False,
+        attribute="accessible_parents",
     )
     children = fields.Nested(
         ObjectListItemResponseSchema, many=True, required=True, allow_none=False

--- a/mwdb/schema/relations.py
+++ b/mwdb/schema/relations.py
@@ -5,7 +5,11 @@ from .object import ObjectListItemResponseSchema
 
 class RelationsResponseSchema(Schema):
     parents = fields.Nested(
-        ObjectListItemResponseSchema, many=True, required=True, allow_none=False
+        ObjectListItemResponseSchema,
+        many=True,
+        required=True,
+        allow_none=False,
+        attribute="accessible_parents",
     )
     children = fields.Nested(
         ObjectListItemResponseSchema, many=True, required=True, allow_none=False


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- ~~[ ] I've added automated tests for my change (if applicable, optional)~~ (already covered)
- ~~[ ] I've updated documentation to reflect my change (if applicable)~~ (no changes)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

There is definitely too much magic there that is quite ineffective. When object has lots of parents, every `Object.access()` that is called in almost every object endpoint will eagerly load all parents and all its tags even if they're not used by the endpoint.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

Replaced eager loading with property `accessible_parents` that makes a query when requested. It is then called by proper schema fields.

Other functions that are relying on user's view of parents are already using dedicated query instead of `object.parents` direct relationship access (e.g. search additionally filters out objects using `g.auth_user.has_access_to_object`)

**Test plan**
<!-- Explain how to test your changes -->

Security checks covered by automated tests. Performed manual check if everything works properly.

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

