### PR TITLE
Bump base of Docker images and bcrypt

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine AS build
+FROM python:3.12-alpine AS build
 
 WORKDIR /app
 RUN python3 -m venv /app/venv
@@ -14,7 +14,7 @@ ARG plugins
 RUN for plugin in $plugins $(find /app/plugins -name 'setup.py' -exec dirname {} \; | sort -u);  \
     do /app/venv/bin/pip --no-cache-dir install $plugin; done
 
-FROM python:3.8-alpine
+FROM python:3.12-alpine
 
 LABEL maintainer="info@cert.pl"
 

--- a/deploy/docker/Dockerfile-web
+++ b/deploy/docker/Dockerfile-web
@@ -1,4 +1,4 @@
-FROM node:16-alpine AS build
+FROM node:22-alpine AS build
 
 LABEL maintainer="info@cert.pl"
 

--- a/deploy/docker/Dockerfile-web-dev
+++ b/deploy/docker/Dockerfile-web-dev
@@ -1,4 +1,4 @@
-FROM node:16-alpine AS build
+FROM node:22-alpine AS build
 
 LABEL maintainer="info@cert.pl"
 

--- a/deploy/docker/Dockerfile-web-unit-test
+++ b/deploy/docker/Dockerfile-web-unit-test
@@ -1,4 +1,4 @@
-FROM node:16-alpine AS build
+FROM node:22-alpine AS build
 
 LABEL maintainer="info@cert.pl"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ marshmallow==3.20.2
 psycopg2-binary==2.9.10
 requests==2.32.0
 apispec[marshmallow,yaml]==6.4.0
-bcrypt==3.1.4
+bcrypt==4.2.1
 python-magic==0.4.18
 luqum==0.13.0
 python-json-logger==2.0.2

--- a/tests/backend/Dockerfile
+++ b/tests/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.12
 COPY requirements.txt /app/requirements.txt
 RUN pip3 install -r /app/requirements.txt
 COPY *.py /app/


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

Current base images for Docker are pretty obsolete.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

- Bumped Python base image from 3.8 to 3.12
- Bumped Node.js base image from 16.x to 22.x
- Bumped bcrypt to 4.2.1 due to compatiblity problems with newer versions of Python

