### PR TITLE
Limit exposed relationships type-wise to 100 elements

### DIFF
--- a/mwdb/model/object.py
+++ b/mwdb/model/object.py
@@ -158,7 +158,9 @@ class Object(db.Model):
     @classmethod
     def _get_object_types(cls):
         mapper = cls.__mapper__
-        return mapper.polymorphic_map.keys() - {mapper.polymorphic_identity}
+        return mapper.polymorphic_map.keys() - {
+            Object.__mapper_args__["polymorphic_identity"]
+        }
 
     def _get_relations_limited_per_type(self, relation_query, limit_each):
         object_type_names = [(object_type,) for object_type in self._get_object_types()]

--- a/mwdb/model/object.py
+++ b/mwdb/model/object.py
@@ -4,11 +4,12 @@ from typing import Any, Dict, Optional
 from uuid import UUID
 
 from flask import g
-from sqlalchemy import and_, cast, distinct, exists, func, select
+from sqlalchemy import and_, cast, distinct, exists, func
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import column_property
-from sqlalchemy.sql.expression import true
+from sqlalchemy.sql.expression import column, select, true, values
+from sqlalchemy.sql.sqltypes import String
 
 from mwdb.core.capabilities import Capabilities
 
@@ -17,6 +18,8 @@ from .attribute import Attribute, AttributeDefinition, AttributePermission
 from .karton import KartonAnalysis, karton_object
 from .object_permission import AccessType, ObjectPermission
 from .tag import Tag
+
+RELATIONS_VIEW_LIMIT_PER_TYPE = 100
 
 relation = db.Table(
     "relation",
@@ -152,8 +155,29 @@ class Object(db.Model):
     def favorite(self):
         return g.auth_user in self.followers
 
-    @property
-    def accessible_parents(self):
+    @classmethod
+    def _get_object_types(cls):
+        mapper = cls.__mapper__
+        return mapper.polymorphic_map.keys() - {mapper.polymorphic_identity}
+
+    def _get_relations_limited_per_type(self, relation_query, limit_each):
+        object_type_names = [(object_type,) for object_type in self._get_object_types()]
+        object_types = values(column("object_type", String), name="object_types").data(
+            object_type_names
+        )
+        relations = db.aliased(
+            Object,
+            (
+                relation_query.filter(Object.type == object_types.c.object_type)
+                .limit(limit_each)
+                .subquery()
+                .lateral()
+            ),
+        )
+        entries = db.session.query(object_types, relations).join(relations, true).all()
+        return [related_object for _, related_object in entries]
+
+    def get_parents_subquery(self):
         """
         Parent objects that are accessible for current user
         """
@@ -163,6 +187,35 @@ class Object(db.Model):
             .filter(relation.c.child_id == self.id)
             .order_by(relation.c.creation_time.desc())
             .filter(g.auth_user.has_access_to_object(Object.id))
+        )
+
+    def get_children_subquery(self):
+        """
+        Child objects that are accessible for current user
+        """
+        return (
+            db.session.query(Object)
+            .join(relation, relation.c.child_id == Object.id)
+            .filter(relation.c.parent_id == self.id)
+            .order_by(relation.c.creation_time.desc())
+            .filter(g.auth_user.has_access_to_object(Object.id))
+        )
+
+    def get_limited_parents_per_type(self, limit_each=RELATIONS_VIEW_LIMIT_PER_TYPE):
+        """
+        Parent objects that are directly loaded for API.
+        Query loads only *limit_each* number of relations for each object type.
+        """
+        return self._get_relations_limited_per_type(
+            self.get_parents_subquery(), limit_each
+        )
+
+    def get_limited_children_per_type(self, limit_each=RELATIONS_VIEW_LIMIT_PER_TYPE):
+        """
+        Parent objects that are accessible for current user
+        """
+        return self._get_relations_limited_per_type(
+            self.get_children_subquery(), limit_each
         )
 
     def add_parent(self, parent, commit=True):

--- a/mwdb/resources/relations.py
+++ b/mwdb/resources/relations.py
@@ -54,7 +54,14 @@ class RelationsResource(Resource):
             raise NotFound("Object not found")
 
         relations = RelationsResponseSchema()
