### PR TITLE
Docs: Update linters/formatters section in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,12 +33,11 @@ https://gist.github.com/Chaser324/ce0505fbed06b947d962).
 
 6. Remember to autoformat your code. 
    
-   For Python code, install exact versions of formatters from https://github.com/CERT-Polska/lint-python-action.
-   Then use formatters and linters listed below.
+   For Python code, install [Ruff linter and formatter](https://docs.astral.sh/ruff/).
+   Then use both linter and formatter.
    ```
-   isort mwdb/
-   black mwdb/
-   flake8 mwdb/
+   ruff check --fix .
+   ruff format .
    ```
    
    For JS code, use Prettier.


### PR DESCRIPTION
`lint-python` is no longer used for linting/formatting Python code as we switched to Ruff :rocket: