### PR TITLE
Bump bcrypt to 5.0.0, handle ValueError for passwords longer than 72 bytes

### DIFF
--- a/mwdb/resources/auth.py
+++ b/mwdb/resources/auth.py
@@ -6,7 +6,7 @@ from sqlalchemy import exists, func
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.sql.expression import false
-from werkzeug.exceptions import Conflict, Forbidden, InternalServerError
+from werkzeug.exceptions import BadRequest, Conflict, Forbidden, InternalServerError
 
 from mwdb.core.capabilities import Capabilities
 from mwdb.core.config import app_config
@@ -237,7 +237,10 @@ class ChangePasswordResource(Resource):
         if user is None:
             raise Forbidden("Set password token expired")
 
-        user.set_password(password=obj["password"])
+        try:
+            user.set_password(password=obj["password"])
+        except ValueError:
+            raise BadRequest("Password can't be longer than 72 bytes")
         db.session.commit()
 
         logger.info("Password changed", extra={"user": user.login})

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ marshmallow==3.20.2
 psycopg2-binary==2.9.10
 requests==2.32.4
 apispec[marshmallow,yaml]==6.4.0
-bcrypt==4.2.1
+bcrypt==5.0.0
 python-magic==0.4.18
 luqum==0.13.0
 python-json-logger==2.0.2


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [x] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

From bcrypt changelog:

> Passing hashpw a password longer than 72 bytes now raises a ValueError. Previously the password was silently truncated, following the behavior of the original OpenBSD bcrypt implementation.

Bump is related with https://github.com/CERT-Polska/mwdb-core/pull/1066
