### PR TITLE
UI: Less confusing attribute uncollapse (nicer replacement for three dots)

### DIFF
--- a/mwdb/web/src/components/ShowObject/common/AttributeRenderer.tsx
+++ b/mwdb/web/src/components/ShowObject/common/AttributeRenderer.tsx
@@ -28,6 +28,7 @@ export function AttributeRenderer({
             onCollapse={(collapsed) => setCollapsed(collapsed)}
             collapsed={collapsed}
             collapsible={isCollapsible}
+            attributesCount={attributes.length}
             onShowRaw={(showRaw) => setShowRaw(showRaw)}
             showRaw={showRaw}
             isRichRendered={isRichRendered}

--- a/mwdb/web/src/components/ShowObject/common/AttributeRow.tsx
+++ b/mwdb/web/src/components/ShowObject/common/AttributeRow.tsx
@@ -1,3 +1,4 @@
+import { useCallback, MouseEvent } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPlus, faMinus } from "@fortawesome/free-solid-svg-icons";
 
@@ -7,6 +8,7 @@ type Props = {
     collapsed: boolean;
     onCollapse: (val: boolean) => void;
     collapsible: boolean;
+    attributesCount: number;
     onShowRaw: (val: boolean) => void;
     showRaw: boolean;
     isRichRendered: boolean;
@@ -19,19 +21,23 @@ export function AttributeRow({
     collapsed,
     onCollapse,
     collapsible,
+    attributesCount,
     onShowRaw,
     showRaw,
     isRichRendered,
     children,
 }: Props) {
+    const switchCollapse = useCallback(
+        (ev: MouseEvent) => {
+            ev.preventDefault();
+            if (collapsible) onCollapse(!collapsed);
+        },
+        [collapsible, collapsed, onCollapse]
+    );
+
     return (
         <tr>
-            <th
-                onClick={(ev) => {
-                    ev.preventDefault();
-                    if (collapsible) onCollapse(!collapsed);
-                }}
-            >
+            <th onClick={switchCollapse}>
                 {collapsible ? (
                     <FontAwesomeIcon
                         icon={collapsed ? faPlus : faMinus}
@@ -68,9 +74,12 @@ export function AttributeRow({
             <td className="flickerable">
                 {children}
                 {collapsible && collapsed ? (
-                    <span style={{ color: "gray", fontWeight: "bold" }}>
-                        ...
-                    </span>
+                    <button
+                        className="unstyled-btn text-muted"
+                        onClick={switchCollapse}
+                    >
+                        ({attributesCount - 3} more...)
+                    </button>
                 ) : (
                     <></>
                 )}

--- a/mwdb/web/src/styles/index.css
+++ b/mwdb/web/src/styles/index.css
@@ -535,3 +535,18 @@ table.table.share-table thead th {
     font-size: 14px;
     z-index: 10000000;
 }
+
+button.unstyled-btn {
+    all: unset;
+    display: inline-block;
+    user-select: none;
+    cursor: pointer;
+}
+
+button.unstyled-btn:focus-visible {
+    outline: auto; /* keep focus visibility */
+}
+
+button.unstyled-btn:disabled {
+    cursor: default;
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

There are user reports that `...` at the bottom of attribute key is very confusing:

- it's not clickable, we need to click on attribute label
- it's selectable, so pretty annoying when selecting values

<img width="514" height="92" alt="image" src="https://github.com/user-attachments/assets/b6b4dc9a-631f-40e2-8ef4-12e5a698ce0c" />

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

`...` is replaced with clickable `(X more)`

<img width="332" height="83" alt="image" src="https://github.com/user-attachments/assets/884c4409-c9c4-4b66-af1f-57f8c0411c25" />

In addition I have added `button.unstyled-btn` into CSS stylesheet that can be used for custom-styled buttons, keeping all of the other features of buttons (e.g. keeping them selectable from keyboard)
