### PR TITLE
Fix: add 'key' element to silence warning 'Each child in a list should have a unique key prop'

### DIFF
--- a/mwdb/web/src/commons/plugins/Extension.tsx
+++ b/mwdb/web/src/commons/plugins/Extension.tsx
@@ -11,8 +11,10 @@ export function Extension({ ident, children, ...props }: Props) {
     if (components.length === 0) return children || <></>;
     return (
         <>
-            {components.map((ExtElement) => (
-                <ExtElement {...props}>{children}</ExtElement>
+            {components.map((ExtElement, index) => (
+                <ExtElement key={`ext-${index}`} {...props}>
+                    {children}
+                </ExtElement>
             ))}
         </>
     );


### PR DESCRIPTION
`fromPlugins` may return aggregated list of components to render. If we're rendering a list of components, React will require a `key` for each element (https://react.dev/learn/rendering-lists#why-does-react-need-keys).

We don't fix any problem here because React automatically assigns key based on element index if key doesn't exist. List of components coming from fromPlugins is practically immutable, so it shouldn't be a problem. So we add a generated index-based key just to silence the warning