### PR TITLE
Drop: legacy_file_upload endpoints

### DIFF
--- a/mwdb/core/deprecated.py
+++ b/mwdb/core/deprecated.py
@@ -17,10 +17,6 @@ class DeprecatedFeature(Enum):
     # API keys non-complaint with RFC7519
     # Deprecated in v2.7.0
     legacy_api_key_v2 = "legacy_api_key_v2"
-    # Legacy PUT/POST /api/<object_type>/<parent>
-    # Use POST /api/<object_type> instead
-    # Deprecated in v2.0.0
-    legacy_object_upload = "legacy_file_upload"
     # Legacy /request/sample/<token>
     # Use /file/<id>/download instead
     # Deprecated in v2.2.0

--- a/mwdb/resources/blob.py
+++ b/mwdb/resources/blob.py
@@ -2,7 +2,6 @@ from flask import request
 from werkzeug.exceptions import Conflict
 
 from mwdb.core.capabilities import Capabilities
-from mwdb.core.deprecated import DeprecatedFeature, deprecated_endpoint
 from mwdb.core.plugins import hooks
 from mwdb.model import TextBlob
 from mwdb.model.object import ObjectTypeConflictError
@@ -221,101 +220,6 @@ class TextBlobItemResource(ObjectItemResource, TextBlobUploader):
                     Request canceled due to database statement timeout.
         """
         return super().get(identifier)
-
-    @deprecated_endpoint(DeprecatedFeature.legacy_object_upload)
-    @requires_authorization
-    @requires_capabilities(Capabilities.adding_blobs)
-    def put(self, identifier):
-        """
-        ---
-        summary: Upload text blob
-        description: |
-            Uploads a new text blob.
-
-            Requires `adding_blobs` capability.
-
-            Deprecated: use POST /blob method instead.
-        security:
-            - bearerAuth: []
-        deprecated: true
-        tags:
-            - blob
-        parameters:
-            - in: path
-              name: identifier
-              schema:
-                type: string
-              default: root
-              description: |
-                Parent object identifier or `root` if there is no parent.
-
-                User must have `adding_parents` capability to specify a parent object.
-        requestBody:
-            required: true
-            content:
-              multipart/form-data:
-                schema:
-                  type: object
-                  description: |
-                    Blob to be uploaded with additional parameters
-                    (verbose mode)
-                  properties:
-                    json:
-                      type: object
-                      properties:
-                          blob_name:
-                             type: string
-                          blob_type:
-                             type: string
-                          content:
-                             type: string
-                      description: JSON-encoded blob object specification
-                    metakeys:
-                      type: object
-                      properties:
-                          metakeys:
-                            type: array
-                            items:
-                                $ref: '#/components/schemas/MetakeyItemRequest'
-                      description: |
-                        Attributes to be added after file upload
-
-                        User must be allowed to set specified attribute keys.
-                    upload_as:
-                      type: string
-                      default: '*'
-                      description: |
-                        Group that object will be shared with.
-
-                        If user doesn't have `sharing_with_all` capability,
-                        user must be a member of specified group
-                        (unless `Group doesn't exist` error will occur).
-
-                        If default value `*` is specified - object will be
-                        exclusively shared with all user's groups excluding `public`.
-                  required:
-                    - json
-              application/json:
-                schema: BlobCreateSpecSchema
-        responses:
-            200:
-                description: Text blob uploaded succesfully
-                content:
-                  application/json:
-                    schema: BlobItemResponseSchema
-            403:
-                description: |
-                    No permissions to perform additional operations
-                    (e.g. adding metakeys)
-            404:
-                description: Specified group doesn't exist
-            409:
-                description: Object exists yet but has different type
-            503:
-                description: |
-                    Request canceled due to database statement timeout.
-        """
-        return super().put(identifier)
 
     @requires_authorization
     @requires_capabilities(Capabilities.removing_objects)

--- a/mwdb/resources/config.py
+++ b/mwdb/resources/config.py
@@ -5,7 +5,6 @@ from sqlalchemy import func
 from werkzeug.exceptions import BadRequest, Conflict, Forbidden, NotFound
 
 from mwdb.core.capabilities import Capabilities
-from mwdb.core.deprecated import DeprecatedFeature, deprecated_endpoint
 from mwdb.core.plugins import hooks
 from mwdb.core.service import Resource
 from mwdb.model import Config, TextBlob, db
@@ -343,108 +342,6 @@ class ConfigItemResource(ObjectItemResource, ConfigUploader):
                     Request canceled due to database statement timeout.
         """
         return super().get(identifier)
