### PR TITLE
Feature: easy toggle to raw JSON view for Rich Attribute

### DIFF
--- a/mwdb/web/src/commons/ui/ConfirmationModal.tsx
+++ b/mwdb/web/src/commons/ui/ConfirmationModal.tsx
@@ -22,6 +22,7 @@ export function ConfirmationModal(props: Props) {
             bottom: "auto",
             marginRight: "-50%",
             transform: "translate(-50%, -50%)",
+            maxHeight: "80%",
         },
     };
 

--- a/mwdb/web/src/components/ShowObject/common/AttributeRenderer.tsx
+++ b/mwdb/web/src/components/ShowObject/common/AttributeRenderer.tsx
@@ -16,7 +16,9 @@ export function AttributeRenderer({
     onRemoveAttribute,
 }: Props) {
     const [collapsed, setCollapsed] = useState<boolean>(true);
+    const [showRaw, setShowRaw] = useState<boolean>(false);
     const isCollapsible = attributes.length > 3;
+    const isRichRendered = attributeDefinition.rich_template !== "";
     const visibleAttributes = collapsed ? attributes.slice(0, 3) : attributes;
 
     return (
@@ -26,6 +28,9 @@ export function AttributeRenderer({
             onCollapse={(collapsed) => setCollapsed(collapsed)}
             collapsed={collapsed}
             collapsible={isCollapsible}
+            onShowRaw={(showRaw) => setShowRaw(showRaw)}
+            showRaw={showRaw}
+            isRichRendered={isRichRendered}
         >
             <>
                 {visibleAttributes.map((attribute: Attribute) => (
@@ -35,6 +40,7 @@ export function AttributeRenderer({
                         value={attribute.value}
                         attributeDefinition={attributeDefinition}
                         onRemove={onRemoveAttribute}
+                        showRaw={showRaw}
                     />
                 ))}
             </>

--- a/mwdb/web/src/components/ShowObject/common/AttributeRow.tsx
+++ b/mwdb/web/src/components/ShowObject/common/AttributeRow.tsx
@@ -7,6 +7,9 @@ type Props = {
     collapsed: boolean;
     onCollapse: (val: boolean) => void;
     collapsible: boolean;
+    onShowRaw: (val: boolean) => void;
+    showRaw: boolean;
+    isRichRendered: boolean;
     children: JSX.Element;
 };
 
@@ -16,6 +19,9 @@ export function AttributeRow({
     collapsed,
     onCollapse,
     collapsible,
+    onShowRaw,
+    showRaw,
+    isRichRendered,
     children,
 }: Props) {
     return (
@@ -41,6 +47,23 @@ export function AttributeRow({
                 >
                     {attributeLabel || attributeKey}
                 </span>
+                {isRichRendered ? (
+                    <div
+                        style={{
+                            cursor: "pointer",
+                            textDecoration: "underline",
+                            fontWeight: "normal",
+                        }}
+                        onClick={(ev) => {
+                            ev.preventDefault();
+                            onShowRaw(!showRaw);
+                        }}
+                    >
+                        Show {showRaw ? "rendered" : "raw"}
+                    </div>
+                ) : (
+                    <></>
+                )}
             </th>
             <td className="flickerable">
                 {children}

--- a/mwdb/web/src/components/ShowObject/common/AttributeValue.tsx
+++ b/mwdb/web/src/components/ShowObject/common/AttributeValue.tsx
@@ -15,6 +15,7 @@ type Props = {
         key: string;
     };
     onRemove?: (id: number) => void;
+    showRaw: boolean;
 };
 
 export function AttributeValue({
@@ -22,6 +23,7 @@ export function AttributeValue({
     attributeId,
     attributeDefinition,
     onRemove,
+    showRaw,
 }: Props) {
     const {
         url_template: urlTemplate,
@@ -33,7 +35,7 @@ export function AttributeValue({
     let valueRender: JSX.Element;
     let valueRaw: string;
 
-    if (richTemplate !== "") {
+    if (richTemplate !== "" && !showRaw) {
         valueRender = (
             <RichAttributeValue
                 attributeDefinition={attributeDefinition}


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the new behaviour?**

Sometimes it's convenient to view the raw JSON attribute value instead of its rendered visualization. This PR adds a toggle that allows to switch between these representations.

![image](https://github.com/user-attachments/assets/b4492344-4c5b-4f46-ae95-cbc6c1e6e5b9)
![image](https://github.com/user-attachments/assets/fc212e59-fc4e-479f-8442-84e42c7b4adf)

