### PR TITLE
Web: Add more Extendable wrappers to improve UI extensibility

### DIFF
--- a/mwdb/web/src/components/RecentView/common/QuickQuery.tsx
+++ b/mwdb/web/src/components/RecentView/common/QuickQuery.tsx
@@ -10,6 +10,7 @@ import { QuickQueryAddModal } from "./QuickQueryAddModal";
 import { QuickQueryItem } from "./QuickQueryItem";
 import { ObjectType, Query } from "@mwdb-web/types/types";
 import { isNil } from "lodash";
+import { Extendable } from "@mwdb-web/commons/plugins";
 
 type Props = {
     type: ObjectType;
@@ -211,8 +212,10 @@ export function QuickQuery(props: Props) {
 
     return (
         <div className="quick-query-bar">
-            Quick query: {predefinedQueryBadges}
-            {userQuickQueryBadges}
+            <Extendable {...props} ident="quickQuery">
+                Quick query: {predefinedQueryBadges}
+                {userQuickQueryBadges}
+            </Extendable>
         </div>
     );
 }

--- a/mwdb/web/src/components/ShowObject/common/CommentBox.tsx
+++ b/mwdb/web/src/components/ShowObject/common/CommentBox.tsx
@@ -3,6 +3,7 @@ import { useState, useContext, useEffect, useCallback } from "react";
 import { APIContext } from "@mwdb-web/commons/api";
 import { AuthContext } from "@mwdb-web/commons/auth";
 import { ObjectContext } from "@mwdb-web/commons/context";
+import { Extendable } from "@mwdb-web/commons/plugins";
 import { ConfirmationModal } from "@mwdb-web/commons/ui";
 import { CommentList } from "./CommentList";
 import { CommentForm } from "./CommentForm";
@@ -75,22 +76,28 @@ export function CommentBox() {
     }, [getComments]);
 
     return (
-        <div className="card card-default">
-            <ConfirmationModal
-                isOpen={isDeleteModalOpen}
-                onRequestClose={() => setDeleteModalOpen(false)}
-                onConfirm={() => {
-                    removeComment(commentToRemove);
-                }}
-                message="Remove the comment?"
-                confirmText="Remove"
-            />
-            <div className="card-header">Comments</div>
-            <CommentList
-                comments={comments ?? []}
-                removeComment={canRemoveComments ? handleRemoveComment : null}
-            />
-            {canAddComments && <CommentForm submitComment={submitComment} />}
-        </div>
+        <Extendable ident="commentBox">
+            <div className="card card-default">
+                <ConfirmationModal
+                    isOpen={isDeleteModalOpen}
+                    onRequestClose={() => setDeleteModalOpen(false)}
+                    onConfirm={() => {
+                        removeComment(commentToRemove);
+                    }}
+                    message="Remove the comment?"
+                    confirmText="Remove"
+                />
+                <div className="card-header">Comments</div>
+                <CommentList
+                    comments={comments ?? []}
+                    removeComment={
+                        canRemoveComments ? handleRemoveComment : null
+                    }
+                />
+                {canAddComments && (
+                    <CommentForm submitComment={submitComment} />
+                )}
+            </div>
+        </Extendable>
     );
 }

--- a/mwdb/web/src/components/ShowObject/common/MultiRelationsBox.tsx
+++ b/mwdb/web/src/components/ShowObject/common/MultiRelationsBox.tsx
@@ -3,6 +3,7 @@ import { faFile, faTable, faScroll } from "@fortawesome/free-solid-svg-icons";
 import { ObjectContext } from "@mwdb-web/commons/context";
 import { RelationsBox } from "./RelationBox";
 import { TypedRelationsBox } from "./TypedRelationsBox";
