### PR TITLE
Add 'hash_pathing_fallback' option, remove File.get_path() method

### DIFF
--- a/mwdb/core/config.py
+++ b/mwdb/core/config.py
@@ -79,6 +79,10 @@ class MWDBConfig(Config):
     # Should we break up the uploads into different folders for example:
     # uploads/9/f/8/6/9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08
     hash_pathing = key(cast=intbool, required=False, default=True)
+    # Try to open file using opposite hash_pathing setting when MWDB
+    # fails to open file using current one. It's useful when you want to
+    # migrate from one scheme to another.
+    hash_pathing_fallback = key(cast=intbool, required=False, default=True)
     # S3 compatible storage endpoint
     s3_storage_endpoint = key(cast=str, required=False)
     # Use TLS with S3 storage


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

We found that `hash_pathing` is useful also for some object storage solutions like MinIO.

MinIO maps `/` prefixes into actual directories on the file system. Even if we use recommended file system that allows to store lots of files in single directory, various operations using object listing (including internal ones like MinIO scanner) are significantly slowed down.

Unfortunately we can't smoothly migrate to the new naming scheme without fallback.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

- Add `hash_pathing_fallback` option. When `File.open()` fails to open file using current `hash_pathing` setting, it tries to use opposite one. It works only for gathering file contents, all new files will be stored using the chosen scheme only.
- Removed deprecated `File.get_path()`. **Check your plugins before applying this change.**
- Moved directory creation from `_calculate_path()` method to `get_or_create()` method. Path retrieval should not make any changes on the storage.

**Test plan**
<!-- Explain how to test your changes -->

Manually checked if fallback actually works. Other cases should be covered by automated tests.