-        return relations.dump(db_object)
+        parents = db_object.get_limited_parents_per_type()
+        children = db_object.get_limited_children_per_type()
+        return relations.dump(
+            {
+                "parents": parents,
+                "children": children,
+            }
+        )
 
 
 class ObjectChildResource(Resource):

--- a/mwdb/schema/object.py
+++ b/mwdb/schema/object.py
@@ -103,30 +103,25 @@ class ObjectItemResponseSchema(Schema):
     upload_time = UTCDateTime(required=True, allow_none=False)
     favorite = fields.Boolean(required=True, allow_none=False)
 
-    parents = fields.Nested(
-        ObjectListItemResponseSchema,
-        many=True,
-        required=True,
-        allow_none=False,
-        attribute="accessible_parents",
-    )
-    children = fields.Nested(
-        ObjectListItemResponseSchema, many=True, required=True, allow_none=False
-    )
-    attributes = fields.Nested(
-        AttributeItemResponseSchema, many=True, required=True, allow_none=False
-    )
+    parents = fields.Method(serialize="_get_parents")
+    children = fields.Method(serialize="_get_children")
+    attributes = fields.Method(serialize="_get_attributes")
     share_3rd_party = fields.Boolean(required=True, allow_none=False)
 
-    @post_dump(pass_original=True)
-    def get_accessible_attributes(self, data, object, **kwargs):
-        """
-        Replace all object attributes with attributes accessible for current user
-        """
+    def _get_parents(self, object):
+        object_parents = object.get_limited_parents_per_type()
+        schema = ObjectListItemResponseSchema()
+        return schema.dump(object_parents, many=True)
+
+    def _get_children(self, object):
+        object_children = object.get_limited_children_per_type()
+        schema = ObjectListItemResponseSchema()
+        return schema.dump(object_children, many=True)
+
+    def _get_attributes(self, object):
         object_attributes = object.get_attributes()
         schema = AttributeItemResponseSchema()
-        attributes_serialized = schema.dump(object_attributes, many=True)
-        return {**data, "attributes": attributes_serialized}
+        return schema.dump(object_attributes, many=True)
 
 
 class ObjectCountResponseSchema(Schema):

--- a/mwdb/schema/relations.py
+++ b/mwdb/schema/relations.py
@@ -4,13 +4,5 @@ from .object import ObjectListItemResponseSchema
 
 
 class RelationsResponseSchema(Schema):
-    parents = fields.Nested(
-        ObjectListItemResponseSchema,
-        many=True,
-        required=True,
-        allow_none=False,
-        attribute="accessible_parents",
-    )
-    children = fields.Nested(
-        ObjectListItemResponseSchema, many=True, required=True, allow_none=False
-    )
+    parents = fields.Nested(ObjectListItemResponseSchema, many=True)
+    children = fields.Nested(ObjectListItemResponseSchema, many=True)

--- a/mwdb/web/src/commons/helpers/index.ts
+++ b/mwdb/web/src/commons/helpers/index.ts
@@ -1,4 +1,4 @@
-import { GenericOrJSX } from "@mwdb-web/types/types";
+import { GenericOrJSX, ObjectLegacyType } from "@mwdb-web/types/types";
 
 export { downloadData } from "./download";
 export * from "./search";
@@ -44,6 +44,18 @@ export function mapObjectType(objectType: string): string {
             file: "file",
             static_config: "config",
             text_blob: "blob",
+        }[objectType] || objectType
+    );
+}
+
+export function mapObjectTypeToSearchPath(
+    objectType: ObjectLegacyType
+): string {
+    return (
+        {
+            file: "/",
+            static_config: "/configs",
+            text_blob: "/blobs",
         }[objectType] || objectType
     );
 }

--- a/mwdb/web/src/components/ShowObject/common/RelationBox.tsx
+++ b/mwdb/web/src/components/ShowObject/common/RelationBox.tsx
@@ -17,10 +17,18 @@ import {
     ConfirmationModal,
     TagList,
 } from "@mwdb-web/commons/ui";
