### PR TITLE
Fix: reset MustacheContext.lastPath before lookup

### DIFF
--- a/mwdb/web/src/components/RichAttribute/MarkedMustache.tsx
+++ b/mwdb/web/src/components/RichAttribute/MarkedMustache.tsx
@@ -263,6 +263,8 @@ class MustacheContext extends Mustache.Context {
     }
 
     lookup(name: string) {
+        // Reset path before lookup
+        this.lastPath = this.parentPath.slice();
         // Check for searchable mark at the beginning
         if (name[0] === "@") {
             // Searchable field mark


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

When multiple value lookups are done within the same context, some of them may not reset the lastPath value.

So the following template with searchable `value.category`
```
{{#if}}{{value.id}}{{/if}}
{{#then}}
{{@value.category}}
{{/then}}
```

creates search link to `attribute.test-attribute.id.value.category:"<category value>"` instead of `attribute.test-attribute.category:"<category value>"`

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

Value of lastPath is reset back to parentPath on every lookup in MustacheContext.
