### PR TITLE
Feature: brownout deprecated API features via enable_brownout flag

### DIFF
--- a/mwdb/core/config.py
+++ b/mwdb/core/config.py
@@ -136,6 +136,7 @@ class MWDBConfig(Config):
     log_only_slow_sql = key(cast=intbool, required=False, default=False)
     use_x_forwarded_for = key(cast=intbool, required=False, default=False)
     enable_debug_log = key(cast=intbool, required=False, default=False)
+    enable_brownout = key(cast=intbool, required=False, default=False)
 
 
 @section("karton")


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

We're going to remove stale and deprecated features in next major version (v3.0.0). We're already tracking the usage of deprecated API elements but to ensure that we're ready to deploy breaking changes, we're going to temporarily "brownout" old features to check the effects.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

This PR introduces `enable_brownout` flag. When enabled, deprecated API elements will throw HTTP 400 (Bad Request) with proper message. The exception is `legacy_api_key_v2` - we're not ready to drop it yet.
