### PR TITLE
Bump version: v2.15.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     depends_on:
       - postgres
       - redis
-    image: certpl/mwdb:v2.14.0
+    image: certpl/mwdb:v2.15.0
     restart: on-failure
     env_file:
       # NOTE: use gen_vars.sh in order to generate this file
@@ -22,7 +22,7 @@ services:
     build:
       context: .
       dockerfile: deploy/docker/Dockerfile-web
-    image: certpl/mwdb-web:v2.14.0
+    image: certpl/mwdb-web:v2.15.0
     ports:
       - "80:80"
     restart: on-failure

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ copyright = '2021, CERT Polska'
 author = 'CERT Polska'
 
 # The full version, including alpha/beta/rc tags
-release = '2.14.0'
+release = '2.15.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/whats-changed.rst
+++ b/docs/whats-changed.rst
@@ -7,6 +7,37 @@ have compatibility problems after minor mwdb-core upgrade.
 
 For upgrade instructions, see :ref:`Upgrading mwdb-core to latest version`.
 
+v2.15.0
+-------
+
+This release contains major improvements of performance and new Rich Attributes features.
+
+Complete changelog can be found here: `v2.15.0 changelog <https://github.com/CERT-Polska/mwdb-core/releases/tag/v2.15.0>`_.
+
+[Important change] Exposed relationships are limited type-wise to 100 elements
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In previous versions of MWDB, related objects were eagerly loaded without pagination. While this approach simplified
+access to related data, it became problematic for frequently occurring objects with a large number of relationships.
+Eager loading in such cases lead to significant performance degradation.
+
+Starting with version v2.15.0, MWDB limits the number of related objects loaded per object type to 100 in
+``GET /api/object/{identifier}`` and ``/api/{type}/{identifier}/relations``.
+
+If you want to get all relationships, use proper search query such as ``parent:(dhash:"<sha256>")``. Listing endpoints
+implement pagination, so big sets of relationships can be loaded much more efficiently.
+
+[Feature] Lambdas - new feature of Rich Attributes templates
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In v2.15.0, MWDB adds support for Lambdas that follow a similar concept to `Jinja filters <https://jinja.palletsprojects.com/en/stable/templates/#filters>`_.
+
+This feature allows to apply basic transformations on objects such as grouping, sorting and counting. You can also build
+basic conditional clauses using if-then-else syntax. Another feature are custom widgets that can be used for making
+collapsible lists, sections and indicators.
+
+Read more about this feature in :ref:`Rich attributes guide`.
+
 v2.14.0
 -------
 

--- a/mwdb/version.py
+++ b/mwdb/version.py
@@ -4,5 +4,5 @@ try:
 except IOError:
     git_revision = ""
 
-app_version = "2.14.0"
+app_version = "2.15.0"
 app_build_version = f"{app_version}+{git_revision}" if git_revision else app_version

--- a/mwdb/web/package-lock.json
+++ b/mwdb/web/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "mwdb-web",
-    "version": "2.14.0",
+    "version": "2.15.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "mwdb-web",
-            "version": "2.14.0",
+            "version": "2.15.0",
             "dependencies": {
                 "@fortawesome/fontawesome-svg-core": "^6.1.1",
                 "@fortawesome/free-regular-svg-icons": "^6.1.1",

--- a/mwdb/web/package.json
+++ b/mwdb/web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mwdb-web",
-    "version": "2.14.0",
+    "version": "2.15.0",
     "private": true,
     "scripts": {
         "dev": "vite",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ Under the hood of mwdb.cert.pl service hosted by CERT.pl.
 """
 
 setup(name="mwdb-core",
-      version="2.14.0",
+      version="2.15.0",
       description="MWDB Core malware database",
       long_description=LONG_DESCRIPTION,
       author="CERT Polska",


### PR DESCRIPTION
**New features:**

* Lambdas: extension to Rich Attributes that allow transformation of objects and to render arbitrary widgets (by @yankovs and @psrok1 in https://github.com/CERT-Polska/mwdb-core/pull/1021)
* Feature: brownout deprecated API features via enable_brownout flag (by @psrok1 in https://github.com/CERT-Polska/mwdb-core/pull/1007)
* Feature: more configuration options for logging (https://github.com/CERT-Polska/mwdb-core/pull/1026)
* Dots are allowed in user and group names (https://github.com/CERT-Polska/mwdb-core/pull/1014)
* 'hash_pathing_fallback' option (https://github.com/CERT-Polska/mwdb-core/pull/1017)
* Feature: easy toggle to raw JSON view for Rich Attribute (https://github.com/CERT-Polska/mwdb-core/pull/1044)

**Improvements:**

* Limit exposed relationships type-wise to 100 elements (https://github.com/CERT-Polska/mwdb-core/pull/1023)
* Add index on comment.user_id (https://github.com/CERT-Polska/mwdb-core/pull/992)
* Changed object.tags eager-load strategy to select-in by @psrok1 in https://github.com/CERT-Polska/mwdb-core/pull/996
* Various dependency version bumps (sqlalchemy 1.3 -> 1.4, Vite v4 -> v6

**Bugfixes:**

* Fix tag visibility in relation graph #1011 (by @postrowinski in https://github.com/CERT-Polska/mwdb-core/pull/1012)
* Fix Prometheus metrics MIME type and bump prometheus-client to 0.21.1 (https://github.com/CERT-Polska/mwdb-core/pull/1016)

**Full Changelog**: https://github.com/CERT-Polska/mwdb-core/compare/v2.14.0...v2.15.0