### PR TITLE
Allow dots in user and group names

### DIFF
--- a/mwdb/schema/group.py
+++ b/mwdb/schema/group.py
@@ -8,10 +8,10 @@ class GroupNameSchemaBase(Schema):
 
     @validates("name")
     def validate_name(self, name):
-        if not re.match("^[A-Za-z0-9_-]{1,32}$", name):
+        if not re.match("^[A-Za-z0-9_.-]{1,32}$", name):
             raise ValidationError(
                 "Group should contain max 32 chars and include only "
-                "letters, digits, underscores and dashes"
+                "letters, digits, underscores, dots and dashes"
             )
         if name.lower() == "private":
             raise ValidationError("Group cannot be named private")
@@ -29,10 +29,10 @@ class GroupUpdateRequestSchema(Schema):
 
     @validates("name")
     def validate_name(self, name):
-        if name is not None and not re.match("^[A-Za-z0-9_-]{1,32}$", name):
+        if name is not None and not re.match("^[A-Za-z0-9_.-]{1,32}$", name):
             raise ValidationError(
                 "Group should contain max 32 chars and include only "
-                "letters, digits, underscores and dashes"
+                "letters, digits, underscores, dots and dashes"
             )
 
 

--- a/mwdb/schema/share.py
+++ b/mwdb/schema/share.py
@@ -10,10 +10,10 @@ class ShareRequestSchema(Schema):
 
     @validates("group")
     def validate_name(self, name):
-        if not re.match("^[A-Za-z0-9_-]{1,32}$", name):
+        if not re.match("^[A-Za-z0-9_.-]{1,32}$", name):
             raise ValidationError(
                 "Group should contain max 32 chars and include only "
-                "letters, digits, underscores and dashes"
+                "letters, digits, underscores, dots and dashes"
             )
 
 

--- a/mwdb/schema/user.py
+++ b/mwdb/schema/user.py
@@ -12,10 +12,10 @@ class UserLoginSchemaBase(Schema):
 
     @validates("login")
     def validate_login(self, value):
-        if not re.match("^[A-Za-z0-9_-]{1,32}$", value):
+        if not re.match("^[A-Za-z0-9_.-]{1,32}$", value):
             raise ValidationError(
                 "Login should contain max 32 chars and include only "
-                "letters, digits, underscores and dashes"
+                "letters, digits, underscores, dots and dashes"
             )
         if value.lower() == "private":
             raise ValidationError("User cannot be named private")

--- a/mwdb/web/src/components/Settings/Views/GroupCreateView.tsx
+++ b/mwdb/web/src/components/Settings/Views/GroupCreateView.tsx
@@ -13,8 +13,8 @@ type FormValues = {
 const validationSchema: Yup.SchemaOf<FormValues> = Yup.object().shape({
     name: Yup.string()
         .matches(
-            /[A-Za-z0-9_-]/,
-            "Group name must contain only letters, digits, '_' and '-' characters"
+            /[A-Za-z0-9_.-]/,
+            "Group name must contain only letters, digits, '_', '.' and '-' characters"
         )
         .max(32, "Max 32 characters allowed.")
         .required("Name is required"),

--- a/mwdb/web/src/components/Settings/Views/GroupDetailsView.tsx
+++ b/mwdb/web/src/components/Settings/Views/GroupDetailsView.tsx
@@ -64,7 +64,7 @@ export function GroupDetailsView() {
                             defaultValue={group.name!}
                             onSubmit={handleUpdate}
                             required
-                            pattern="[A-Za-z0-9_-]{1,32}"
+                            pattern="[A-Za-z0-9_.-]{1,32}"
                         />
                     </DetailsRecord>
                     <DetailsRecord label="Members">

--- a/mwdb/web/src/components/Settings/Views/UserCreateView.tsx
+++ b/mwdb/web/src/components/Settings/Views/UserCreateView.tsx
@@ -12,8 +12,8 @@ type FormValues = CreateUser;
 const validationSchema: Yup.SchemaOf<FormValues> = Yup.object().shape({
     login: Yup.string()
         .matches(
-            /[A-Za-z0-9_-]/,
-            "Login must contain only letters, digits, '_' and '-'"
+            /[A-Za-z0-9_.-]/,
+            "Login must contain only letters, digits, '_', '.' and '-'"
         )
         .max(32, "Max 32 characters allowed.")
         .required("Login is required"),

--- a/mwdb/web/src/components/Views/UserRegisterView.tsx
+++ b/mwdb/web/src/components/Views/UserRegisterView.tsx
@@ -25,8 +25,8 @@ const validationSchema: Yup.SchemaOf<FormValues> = Yup.object().shape({
     login: Yup.string()
         .required("Login is required")
         .matches(
-            /[A-Za-z0-9_-]{1,32}/,
-            "Login must contain only letters, digits, '_'and '-' characters, max 32 characters allowed."
+            /[A-Za-z0-9_.-]{1,32}/,
+            "Login must contain only letters, digits, '_', '.' and '-' characters, max 32 characters allowed."
         ),
     email: Yup.string()
         .required("Email is required")


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

I noticed this problem during integration with OIDC SSO where dots were used in preferred usernames. We don't have any good reason to ban this character.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

Dots are allowed in user and group names.
