### PR TITLE
Rich attributes: disable auto-URL rendering, bump marked to 15.0.12

### DIFF
--- a/mwdb/web/package-lock.json
+++ b/mwdb/web/package-lock.json
@@ -20,7 +20,7 @@
                 "diff-match-patch": "^1.0.4",
                 "identicon.js": "^2.3.2",
                 "lodash": "^4.17.10",
-                "marked": "^4.0.10",
+                "marked": "^15.0.12",
                 "mustache": "^4.2.0",
                 "popper.js": "^1.16.1",
                 "react": "^18.1.0",
@@ -10398,14 +10398,14 @@
             }
         },
         "node_modules/marked": {
-            "version": "4.2.12",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
-            "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
+            "version": "15.0.12",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+            "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
             "bin": {
                 "marked": "bin/marked.js"
             },
             "engines": {
-                "node": ">= 12"
+                "node": ">= 18"
             }
         },
         "node_modules/math-intrinsics": {
@@ -21269,9 +21269,9 @@
             }
         },
         "marked": {
-            "version": "4.2.12",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
-            "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw=="
+            "version": "15.0.12",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+            "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="
         },
         "math-intrinsics": {
             "version": "1.1.0",

--- a/mwdb/web/package.json
+++ b/mwdb/web/package.json
@@ -23,7 +23,7 @@
         "diff-match-patch": "^1.0.4",
         "identicon.js": "^2.3.2",
         "lodash": "^4.17.10",
-        "marked": "^4.0.10",
+        "marked": "^15.0.12",
         "mustache": "^4.2.0",
         "popper.js": "^1.16.1",
         "react": "^18.1.0",

--- a/mwdb/web/src/components/RichAttribute/MarkedMustache.tsx
+++ b/mwdb/web/src/components/RichAttribute/MarkedMustache.tsx
@@ -374,49 +374,12 @@ class MustacheWriter extends Mustache.Writer {
     }
 }
 
-// Overrides to not use HTML escape
-// https://github.com/markedjs/marked/blob/e3f8cd7c7ce75ce4f7e22bd082c45deb1678846d/src/Tokenizer.js#L67
+// Tokenizer overrides
+// Reference: https://github.com/markedjs/marked/blob/v15.0.12/src/Tokenizer.ts#L61
 class MarkedTokenizer extends Tokenizer {
     rules: any;
-    escape(src: string): any {
-        const cap = this.rules.inline.escape.exec(src);
-        if (cap) {
-            return {
-                type: "escape",
-                raw: cap[0],
-                text: cap[1],
-            };
-        }
+    url(src: string): any {
         return false;
-    }
-
-    codespan(src: string): any {
-        const cap = this.rules.inline.code.exec(src);
-        if (cap) {
-            let text = cap[2].replace(/\n/g, " ");
-            const hasNonSpaceChars = /[^ ]/.test(text);
-            const hasSpaceCharsOnBothEnds = /^ /.test(text) && / $/.test(text);
-            if (hasNonSpaceChars && hasSpaceCharsOnBothEnds) {
-                text = text.substring(1, text.length - 1);
-            }
-            return {
-                type: "codespan",
-                raw: cap[0],
-                text,
-            };
-        }
-    }
-
-    inlineText(src: string, smartypants: (cap: string) => string): any {
-        const cap = this.rules.inline.text.exec(src);
-        if (cap) {
-            let text = this.options.smartypants ? smartypants(cap[0]) : cap[0];
-            return {
-                type: "text",
-                raw: cap[0],
-                text,
-            };
-        }
     }
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [x] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

- Marked.js autorenders URLs and e-mail addresses as links. It's not desired behavior for MWDB where links contained in attribute values are usually malicious.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

- Overridden "url" method of Marked tokenizer to always return false and ignore that rule.
- If someone wants to render link in that way, they can use https://github.github.com/gfm/#autolinks-extension- syntax
- Bumped Marked to 15.0.12:
    - they fixed escaping issues with autolink rendering
    - they fixed HTML escaping on tokenizer level which was the reason why we have done Tokenizer overrides in previous versions.

**Test plan**
<!-- Explain how to test your changes -->

Checked manually if bug was fixed and if other Rich attributes features still work correctly.

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->
