### PR TITLE
 Pending users: send mail without password link when passwords are disabled

### DIFF
--- a/mwdb/core/mail.py
+++ b/mwdb/core/mail.py
@@ -2,6 +2,8 @@ import os
 import smtplib
 from email.message import EmailMessage
 
+from mwdb.paths import mail_templates_dir
+
 from .config import app_config
 
 
@@ -13,7 +15,10 @@ def create_message(kind, subject, recipient_email, **params) -> EmailMessage:
     template_path = f"{app_config.mwdb.mail_templates_folder}/{kind}.txt"
 
     if not os.path.exists(template_path):
-        raise MailError("Text template file not found: {}".format(template_path))
+        # Fallback to built-in templates
+        template_path = f"{mail_templates_dir}/{kind}.txt"
+        if not os.path.exists(template_path):
+            raise MailError("Text template file not found: {}".format(template_path))
 
     with open(template_path, "r") as f:
         template = f.read()

--- a/mwdb/resources/user.py
+++ b/mwdb/resources/user.py
@@ -129,14 +129,23 @@ class UserPendingResource(Resource):
 
         if app_config.mwdb.mail_smtp:
             try:
-                send_email_notification(
-                    "register",
-                    "New account registered in MWDB",
-                    user.email,
-                    base_url=app_config.mwdb.base_url,
-                    login=user.login,
-                    set_password_token=user.generate_set_password_token(),
-                )
+                if app_config.mwdb.enable_password_auth:
+                    send_email_notification(
+                        "register",
+                        "New account registered in MWDB",
+                        user.email,
+                        base_url=app_config.mwdb.base_url,
+                        login=user.login,
+                        set_password_token=user.generate_set_password_token(),
+                    )
+                else:
+                    send_email_notification(
+                        "register_no_pass",
+                        "New account registered in MWDB",
+                        user.email,
+                        base_url=app_config.mwdb.base_url,
+                        login=user.login,
+                    )
             except MailError:
                 logger.exception("Can't send e-mail notification")
                 raise InternalServerError(

--- a/mwdb/templates/mail/register_no_pass.txt
+++ b/mwdb/templates/mail/register_no_pass.txt
@@ -1,0 +1,3 @@
+Hi {login},
+
+Your mwdb-core account has been successfully registered.


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the new behaviour?**

This PR adapts 'Pending registrations' feature to OIDC registration approval use case:

- if mail server is not configured, approval doesn't send notification
- if password authentication is disabled, `register_no_pass` template is used that doesn't generate set password link
- if mail template is not in user-defined mail templates directory, MWDB will fallback to built-in template