-
-    @deprecated_endpoint(DeprecatedFeature.legacy_object_upload)
-    @requires_authorization
-    @requires_capabilities(Capabilities.adding_configs)
-    def put(self, identifier):
-        """
-        ---
-        summary: Upload config
-        description: |
-            Uploads a new config.
-
-            Requires `adding_configs` capability.
-
-            Deprecated: use POST /config method instead.
-        security:
-            - bearerAuth: []
-        deprecated: true
-        tags:
-            - config
-        parameters:
-            - in: path
-              name: identifier
-              schema:
-                type: string
-              default: root
-              description: |
-                Parent object identifier or `root` if there is no parent.
-
-                User must have `adding_parents` capability to specify a parent object.
-        requestBody:
-            required: true
-            content:
-              multipart/form-data:
-                schema:
-                  type: object
-                  description: |
-                    Configuration to be uploaded with additional parameters
-                    (verbose mode)
-                  properties:
-                    json:
-                      type: object
-                      properties:
-                          family:
-                             type: string
-                          config_type:
-                             type: string
-                             default: static
-                          cfg:
-                             type: object
-                      description: JSON-encoded config object specification
-                    metakeys:
-                      type: object
-                      properties:
-                          metakeys:
-                            type: array
-                            items:
-                                $ref: '#/components/schemas/MetakeyItemRequest'
-                      description: |
-                        Attributes to be added after file upload
-
-                        User must be allowed to set specified attribute keys.
-                    upload_as:
-                      type: string
-                      default: '*'
-                      description: |
-                        Group that object will be shared with.
-
-                        If user doesn't have `sharing_with_all` capability,
-                        user must be a member of specified group
-                        (unless `Group doesn't exist` error will occur).
-
-                        If default value `*` is specified - object will be
-                        exclusively shared with all user's groups excluding `public`.
-                  required:
-                    - json
-              application/json:
-                schema: ConfigCreateSpecSchema
-        responses:
-            200:
-                description: Information about uploaded config
-                content:
-                  application/json:
-                    schema: ConfigItemResponseSchema
-            403:
-                description: |
-                    No permissions to perform additional operations
-                    (e.g. adding parent, metakeys)
-            404:
-                description: |
-                    One of attribute keys doesn't exist or
-                    user doesn't have permission to set it.
-
-                    Specified `upload_as` group doesn't exist or
-                    user doesn't have permission to share objects
-                    with that group
-            409:
-                description: Object exists yet but has different type
-            503:
-                description: |
-                    Request canceled due to database statement timeout.
-        """
-        return super().put(identifier)
 
     @requires_authorization
     @requires_capabilities(Capabilities.removing_objects)

--- a/mwdb/resources/file.py
+++ b/mwdb/resources/file.py
@@ -2,7 +2,6 @@ from flask import Response, g, request
 from werkzeug.exceptions import BadRequest, Conflict, Forbidden, NotFound, Unauthorized
 
 from mwdb.core.capabilities import Capabilities
-from mwdb.core.deprecated import DeprecatedFeature, deprecated_endpoint
 from mwdb.core.plugins import hooks
 from mwdb.core.service import Resource
 from mwdb.model import File
