### PR TITLE
Rich attributes: put arrayIndex and isLastElement local variables in array sections

### DIFF
--- a/docs/rich-attributes-guide.rst
+++ b/docs/rich-attributes-guide.rst
@@ -568,6 +568,37 @@ It may not work if you apply a lambda. In that case, you can use a Markdown synt
 
 If you worry about proper query escaping, ``jsonify`` and ``uriencode`` should be enough to encode your value into final URI by Markdown renderer.
 
+Array indices
+~~~~~~~~~~~~~
+
+.. versionadded:: 2.16.0
+
+If Mustache section enumerates an array, two special attributes are available:
+
+- ``$arrayIndex`` is set to the index of current element
+- ``$isLastElement`` is set to true when current element is last in the array and false otherwise
+
+This is especially useful for making commas between elements:
+
+.. code-block::
+
+    {{#value.receivers}}{{#$arrayIndex}}, {{/$arrayIndex}}{{@.}}{{/value.receivers}}
+
+The above template renders a comma only if ``$arrayIndex`` is non-zero, so the comma will be put only between the
+consecutive elements. We can also use inverted section and ``$isLastElement`` value to make the equivalent template:
+
+.. code-block::
+
+    {{#value.receivers}}{{@.}}{{^$isLastElement }}, {{/$isLastElement }}{{/value.receivers}}
+
+.. note::
+
+    These attributes are available only if:
+
+    - they're referenced directly in the array enumerating section
+    - elements does not contain ``$arrayIndex`` and ``$isLastElement`` elements, as element attributes have precedence
+      over special attributes injected into context
+
 Known issues
 ------------
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [x] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

Sometimes it's useful to have an information about position of element in the array.

For example: when we enumerate values and want to put comma in between, we may do that by rendering leading comma for all values except the first. Right now it's impossible to do that in Rich attributes.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

For array enumeration, two additional variables are injected into context:

- `$arrayIndex` set to the index of current element
- `$isLastElement` that is set to `true` when current element is last in the array and `false` otherwise

These variables are available only directly in the array section and are not available in nested sections.

Using these values, we're able to conditionally render a comma when arrayIndex is non-zero.
```
{{#value.receivers}}{{#$arrayIndex}}, {{/$arrayIndex}}{{@.}}{{/value.receivers}}
```

<img width="253" height="21" alt="image" src="https://github.com/user-attachments/assets/76e26a26-e08b-4aa8-a470-087510d5b4b1" />
