### PR TITLE
UI: Indicate in group settings that group is immutable

### DIFF
--- a/mwdb/web/src/commons/ui/EditableItem.tsx
+++ b/mwdb/web/src/commons/ui/EditableItem.tsx
@@ -1,25 +1,27 @@
-import { useState } from "react";
+import React, { useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faTimes, faSave } from "@fortawesome/free-solid-svg-icons";
 import { EditButton } from "./EditButton";
 import { InputHTMLAttributes } from "react";
 import { SelectHTMLAttributes } from "react";
 
-type Select = SelectHTMLAttributes<HTMLSelectElement>;
-type Input = InputHTMLAttributes<HTMLInputElement>;
+type Select = Omit<SelectHTMLAttributes<HTMLSelectElement>, "onSubmit">;
+type Input = Omit<InputHTMLAttributes<HTMLInputElement>, "onSubmit">;
 
 type SelectOrInput = Select | Input;
 
-type Props = SelectOrInput & {
-    name: string;
-    defaultValue: string;
-    type?: string;
-    selective?: boolean;
-    badge?: boolean;
-    masked?: boolean;
-    children?: JSX.Element | JSX.Element[];
-    onSubmit: (value: Record<string, string>) => void;
-};
+type Props = React.PropsWithChildren<
+    SelectOrInput & {
+        name: string;
+        defaultValue: string;
+        type?: string;
+        selective?: boolean;
+        badge?: boolean;
+        masked?: boolean;
+        disabled?: boolean;
+        onSubmit: (value: Record<string, string>) => void;
+    }
+>;
 
 export function EditableItem(props: Props) {
     const {
@@ -31,6 +33,8 @@ export function EditableItem(props: Props) {
         defaultValue,
         onSubmit,
         masked,
+        disabled,
+        ...inputProps
     } = props;
     const [value, setValue] = useState<string>(defaultValue);
     const [edit, setEdit] = useState<boolean>(false);
@@ -47,7 +51,7 @@ export function EditableItem(props: Props) {
                 <div className="input-group">
                     {selective ? (
                         <select
-                            {...(props as Select)}
+                            {...(inputProps as Select)}
                             className="form-control"
                             value={value}
                             name={name}
@@ -57,7 +61,7 @@ export function EditableItem(props: Props) {
                         </select>
                     ) : (
                         <input
-                            {...(props as Input)}
+                            {...(inputProps as Input)}
                             type={type || "text"}
                             name={name}
                             className="form-control"
@@ -101,13 +105,17 @@ export function EditableItem(props: Props) {
                             <span>{defaultValue}</span>
                         )}
                     </span>
-                    <EditButton
-                        onClick={(ev) => {
-                            ev.preventDefault();
-                            setValue(defaultValue);
-                            setEdit(true);
-                        }}
-                    />
+                    {!disabled ? (
+                        <EditButton
+                            onClick={(ev) => {
+                                ev.preventDefault();
+                                setValue(defaultValue);
+                                setEdit(true);
+                            }}
+                        />
+                    ) : (
+                        []
+                    )}
                 </div>
             )}
         </form>

--- a/mwdb/web/src/commons/ui/PseudoEditableItem.tsx
+++ b/mwdb/web/src/commons/ui/PseudoEditableItem.tsx
@@ -5,9 +5,14 @@ import { EditButton } from "./EditButton";
 type Props = {
     children: React.ReactNode;
     editLocation: string;
+    disabled?: boolean;
 };
 
-export function PseudoEditableItem({ children, editLocation }: Props) {
+export function PseudoEditableItem({
+    children,
+    editLocation,
+    disabled,
+}: Props) {
     /*
      Looks the same as regular editable item, but Edit button redirects to the
      separate editing view
@@ -15,9 +20,13 @@ export function PseudoEditableItem({ children, editLocation }: Props) {
     return (
         <div>
             <span className="align-middle">{children}</span>
-            <Link to={editLocation}>
-                <EditButton />
-            </Link>
+            {!disabled ? (
+                <Link to={editLocation}>
+                    <EditButton />
+                </Link>
+            ) : (
+                []
+            )}
         </div>
     );
 }

--- a/mwdb/web/src/components/Settings/Views/GroupDetailsView.tsx
+++ b/mwdb/web/src/components/Settings/Views/GroupDetailsView.tsx
@@ -13,7 +13,10 @@ import {
 import { useViewAlert } from "@mwdb-web/commons/hooks";
 import { makeSearchLink } from "@mwdb-web/commons/helpers";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faTrash } from "@fortawesome/free-solid-svg-icons";
+import {
+    faTrash,
+    faTriangleExclamation,
+} from "@fortawesome/free-solid-svg-icons";
 import { DetailsRecord } from "../common/DetailsRecord";
 import { GroupOutletContext } from "@mwdb-web/types/context";
 import { Group } from "@mwdb-web/types/types";
@@ -57,6 +60,20 @@ export function GroupDetailsView() {
 
     return (
         <div className="container">
+            {group.immutable ? (
+                <div className="alert alert-warning" role="alert">
+                    <FontAwesomeIcon
+                        className="ml-1 mt-1"
+                        icon={faTriangleExclamation}
+                        size="1x"
+                        pull="left"
+                    />
+                    Group is immutable and managed by system, some fields may be
+                    not editable.
+                </div>
+            ) : (
+                []
+            )}
             <table className="table table-striped table-bordered wrap-table">
                 <tbody>
                     <DetailsRecord label="Group name">
@@ -66,6 +83,7 @@ export function GroupDetailsView() {
                             onSubmit={handleUpdate}
                             required
                             pattern="[A-Za-z0-9_.-]{1,32}"
+                            disabled={group.immutable}
                         />
                     </DetailsRecord>
                     <DetailsRecord label="Provider">
@@ -76,6 +94,7 @@ export function GroupDetailsView() {
                     <DetailsRecord label="Members">
                         <PseudoEditableItem
                             editLocation={`/settings/group/${group.name}/members`}
+                            disabled={group.immutable}
                         >
                             {group &&
                                 group.users


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

Right now there is no clear indication that group properties can't be edited because group is immutable

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

Added that indication by:
- adding a banner with proper message
- hiding the Edit buttons

<img width="1133" height="390" alt="image" src="https://github.com/user-attachments/assets/458e5ab1-7930-4c5c-8f8e-d4f1e2a41272" />

I have also fixed the EditableItem typing to be more appropriate and not leaking the unnecessary props to the input/select component (which also fixes some typing issues)
