### PR TITLE
Bump sqlalchemy to 1.4 and database-related dependencies

### DIFF
--- a/mwdb/model/object.py
+++ b/mwdb/model/object.py
@@ -58,12 +58,14 @@ class Object(db.Model):
     share_3rd_party = db.Column(db.Boolean, nullable=False)
 
     upload_count = column_property(
-        select([func.count(distinct(ObjectPermission.related_user_id))]).where(
+        select([func.count(distinct(ObjectPermission.related_user_id))])
+        .where(
             and_(
                 ObjectPermission.object_id == id,
                 ObjectPermission.reason_type == AccessType.ADDED,
             )
-        ),
+        )
+        .scalar_subquery(),
         deferred=True,
     )
 
@@ -105,7 +107,7 @@ class Object(db.Model):
         "User",
         secondary="comment",
         back_populates="commented_objects",
-        passive_deletes=True,
+        viewonly=True,
     )
 
     shares = db.relationship(

--- a/mwdb/model/user.py
+++ b/mwdb/model/user.py
@@ -68,7 +68,7 @@ class User(db.Model):
         "Object",
         secondary="comment",
         back_populates="comment_authors",
-        passive_deletes=True,
+        viewonly=True,
     )
 
     comments = db.relationship(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 Werkzeug==3.0.6
 gunicorn==22.0.0
-alembic==1.4.2
+alembic==1.14.0
 Flask==2.3.3
-Flask-SQLAlchemy==2.5.1
-Flask-Migrate==3.1.0
-SQLAlchemy==1.3.18
+Flask-SQLAlchemy==3.0.5
+Flask-Migrate==4.0.7
+SQLAlchemy==1.4.54
 marshmallow==3.20.2
-psycopg2-binary==2.9.9
+psycopg2-binary==2.9.10
 requests==2.32.0
 apispec[marshmallow,yaml]==6.4.0
 bcrypt==3.1.4


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

I'm missing some features in 1.3.x branch. The 1.3.x branch is also from 2021 and it's good time to switch to something with better support.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

This PR upgrades sqlalchemy to 1.4 and all related dependencies to newer versions. Flask-SQLAlchemy is pinned on 3.0.5, because 3.1.0 requires sqlalchemy 2.0. I think this needs a bit more work.
