### PR TITLE
v3: Drop support for legacy 'page' parameter

### DIFF
--- a/mwdb/core/deprecated.py
+++ b/mwdb/core/deprecated.py
@@ -31,10 +31,6 @@ class DeprecatedFeature(Enum):
     # Use GET /<object_type> instead
     # Deprecated in v2.0.0
     legacy_search = "legacy_search"
-    # Legacy ?page parameter in object listing endpoints
-    # Use "?older_than" instead
-    # Deprecated in v2.0.0
-    legacy_page_parameter = "legacy_page_parameter"
     # Legacy Metakey API
     # Use Attribute API instead
     # Deprecated in v2.6.0

--- a/mwdb/resources/object.py
+++ b/mwdb/resources/object.py
@@ -216,9 +216,6 @@ class ObjectResource(Resource):
                 description: |
                     Request canceled due to database statement timeout.
         """
-        if "page" in request.args:
-            uses_deprecated_api(DeprecatedFeature.legacy_page_parameter)
-
         obj = load_schema(request.args, ObjectListRequestSchema())
 
         pivot_obj = None
@@ -243,9 +240,6 @@ class ObjectResource(Resource):
         ).order_by(Object.id.desc())
         if pivot_obj:
             db_query = db_query.filter(Object.id < pivot_obj.id)
-        # Legacy parameter - to be removed in the future
-        elif obj["page"] is not None and obj["page"] > 1:
-            db_query = db_query.offset((obj["page"] - 1) * 10)
 
         objects = db_query.limit(limit).all()
 

--- a/mwdb/schema/object.py
+++ b/mwdb/schema/object.py
@@ -1,13 +1,6 @@
 import json
 
-from marshmallow import (
-    Schema,
-    ValidationError,
-    fields,
-    post_dump,
-    pre_load,
-    validates_schema,
-)
+from marshmallow import Schema, ValidationError, fields, post_dump, pre_load
 
 from .attribute import AttributeItemRequestSchema, AttributeItemResponseSchema
 from .metakey import MetakeyItemRequestSchema
@@ -16,18 +9,9 @@ from .utils import UTCDateTime
 
 
 class ObjectListRequestSchema(Schema):
-    page = fields.Int(missing=None)  # legacy, to be removed in future
     query = fields.Str(missing=None)
     older_than = fields.Str(missing=None)
     count = fields.Int(missing=10)
-
-    @validates_schema
-    def validate_key(self, data, **kwargs):
-        if data["page"] is not None and data["older_than"] is not None:
-            raise ValidationError(
-                "'page' and 'older_than' can't be used simultaneously. "
-                "Use 'older_than' for new code."
-            )
 
 
 class ObjectCountRequestSchema(Schema):


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

'page' parameter is deprecated since the initial v2 release, but was used by some mwdb.cert.pl users. Right now it's not even documented in the current API.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

This PR removes 'page' parameter support in v3.0.x branch.

