### PR TITLE
Bump minimum Python version to 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(name="mwdb-core",
       include_package_data=True,
       url="https://github.com/CERT-Polska/mwdb-core",
       install_requires=open("requirements.txt").read().splitlines(),
-      python_requires='>=3.7',
+      python_requires='>=3.10',
       entry_points={
         'console_scripts': [
             'mwdb-core=mwdb.cli:cli'


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

Python 3.9 EOL is 2025-10. Current minimum version is already incorrect because we have dependencies that are Py3.9+.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

Minimum Python version is set to 3.10
