### PR TITLE
Feat: Add ability to add custom content style to ConfirmationModal

### DIFF
--- a/mwdb/web/src/commons/ui/ConfirmationModal.tsx
+++ b/mwdb/web/src/commons/ui/ConfirmationModal.tsx
@@ -37,7 +37,7 @@ export function ConfirmationModal(props: Props) {
                 content: {
                     ...modalStyle.content,
                     ...(props.contentStyle || {}),
-                }
+                },
             }}
         >
             <div className="modal-header">

--- a/mwdb/web/src/commons/ui/ConfirmationModal.tsx
+++ b/mwdb/web/src/commons/ui/ConfirmationModal.tsx
@@ -11,6 +11,7 @@ type Props = ReactModal.Props & {
     onConfirm?: React.MouseEventHandler;
     confirmDisabled?: boolean;
     confirmText?: string;
+    contentStyle?: React.CSSProperties;
 };
 
 export function ConfirmationModal(props: Props) {
@@ -32,7 +33,12 @@ export function ConfirmationModal(props: Props) {
             isOpen={props.isOpen}
             onRequestClose={props.onRequestClose}
             onAfterOpen={props.onAfterOpen}
-            style={modalStyle}
+            style={{
+                content: {
+                    ...modalStyle.content,
+                    ...(props.contentStyle || {}),
+                }
+            }}
         >
             <div className="modal-header">
                 <h5 className="modal-title">{props.message}</h5>


### PR DESCRIPTION
- [X] I've read the [contributing guideline](CONTRIBUTING.md).
- [X] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**

In a commit a while ago, the following CSS property was added by default to the `ConfirmationModal` component: `maxHeight: "80%"`.

We have many plugins that use this component and as a result many of our plugins were broken in the way they are displayed.

**What is the new behaviour?**
Add the ability to use custom styles that can override the existing ones.

**Test plan**
I tested this code to see that just adding it doesn't break anything, and then tested to see if this allows me to fix the issue - it does, by allowing me to override the default styles
