### PR TITLE
UI: Remove toast 'You need to authenticate before accessing this page'

### DIFF
--- a/mwdb/web/src/commons/ui/RequiresAuth.tsx
+++ b/mwdb/web/src/commons/ui/RequiresAuth.tsx
@@ -14,9 +14,6 @@ export function RequiresAuth({ children }: Props) {
     const auth = useContext(AuthContext);
     const location = useLocation();
     if (!auth.isAuthenticated) {
-        toast("You need to authenticate before accessing this page", {
-            type: "error",
-        });
         return (
             <Navigate
                 to="/login"


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

MWDB is showing an error message "You need to authenticate before accessing this page" when user is navigating to `/`  (or any other route) without being authenticated. It's confusing for the users and redundant: users are redirected to the login page only when they're logged out and the redirection itself is sufficient to communicate the need for authentication.

<img width="680" height="678" alt="image" src="https://github.com/user-attachments/assets/93842970-8357-46be-90ee-a29d709bb971" />

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

Removed the "You need to authenticate before accessing this page" toast message

