### PR TITLE
Fix: lazy load User.openid_identities

### DIFF
--- a/mwdb/model/user.py
+++ b/mwdb/model/user.py
@@ -54,7 +54,7 @@ class User(db.Model):
         OpenIDUserIdentity,
         back_populates="user",
         cascade="all, delete-orphan",
-        lazy="selectin",
+        lazy="select",
     )
     permissions = db.relationship(
         "ObjectPermission",


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

I noticed that OpenIDUserIdentity is eagerly loaded along with all User objects, which means it generates additional SELECT query for every authenticated API request. In the same time, this relationship is almost never used and the only place is `/oauth/identities` where it can be simply lazy loaded.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

Changed loading strategy from `selectin` to `select`.