@@ -238,95 +237,6 @@ class FileItemResource(ObjectItemResource, FileUploader):
                     Request canceled due to database statement timeout.
         """
         return super().get(identifier)
-
-    @deprecated_endpoint(DeprecatedFeature.legacy_object_upload)
-    @requires_authorization
-    @requires_capabilities(Capabilities.adding_files)
-    def post(self, identifier):
-        """
-        ---
-        summary: Upload file
-        description: |
-            Uploads a new file.
-
-            Requires `adding_files` capability.
-
-            Deprecated: use POST /file instead.
-        security:
-            - bearerAuth: []
-        deprecated: true
-        tags:
-            - file
-        parameters:
-            - in: path
-              name: identifier
-              schema:
-                type: string
-              default: 'root'
-              description: |
-                Parent object identifier or `root` if there is no parent.
-
-                User must have `adding_parents` capability to specify a parent object.
-        requestBody:
-            required: true
-            content:
-              multipart/form-data:
-                schema:
-                  type: object
-                  properties:
-                    file:
-                      type: string
-                      format: binary
-                      description: File contents to be uploaded
-                    metakeys:
-                      type: object
-                      properties:
-                          metakeys:
-                            type: array
-                            items:
-                                $ref: '#/components/schemas/MetakeyItemRequest'
-                      description: |
-                        Attributes to be added after file upload
-
-                        User must be allowed to set specified attribute keys.
-                    upload_as:
-                      type: string
-                      default: '*'
-                      description: |
-                        Group that object will be shared with.
-
-                        If user doesn't have `sharing_with_all` capability,
-                        user must be a member of specified group
-                        (unless `Group doesn't exist` error will occur).
-
-                        If default value `*` is specified - object will be
-                        exclusively shared with all user's groups excluding `public`.
-                  required:
-                    - file
-        responses:
-            200:
-                description: Information about uploaded file
-                content:
-                  application/json:
-                    schema: FileItemResponseSchema
-            403:
-                description: |
-                    No permissions to perform additional operations
-                    (e.g. adding parent, attributes)
-            404:
-                description: |
-                    One of attribute keys doesn't exist or user doesn't have
-                    permission to set it.
-
-                    Specified `upload_as` group doesn't exist or user doesn't have
-                    permission to share objects with that group
-            409:
-                description: Object exists yet but has different type
-            503:
-                description: |
-                    Request canceled due to database statement timeout.
-        """
-        return super().post(identifier)
 
     @requires_authorization
     @requires_capabilities(Capabilities.removing_objects)

--- a/mwdb/resources/object.py
+++ b/mwdb/resources/object.py
@@ -1,8 +1,7 @@
-import json
 from uuid import UUID
 
 from flask import g, request
-from werkzeug.exceptions import BadRequest, Forbidden, MethodNotAllowed, NotFound
+from werkzeug.exceptions import BadRequest, Forbidden, NotFound
 
 from mwdb.core.capabilities import Capabilities
 from mwdb.core.config import app_config
@@ -291,41 +290,6 @@ class ObjectItemResource(Resource, ObjectUploader):
             raise NotFound("Object not found")
         schema = self.ItemResponseSchema()
         return schema.dump(obj)
-
-    def _get_upload_args(self, parent_identifier):
-        """
-        Transforms upload arguments mixed into various request fields
-        """
-        if request.is_json:
-            # If request is application/json: all args are in JSON
-            args = json.loads(request.get_data(parse_form_data=True, as_text=True))
-        else:
-            if "json" in request.form:
-                # If request is multipart/form-data:
-                # some args are in JSON and some are part of form
-                args = json.loads(request.form["json"])
-            else:
-                args = {}
-            if request.form.get("metakeys"):
-                args["metakeys"] = request.form["metakeys"]
-            if request.form.get("upload_as"):
-                args["upload_as"] = request.form["upload_as"]
-        args["parent"] = parent_identifier if parent_identifier != "root" else None
-        return args
-
-    @requires_authorization
-    def post(self, identifier):
-        if self.ObjectType is Object:
-            raise MethodNotAllowed()
-
-        schema = self.CreateRequestSchema()
-        obj = load_schema(self._get_upload_args(identifier), schema)
-
-        return self.create_object(obj)
-
-    @requires_authorization
-    def put(self, identifier):
-        return self.post(identifier)
 
     @requires_authorization
     @requires_capabilities(Capabilities.removing_objects)


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

That's another feature that was deprecated since initial release. Earlier versions of MWDB used `/api/file/<parent>` endpoint to upload and "attach" a new object to the existing parent. In case of no parent, `/api/file/root` was used instead.

It was pretty obscure way of uploading objects so it was replaced with `POST /api/<object_type>` endpoint, but previous endpoint was left for compatibility reasons

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

Legacy upload endpoints are removed.

**Test plan**
<!-- Explain how to test your changes -->

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #issuenumber
