### PR TITLE
Web (dev): Debug boxes to enhance discoverability of Extendable components

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -54,8 +54,9 @@ services:
       - "80:3000"
     environment:
       HOST: 0.0.0.0
-      REACT_APP_API_URL: "/api/"
       NODE_ENV: development
+      # Uncomment this to enable Extendable debug boxes
+      # VITE_EXTENDABLE_DEBUG_BOX: 1
     volumes:
       - "./mwdb/web/public:/app/public"
       - "./mwdb/web/src:/app/src"

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -56,6 +56,7 @@ services:
       HOST: 0.0.0.0
       NODE_ENV: development
       # Uncomment this to enable Extendable debug boxes
+      # See also https://github.com/CERT-Polska/mwdb-core/pull/1182
       # VITE_EXTENDABLE_DEBUG_BOX: 1
     volumes:
       - "./mwdb/web/public:/app/public"

--- a/mwdb/web/src/commons/plugins/Extendable.tsx
+++ b/mwdb/web/src/commons/plugins/Extendable.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import { Extension } from "./Extension";
 
 type Props = {
@@ -6,7 +7,20 @@ type Props = {
     [extensionProp: string]: any;
 };
 
-export function Extendable({ ident, children, ...props }: Props) {
+function onMouseOver(this: HTMLDivElement, ev: MouseEvent) {
+    console.log(this);
+    if (this.className === "extendable-debug-box") {
+        this.className = "extendable-debug-box active";
+        ev.stopPropagation();
+    }
+}
+
+function onMouseOut(this: HTMLDivElement) {
+    if (this.className === "extendable-debug-box active")
+        this.className = "extendable-debug-box";
+}
+
+function _Extendable({ ident, children, ...props }: Props) {
     return (
         <>
             {<Extension {...props} ident={`${ident}Before`} />}
@@ -19,3 +33,37 @@ export function Extendable({ ident, children, ...props }: Props) {
         </>
     );
 }
+
+function ExtendableDebugBox({ ident, children, ...props }: Props) {
+    const debugBoxRef = useRef<HTMLDivElement | null>(null);
+
+    useEffect(() => {
+        const element = debugBoxRef.current;
+        if (element) {
+            element.addEventListener("mouseover", onMouseOver);
+            element.addEventListener("mouseout", onMouseOut);
+        }
+        return () => {
+            if (element) {
+                element.addEventListener("mouseover", onMouseOver);
+                element.addEventListener("mouseout", onMouseOut);
+            }
+        };
+    }, []);
+
+    return (
+        <div
+            className="extendable-debug-box"
+            data-label={`Extendable ${ident}`}
+            ref={debugBoxRef}
+        >
+            <_Extendable ident={ident} {...props}>
+                {children}
+            </_Extendable>
+        </div>
+    );
+}
+
+export const Extendable = import.meta.env.VITE_EXTENDABLE_DEBUG_BOX
+    ? ExtendableDebugBox
+    : _Extendable;

--- a/mwdb/web/src/styles/index.css
+++ b/mwdb/web/src/styles/index.css
@@ -517,3 +517,21 @@ table.table.share-table thead th {
     background-color: #f9fafb;
     border-bottom: 1px solid #dee2e6;
 }
+
+.extendable-debug-box {
+    display: contents;
+}
+
+.extendable-debug-box.active > * {
+    border: 1px solid red;
+}
+
+.extendable-debug-box.active::before {
+    content: attr(data-label);
+    color: red;
+    position: absolute;
+    background: white;
+    padding: 0 6px;
+    font-size: 14px;
+    z-index: 10000000;
+}

--- a/mwdb/web/src/vite-env.d.ts
+++ b/mwdb/web/src/vite-env.d.ts
@@ -1,0 +1,14 @@
+interface ViteTypeOptions {
+    // By adding this line, you can make the type of ImportMetaEnv strict
+    // to disallow unknown keys.
+    // strictImportMetaEnv: unknown
+}
+
+interface ImportMetaEnv {
+    readonly VITE_EXTENDABLE_DEBUG_BOX: string;
+    // more env variables...
+}
+
+interface ImportMeta {
+    readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

It's difficult to easily discover Extendable components while writing an UI plugin.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

This PR introduces a small built-in tool that helps in discovering which parts of UI are Extendable.

When we use `docker-compose-dev.yml` with `VITE_EXTENDABLE_DEBUG_BOX=1` enabled in `mwdb-web` env specification: Extendables will be labeled with extra border that shows up when we hover a mouse over an Extendable container element.

<img width="667" height="411" alt="image" src="https://github.com/user-attachments/assets/9ff1fcad-3ecd-4eeb-8d7d-3b72bcb1f7c5" />
