### PR TITLE
Fix a slight typo/deprecated info in documentation

### DIFF
--- a/docs/user-guide/7-Lucene-search.rst
+++ b/docs/user-guide/7-Lucene-search.rst
@@ -219,7 +219,7 @@ Untyped fields
 * ``dhash:<string>`` - Object identifier (SHA256)
 * ``tag:<string>`` - Object tag
 * ``comment:<string>`` - Object comment contents
-* ``meta.<attribute>:<string>`` - Object attribute value
+* ``attribute.<attribute>:<string>`` - Object attribute value
 * ``upload_time:<datetime>`` - Object first upload timestamp
 * ``karton:<uuid>`` - Karton analysis artifacts
 


### PR DESCRIPTION
**What is the current behaviour?**
Obsoleta key name used in documentation

**What is the new behaviour?**
I changed meta. to attribute.
