### PR TITLE
CLI: `set-admin-password` utility command to set admin password

### DIFF
--- a/mwdb/cli/cli.py
+++ b/mwdb/cli/cli.py
@@ -143,7 +143,9 @@ def set_admin_password(password):
     """
     from mwdb.model import User, db
 
-    admin = db.session.query(User).filter(User.login == "admin").first()
+    admin = (
+        db.session.query(User).filter(User.login == app_config.mwdb.admin_login).first()
+    )
     admin.set_password(password)
     db.session.add(admin)
     db.session.commit()


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

This PR adds extra CLI command `mwdb-core set-admin-password` that allows to set `admin`'s password via CLI.

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #850