-import { getErrorMessage } from "@mwdb-web/commons/helpers";
+import {
+    getErrorMessage,
+    makeSearchLink,
+    mapObjectTypeToSearchPath,
+} from "@mwdb-web/commons/helpers";
 import { useRemotePath } from "@mwdb-web/commons/remotes";
 import { RelationsAddModal } from "../Actions/RelationsAddModal";
-import { Capability, RelationItem } from "@mwdb-web/types/types";
+import {
+    Capability,
+    ObjectLegacyType,
+    RelationItem,
+} from "@mwdb-web/types/types";
 
 type RelationToRemove = {
     relation: "parent" | "child";
@@ -32,6 +40,9 @@ type Props = {
     parents?: RelationItem[];
     header?: string;
     icon?: IconDefinition;
+    parentsCount?: number;
+    childrenCount?: number;
+    elementType?: ObjectLegacyType;
     updateRelationsActivePage?: () => void;
 };
 
@@ -191,11 +202,56 @@ export function RelationsBox(props: Props) {
             </td>
         </tr>
     ));
+
+    let header;
+    let elementCount = (props.parentsCount || 0) + (props.childrenCount || 0);
+    if (!props.header) {
+        header = "Relations";
+    } else {
+        if (props.parentsCount && props.parentsCount >= 100) {
+            let queryLink = makeSearchLink({
+                field: "child",
+                value: `(dhash:${context.object?.id})`,
+                noEscape: true,
+                pathname: mapObjectTypeToSearchPath(
+                    props.elementType || "file"
+                ),
+            });
+            header = (
+                <>
+                    {props.header}: {elementCount}+ (
+                    <Link to={queryLink}>query all parents</Link>)
+                </>
+            );
+        } else if (props.childrenCount && props.childrenCount >= 100) {
+            let queryLink = makeSearchLink({
+                field: "parent",
+                value: `(dhash:${context.object?.id})`,
+                noEscape: true,
+                pathname: mapObjectTypeToSearchPath(
+                    props.elementType || "file"
+                ),
+            });
+            header = (
+                <>
+                    {props.header}: {elementCount}+ (
+                    <Link to={queryLink}>query all children</Link>)
+                </>
+            );
+        } else {
+            header = (
+                <>
+                    {props.header}: {elementCount}
+                </>
+            );
+        }
+    }
+
     return (
         <div className="card card-default">
             <div className="card-header">
                 {props.icon && <FontAwesomeIcon icon={props.icon} size="1x" />}
-                {props.header || "Relations"}
+                {header}
                 {!api.remote ? (
                     <Link
                         to="#"

--- a/mwdb/web/src/components/ShowObject/common/TypedRelationsBox.tsx
+++ b/mwdb/web/src/components/ShowObject/common/TypedRelationsBox.tsx
@@ -66,7 +66,10 @@ export function TypedRelationsBox(props: Props) {
         return (
             <div>
                 <RelationsBox
-                    header={`${props.header}: ${typedRelationsCount}`}
+                    header={props.header}
+                    parentsCount={parentsFiltered.length}
+                    childrenCount={childrenFiltered.length}
+                    elementType={props.type}
                     icon={props.icon}
                     updateRelationsActivePage={() =>
                         updateActivePage(


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [x] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

This PR addresses the same problem as #881 and #1008.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

If there are more relationships than 100 within a specific type, only the latest 100 are shown via API. Limiting must be done typewise because MWDB UI divides relationships into object types:

![image](https://github.com/user-attachments/assets/d6978b0e-7bff-4239-848b-eb6f15105029)

So there is a possibililty that with 100+ parent samples, blob relationship won't be shown which is surprising and incorrect behavior.

If there is 100 or more relationships within a specific type, MWDB shows additional link to query that allows to search for all related objects of that type.

![image](https://github.com/user-attachments/assets/c496bd9f-7623-4a88-8b3a-63e895a24849)

Usually the relationships within type are in specific direction, that's why MWDB UI tries to deduce whether "parent query" or "child query" should be shown.


