### PR TITLE
Drop: share_queried_objects capability

### DIFF
--- a/docs/user-guide/9-Sharing-objects.rst
+++ b/docs/user-guide/9-Sharing-objects.rst
@@ -149,11 +149,6 @@ Each capability has its own name and scope:
   Allows to access all users and groups in MWDB. Rules described in *Who is who?* don't apply to users with that permission. Enables user to create new user accounts, new groups and change their capabilities and membership. Allows to manage attribute keys, define new ones, delete and set the group permissions for them.
 
 * 
-  **share_queried_objects - Query for all objects in system**
-
-  That one is a bit tricky and will be possibly deprecated. MWDB will automatically share object and all descendants with group if member directly accessed it via identifier (knows the hash e.g. have direct link to the object). It can be used for bot accounts, so they have access only to these objects that are intended to be processed by them. Internally, we abandoned that idea, so that capability may not be stable.
-
-* 
   **access_all_objects - Has access to all uploaded objects into system**
 
   Grants access to all uploaded objects in MWDB.

--- a/mwdb/core/capabilities.py
+++ b/mwdb/core/capabilities.py
@@ -1,8 +1,6 @@
 class Capabilities(object):
     # Can create/update users and groups
     manage_users = "manage_users"
-    # Queried objects by members are automatically shared with this group
-    share_queried_objects = "share_queried_objects"
     # All new uploaded objects are automatically shared with this group
     access_all_objects = "access_all_objects"
     # Can share objects with all groups, have access to complete list of groups

--- a/mwdb/core/deprecated.py
+++ b/mwdb/core/deprecated.py
@@ -17,10 +17,6 @@ class DeprecatedFeature(Enum):
     # API keys non-complaint with RFC7519
     # Deprecated in v2.7.0
     legacy_api_key_v2 = "legacy_api_key_v2"
-    # Legacy /request/sample/<token>
-    # Use /file/<id>/download instead
-    # Deprecated in v2.2.0
-    legacy_file_download = "legacy_file_download"
     # Legacy Metakey API
     # Use Attribute API instead
     # Deprecated in v2.6.0

--- a/mwdb/model/object.py
+++ b/mwdb/model/object.py
@@ -475,8 +475,6 @@ class Object(db.Model):
             (default: currently authenticated user)
         :return: Object instance or None
         """
-        from .group import Group
-
         if requestor is None:
             requestor = g.auth_user
 
@@ -489,23 +487,6 @@ class Object(db.Model):
         if obj.has_explicit_access(requestor):
             return obj
 
-        # If not, but has "share_queried_objects" rights: give_access
-        if requestor.has_rights(Capabilities.share_queried_objects):
-            share_queried_groups = (
-                db.session.query(Group)
-                .filter(
-                    and_(
-                        Group.capabilities.contains(
-                            [Capabilities.share_queried_objects]
-                        ),
-                        requestor.is_member(Group.id),
-                    )
-                )
-                .all()
-            )
-            for group in share_queried_groups:
-                obj.give_access(group.id, AccessType.QUERIED, obj, requestor)
-            return obj
         # Well.. I've tried
         return None
 

--- a/mwdb/web/src/commons/auth/capabilities.tsx
+++ b/mwdb/web/src/commons/auth/capabilities.tsx
@@ -4,7 +4,6 @@ import { Capability } from "@mwdb-web/types/types";
 export let capabilitiesList: Record<Capability, string> = {
     [Capability.manageUsers]:
         "Managing users and groups (system administration)",
-    [Capability.shareQueriedObjects]: "Query for all objects in system",
     [Capability.accessAllObjects]:
         "Has access to all new uploaded objects into system",
     [Capability.sharingWithAll]: "Can share objects with all groups in system",

--- a/mwdb/web/src/types/types.ts
+++ b/mwdb/web/src/types/types.ts
@@ -2,7 +2,6 @@ import { AxiosError } from "axios";
 
 export enum Capability {
     manageUsers = "manage_users",
-    shareQueriedObjects = "share_queried_objects",
     accessAllObjects = "access_all_objects",
     sharingWithAll = "sharing_with_all",
     accessUploaderInfo = "access_uploader_info",

--- a/tests/backend/test_permissions.py
+++ b/tests/backend/test_permissions.py
@@ -30,23 +30,6 @@ def test_manage_users(admin_session):
     request("PUT", "/group/{}".format(group_name), json={"capabilities": []})
 
 
-def test_share_queried_objects(admin_session):
-    testCase = RelationTestCase(admin_session)
-
-    Alice = testCase.new_user("Alice")
-    Bob = testCase.new_user("Bob", capabilities=["share_queried_objects"])
-
-    Sample = testCase.new_sample("Sample")
-
-    with ShouldRaise(status_code=404):
-        Alice.session.get_sample(Sample.dhash)
-
-    Bob.session.get_sample(Sample.dhash)
-
-    Sample.should_not_access(Alice)
-    Sample.should_access(Bob)
-
-
 def test_access_all_objects(admin_session):
     testCase = RelationTestCase(admin_session)
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

`share_queried_objects` was a very obscure feature that allow certain users to access any sample in the system if they know a direct link to the specific object. It was never used in mwdb.cert.pl and is not very well supported e.g. you can't reach these sample via search by providing a hash.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

This PR removes support for share_queried_objects capability.

Also removed `DeprecatedFeature` that I forgot to remove in #1003