+import { Extendable } from "@mwdb-web/commons/plugins";
 
 export function MultiRelationsBox() {
     const context = useContext(ObjectContext);
@@ -10,31 +11,35 @@ export function MultiRelationsBox() {
     const children = context.object!.children;
     const itemsCountPerPage = 5;
 
-    return parents && children && parents.length + children.length > 0 ? (
-        <div>
-            <TypedRelationsBox
-                header="Related samples"
-                type="file"
-                icon={faFile}
-                itemsCountPerPage={itemsCountPerPage}
-                {...{ parents, children }}
-            />
-            <TypedRelationsBox
-                header="Related configs"
-                type="static_config"
-                icon={faTable}
-                itemsCountPerPage={itemsCountPerPage}
-                {...{ parents, children }}
-            />
-            <TypedRelationsBox
-                header="Related blobs"
-                type="text_blob"
-                icon={faScroll}
-                itemsCountPerPage={itemsCountPerPage}
-                {...{ parents, children }}
-            />
-        </div>
-    ) : (
-        <RelationsBox />
+    return (
+        <Extendable ident="multiRelationsBox">
+            {parents && children && parents.length + children.length > 0 ? (
+                <div>
+                    <TypedRelationsBox
+                        header="Related samples"
+                        type="file"
+                        icon={faFile}
+                        itemsCountPerPage={itemsCountPerPage}
+                        {...{ parents, children }}
+                    />
+                    <TypedRelationsBox
+                        header="Related configs"
+                        type="static_config"
+                        icon={faTable}
+                        itemsCountPerPage={itemsCountPerPage}
+                        {...{ parents, children }}
+                    />
+                    <TypedRelationsBox
+                        header="Related blobs"
+                        type="text_blob"
+                        icon={faScroll}
+                        itemsCountPerPage={itemsCountPerPage}
+                        {...{ parents, children }}
+                    />
+                </div>
+            ) : (
+                <RelationsBox />
+            )}
+        </Extendable>
     );
 }

--- a/mwdb/web/src/components/ShowObject/common/SharesBox.tsx
+++ b/mwdb/web/src/components/ShowObject/common/SharesBox.tsx
@@ -2,7 +2,9 @@ import { useState, useEffect, useCallback, useContext } from "react";
 
 import { APIContext } from "@mwdb-web/commons/api";
 import { ObjectContext } from "@mwdb-web/commons/context";
+import { Extendable } from "@mwdb-web/commons/plugins";
 import { ConfirmationModal } from "@mwdb-web/commons/ui";
+
 import { SharesList } from "./SharesList";
 import { SharingStatusIcon } from "./SharingStatusIcon";
 
@@ -61,7 +63,7 @@ export function SharesBox() {
     }
 
     return (
-        <div>
+        <Extendable ident="sharesBox">
             <div className="card card-default">
                 <ConfirmationModal
                     isOpen={isModalOpen}
@@ -102,6 +104,6 @@ export function SharesBox() {
                     currentFile={context.object.id}
                 />
             </div>
-        </div>
+        </Extendable>
     );
 }

--- a/mwdb/web/src/components/ShowObject/common/ShowObject.tsx
+++ b/mwdb/web/src/components/ShowObject/common/ShowObject.tsx
@@ -77,7 +77,39 @@ function objectReducer(state: ObjectState, action: ObjectAction) {
     }
 }
 
-type Props = {
+type ShowObjectMainBoxProps = {
+    headerIcon: IconDefinition;
+    headerCaption: string;
+    defaultTab?: string;
+    children: JSX.Element | JSX.Element[];
+};
+
+function ShowObjectMainBox({
+    headerIcon,
+    headerCaption,
+    defaultTab,
+    children,
+}: ShowObjectMainBoxProps) {
+    return (
+        <Extendable ident="showObjectMainBox">
+            <div className="card">
+                <Extendable ident="showObjectPresenter">
+                    <div className="card-header detailed-view-header">
+                        <FontAwesomeIcon icon={headerIcon} />
+                        {headerCaption}
+                    </div>
+                    <ObjectBox defaultTab={defaultTab || "details"}>
+                        <Extendable ident="showObjectTabs">
+                            {children}
+                        </Extendable>
+                    </ObjectBox>
+                </Extendable>
+            </div>
+        </Extendable>
+    );
+}
+
+type ShowObjectProps = {
     ident: string;
     children: JSX.Element | JSX.Element[];
     objectType: ObjectType;
@@ -88,7 +120,7 @@ type Props = {
     searchEndpoint: string;
 };
 
-export function ShowObject(props: Props) {
+export function ShowObject(props: ShowObjectProps) {
     const {
         ident,
         objectType,
@@ -146,21 +178,13 @@ export function ShowObject(props: Props) {
                 <div className="row">
                     <div className="col-md-7">
                         <Extendable ident="showObjectLeftColumn">
-                            <div className="card">
-                                <Extendable ident="showObjectPresenter">
-                                    <div className="card-header detailed-view-header">
-                                        <FontAwesomeIcon icon={headerIcon} />
-                                        {headerCaption}
-                                    </div>
-                                    <ObjectBox
-                                        defaultTab={defaultTab || "details"}
-                                    >
-                                        <Extendable ident="showObjectTabs">
-                                            {children}
-                                        </Extendable>
-                                    </ObjectBox>
-                                </Extendable>
-                            </div>
+                            <ShowObjectMainBox
+                                headerIcon={headerIcon}
+                                headerCaption={headerCaption}
+                                defaultTab={defaultTab}
+                            >
+                                {children}
+                            </ShowObjectMainBox>
                             <AttributesBox />
                             {config.config
                                 .is_3rd_party_sharing_consent_enabled && (

--- a/mwdb/web/src/components/ShowObject/common/TagBox.tsx
+++ b/mwdb/web/src/components/ShowObject/common/TagBox.tsx
@@ -3,6 +3,7 @@ import { useState, useContext } from "react";
 import { APIContext } from "@mwdb-web/commons/api";
 import { AuthContext } from "@mwdb-web/commons/auth";
 import { ObjectContext } from "@mwdb-web/commons/context";
+import { Extendable } from "@mwdb-web/commons/plugins";
 import { ConfirmationModal } from "@mwdb-web/commons/ui";
 import { TagList } from "@mwdb-web/commons/ui";
 import { TagForm } from "./TagForm";
@@ -56,31 +57,35 @@ export function TagBox() {
     }
 
     return (
-        <div className="card card-default">
-            <ConfirmationModal
-                isOpen={modalIsOpen}
-                onRequestClose={() => setModalIsOpen(false)}
-                onConfirm={(e) => tagRemove(tagToRemove)}
-                message={`Remove tag ${tagToRemove}?`}
-                confirmText="Remove"
-            />
-            <div className="card-header">Tags</div>
-            <div className="card-body">
-                {tags && tags.length > 0 ? (
-                    <TagList
-                        tag={""}
-                        tags={tags}
-                        tagRemove={(e, tag) => handleTagRemove(tag)}
-                        deletable={auth.hasCapability(Capability.removingTags)}
-                        searchEndpoint={context.searchEndpoint}
-                    />
-                ) : (
-                    <div className="text-muted">No tags to display</div>
+        <Extendable ident="tagBox">
+            <div className="card card-default">
+                <ConfirmationModal
+                    isOpen={modalIsOpen}
+                    onRequestClose={() => setModalIsOpen(false)}
+                    onConfirm={(e) => tagRemove(tagToRemove)}
+                    message={`Remove tag ${tagToRemove}?`}
+                    confirmText="Remove"
+                />
+                <div className="card-header">Tags</div>
+                <div className="card-body">
+                    {tags && tags.length > 0 ? (
+                        <TagList
+                            tag={""}
+                            tags={tags}
+                            tagRemove={(e, tag) => handleTagRemove(tag)}
+                            deletable={auth.hasCapability(
+                                Capability.removingTags
+                            )}
+                            searchEndpoint={context.searchEndpoint}
+                        />
+                    ) : (
+                        <div className="text-muted">No tags to display</div>
+                    )}
+                </div>
+                {auth.hasCapability(Capability.addingTags) && !api.remote && (
+                    <TagForm onTagSubmit={handleTagSubmit} />
                 )}
             </div>
-            {auth.hasCapability(Capability.addingTags) && !api.remote && (
-                <TagForm onTagSubmit={handleTagSubmit} />
-            )}
-        </div>
+        </Extendable>
     );
 }


### PR DESCRIPTION
Improving extendability of RecentView and ShowObject:

- added `quickQuery` Extendable with exposed props, so someone can add plugin-provided quick queries or other query widgets
- added Extendable box wrappers for Comments box, Relations box, Shares box, Tag box and finally ShowObject main box (`showObjectPresenter` allows to extend only the inner of the box)