### PR TITLE
Extendable InjectAfter: allow to inject component in the middle of the original children list

### DIFF
--- a/docs/integration-guide.rst
+++ b/docs/integration-guide.rst
@@ -335,6 +335,58 @@ by references to few methods and wrappers from ``common/plugins`` :
 
 So ``navbar`` is one of ``Extendable`` wrappers that can be found within application and that's why we can add extra navbar item.
 
+Web plugins: Transforming Extendable element
+--------------------------------------------
+
+.. versionadded:: 2.16.0
+
+MWDB Core applies the ``Extendable`` wrapper primarily to basic container components. For example: the ``ShowObject`` view component is composed of two Extendables: ``showObjectLeftColumn`` and ``showObjectRightColumn``. As explained in the previous sections, plugins can normally place elements *before*, *after* and *instead of* the original component.
+
+But what if you want to insert an additional card **between** existing cards in the left column rather than only before/after the entire block?
+
+Starting from version 2.16.0, ``<name>Replace`` extension components are treated as wrappers around the original element. The original component is passed as ``children``, which allows you to transform or rearrange those children using utilities like `React.Children.map <https://18.react.dev/reference/react/Children#children-map>`_.
+
+To simplify common use cases, MWDB provides a helper component called ``InjectAfter``. It injects a custom element after the specified index in the original children list.
+
+For example, to render an "Extra Tab" card immediately after the basic object details, you can write:
+
+.. code-block:: jsx
+
+    import React from 'react';
+    import { InjectAfter } from "@mwdb-web/commons/plugins";
+
+    function ObjectExtraTab() {
+        return (
+            <div className="card">
+                <div className="card-header">
+                    Extra tab
+                </div>
+                <div className="card-body">
+                    Hello from this tab
+                </div>
+            </div>
+        )
+    }
+
+    export default () => ({
+        showObjectLeftColumnReplace: [
+            ({children}) => (
+                <InjectAfter
+                    afterElementIndex={0}
+                    element={() => <ObjectExtraTab />}
+                >
+                    {children}
+                </InjectAfter>
+            )
+        ],
+    })
+
+.. note::
+
+    Only one replacement should be defined for each Extendable.
+    If multiple plugins attempt to replace the same Extendable,
+    the original children will be rendered multiple times.
+
 Web plugins: how it works internally?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/mwdb/web/src/commons/plugins/Extendable.tsx
+++ b/mwdb/web/src/commons/plugins/Extendable.tsx
@@ -1,9 +1,9 @@
 import { Extension } from "./Extension";
 
 type Props = {
-    [extensionProp: string]: any;
     ident: string;
-    fallback?: JSX.Element;
+    children?: any;
+    [extensionProp: string]: any;
 };
 
 export function Extendable({ ident, children, ...props }: Props) {
@@ -11,11 +11,9 @@ export function Extendable({ ident, children, ...props }: Props) {
         <>
             {<Extension {...props} ident={`${ident}Before`} />}
             {
-                <Extension
-                    {...props}
-                    ident={`${ident}Replace`}
-                    fallback={children}
-                />
+                <Extension {...props} ident={`${ident}Replace`}>
+                    {children}
+                </Extension>
             }
             {<Extension {...props} ident={`${ident}After`} />}
         </>

--- a/mwdb/web/src/commons/plugins/Extension.tsx
+++ b/mwdb/web/src/commons/plugins/Extension.tsx
@@ -1,18 +1,18 @@
 import { fromPlugins } from "./loader";
 
 type Props = {
-    [extensionProp: string]: any;
     ident: string;
-    fallback?: JSX.Element;
+    children?: any;
+    [extensionProp: string]: any;
 };
 
-export function Extension({ ident, fallback, ...props }: Props) {
+export function Extension({ ident, children, ...props }: Props) {
     const components = fromPlugins(ident);
-    if (components.length === 0) return fallback || <></>;
+    if (components.length === 0) return children || <></>;
     return (
         <>
             {components.map((ExtElement) => (
-                <ExtElement {...props} />
+                <ExtElement {...props}>{children}</ExtElement>
             ))}
         </>
     );

--- a/mwdb/web/src/commons/plugins/index.jsx
+++ b/mwdb/web/src/commons/plugins/index.jsx
@@ -1,3 +1,4 @@
 export { Extension } from "./Extension";
 export { Extendable } from "./Extendable";
 export { loadPlugins, afterPluginsLoaded, fromPlugins } from "./loader";
+export { InjectAfter } from "./utils";

--- a/mwdb/web/src/commons/plugins/utils.tsx
+++ b/mwdb/web/src/commons/plugins/utils.tsx
@@ -1,0 +1,23 @@
+import React, { Children } from "react";
+
+type InjectAfterProps = {
+    afterElementIndex: number;
+    element: React.ComponentType;
+    children: any[];
+};
+
+export function InjectAfter({
+    afterElementIndex,
+    element,
+    children,
+}: InjectAfterProps) {
+    const Element = element;
+    const result: any[] = [];
+    Children.map(children, (child, index) => {
+        result.push(child);
+        if (index === afterElementIndex) {
+            result.push(<Element />);
+        }
+    });
+    return result;
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- ~~[ ] I've added automated tests for my change (if applicable, optional)~~
- [x] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

During implementation of an internal plugin I hit the main limitation of Extendables: they can be only surrounded by new elements or completely replaced by them. I don't want to spam Extendables everywhere and on every level, so I needed to provide a way to transform the existing children tree.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

- `<name>Replace` Extensions are now wrappers around the original children. Previously children were passed via `fallback` prop and it was impossible to control them and re-render them by the plugin component.
- added `InjectAfter` helper that adds a new element after the n-th position
- added documentation that explains how to inject a new card in the left column of ShowObject
