### PR TITLE
Web: memoizations in InjectAfter, RichAttributeValue and ObjectContext.object

### DIFF
--- a/mwdb/web/src/commons/plugins/utils.tsx
+++ b/mwdb/web/src/commons/plugins/utils.tsx
@@ -1,4 +1,4 @@
-import React, { Children } from "react";
+import React, { Children, useMemo } from "react";
 
 type InjectAfterProps = {
     afterElementIndex: number;
@@ -11,13 +11,15 @@ export function InjectAfter({
     element,
     children,
 }: InjectAfterProps) {
-    const Element = element;
-    const result: any[] = [];
-    Children.map(children, (child, index) => {
-        result.push(child);
-        if (index === afterElementIndex) {
-            result.push(<Element />);
-        }
-    });
-    return result;
+    return useMemo(() => {
+        const Element = element;
+        const result: any = [];
+        Children.map(children, (child, index) => {
+            result.push(child);
+            if (index === afterElementIndex) {
+                result.push(<Element />);
+            }
+        });
+        return result;
+    }, [afterElementIndex, element, children]);
 }

--- a/mwdb/web/src/components/ShowObject/common/RichAttributeValue.tsx
+++ b/mwdb/web/src/components/ShowObject/common/RichAttributeValue.tsx
@@ -1,4 +1,4 @@
-import { useContext } from "react";
+import { useContext, useMemo } from "react";
 import { ObjectContext } from "@mwdb-web/commons/context";
 import { renderValue } from "../../RichAttribute/MarkedMustache";
 import { AttributeDefinition } from "@mwdb-web/types/types";
@@ -13,21 +13,24 @@ export function RichAttributeValue({ attributeDefinition, value }: Props) {
     // TODO: RichAttributeValue and RichAttributeRenderer should be unified
     const { rich_template: richTemplate, key } = attributeDefinition;
     const object = useContext(ObjectContext);
-    try {
-        const context = {
-            key,
-            value,
-            object: object.object,
-        };
-        return renderValue(richTemplate, context, {
-            searchEndpoint: object.searchEndpoint,
-            makeQuery: (path, value) => makeAttributeQuery(path, value, key),
-        });
-    } catch (e) {
-        return (
-            <pre className="attribute-object" style={{ color: "red" }}>
-                {"(template error)"} {JSON.stringify(value, null, 4)}
-            </pre>
-        );
-    }
+    return useMemo(() => {
+        try {
+            const context = {
+                key,
+                value,
+                object: object.object,
+            };
+            return renderValue(richTemplate, context, {
+                searchEndpoint: object.searchEndpoint,
+                makeQuery: (path, value) =>
+                    makeAttributeQuery(path, value, key),
+            });
+        } catch (e) {
+            return (
+                <pre className="attribute-object" style={{ color: "red" }}>
+                    {"(template error)"} {JSON.stringify(value, null, 4)}
+                </pre>
+            );
+        }
+    }, [attributeDefinition, value, object.object, object.searchEndpoint]);
 }

--- a/mwdb/web/src/components/ShowObject/common/ShowObject.tsx
+++ b/mwdb/web/src/components/ShowObject/common/ShowObject.tsx
@@ -7,6 +7,7 @@ import {
     Reducer,
 } from "react";
 import { toast } from "react-toastify";
+import _ from "lodash";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
@@ -49,6 +50,17 @@ type ObjectActionReducer = ObjectStateReducer & {
     error?: unknown;
 };
 
+function isDummyUpdate(
+    currentObject: { [k: string]: any },
+    objectUpdate: { [k: string]: any }
+) {
+    // Deeply compares the object update and returns true
+    // if update doesn't actually update the object state
+    return Object.keys(objectUpdate).every((updatedKey) =>
+        _.isEqual(currentObject[updatedKey], objectUpdate[updatedKey])
+    );
+}
+
 function objectReducer(state: ObjectStateReducer, action: ObjectActionReducer) {
     switch (action.type) {
         case objectLoad:
@@ -56,6 +68,11 @@ function objectReducer(state: ObjectStateReducer, action: ObjectActionReducer) {
             return { object: action.object, objectError: null };
         case objectUpdate:
             // Update object data with new information
+            if (!action.object)
+                return { object: state.object, objectError: null };
+            if (state.object && isDummyUpdate(state.object, action.object)) {
+                return { object: state.object, objectError: null };
+            }
             return {
                 object: { ...state.object, ...action.object },
                 objectError: null,


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

Rich Attribute and InjectAfter components may periodically remount due to small updates in object data. It's difficult to fight with the root cause, but the problem can be mitigated with few memoizations.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

- InjectAfter result is memoized, so new array of children is emitted only when props are changed
- RichAttributeValue is memoized (similarly)
- During `objectUpdate` the updated keys are deeply compared with the current object value, so we don't emit new updated object when there's no actual change
