### PR TITLE
Refactor: remove unused ObjectContext.objectError

### DIFF
--- a/mwdb/web/src/types/context.ts
+++ b/mwdb/web/src/types/context.ts
@@ -89,7 +89,6 @@ export type GroupOutletContext = {
 
 export type ObjectContextValues = {
     object?: Partial<ObjectOrConfigOrBlobData>;
-    objectError: unknown;
     objectType: ObjectType;
     searchEndpoint: string;
     setObjectError: (error: unknown) => void;


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [x] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

`objectError` used to be a state because it was shown in the banner on the top of the view. Right now, we use react-toastify for that so this part of state is never used and may trigger unnecessary view updates.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

- Removed unused `ObjectContext.objectError`
- Changed naming of types to be a bit more correct
