### PR TITLE
Fix Prometheus metrics MIME type and bump prometheus-client to 0.21.1

### DIFF
--- a/mwdb/resources/metrics.py
+++ b/mwdb/resources/metrics.py
@@ -1,4 +1,5 @@
 from flask import Response
+from prometheus_client import CONTENT_TYPE_LATEST
 
 from mwdb.core.capabilities import Capabilities
 from mwdb.core.metrics import collect
@@ -32,5 +33,5 @@ class MetricsResource(Resource):
         metrics = collect()
         return Response(
             metrics,
-            content_type="application/octet-stream",
+            content_type=CONTENT_TYPE_LATEST,
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,4 +26,4 @@ python-dateutil==2.8.2
 pyzipper==0.3.5
 pycryptodomex==3.19.1
 ssdeep==3.4
-prometheus-client==0.19.0
+prometheus-client==0.21.1


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

- `/api/varz` offers Prometheus metrics but sends them with generic `application/octet-stream` Content Type.
- Because of that, there are issues with compatibility with Prometheus v3 which is more strict concerning the Content-Type and doesn't automatically fallback to legacy protocol unless it's configured to do so (https://prometheus.io/docs/prometheus/latest/migration/). 

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

- Set correct Content-Type for the response (got from `prometheus_client.CONTENT_TYPE_LATEST`)
- Bumped `prometheus-client` to latest. I initially thought that 0.20.0 updates the PrometheusText version to 1.0.0, but misread the changelog and the bump was for OpenMetricsText, so the format we're using stays on `0.0.4`. Anyway, it's always a good opportunity to bump the version.

