### PR TITLE
Bump version: v2.18.0

### DIFF
--- a/docs/whats-changed.rst
+++ b/docs/whats-changed.rst
@@ -7,6 +7,25 @@ have compatibility problems after minor mwdb-core upgrade.
 
 For upgrade instructions, see :ref:`Upgrading mwdb-core to latest version`.
 
+v2.18.0
+-------
+
+This release contains major improvements of OpenID Connect integration along with various bugfixes and improvements. MWDB Core code is now linted and formatted using `Ruff <https://docs.astral.sh/ruff/>`_.
+
+Complete changelog can be found here: `v2.18.0 changelog <https://github.com/CERT-Polska/mwdb-core/releases/tag/v2.18.0>`_.
+
+[New feature] Managing MWDB groups using OpenID Provider
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This release contains new feature that allows to synchronize OpenID Provider groups membership with MWDB groups. The synchronization occurs when user authenticates using OpenID Connect.
+
+There are two synchronization modes:
+
+- **FULL**: User custom groups are fully synchronized with the OIDC groups. Users are automatically added to all matching MWDB groups and removed from groups that are no longer present in the OIDC.
+- **MIXED**: Users are added to or removed only from MWDB groups explicitly associated with the OIDC provider.
+
+Read more about this feature in the :ref:`Manage MWDB groups from OpenID Provider groups` documentation.
+
 v2.17.0
 -------
 


### PR DESCRIPTION
**New features:**

- MWDB groups management with OpenID Connect (by @dev-cti in https://github.com/CERT-Polska/mwdb-core/pull/1147)
  You can read more about this feature here: ["Manage MWDB groups from OpenID Provider groups" documentation chapter](https://mwdb.readthedocs.io/en/latest/oauth-guide.html#manage-mwdb-groups-from-openid-provider-groups)
  Thanks for @dev-cti for contribution!

**Improvements:**

- UI: Removed noisy toast 'You need to authenticate before accessing this page' after navigating to `/` (by @psrok1 in https://github.com/CERT-Polska/mwdb-core/pull/1136)
- UI: Less confusing attribute uncollapse (replacement for three dots) (by @psrok1 in https://github.com/CERT-Polska/mwdb-core/pull/1185)
- UI: Indicate in group settings that group is immutable (by @psrok1 in https://github.com/CERT-Polska/mwdb-core/pull/1208)
- Optimized object deletion: database-level cascades and ObjectPermission.related_object_id index (by @psrok1 in https://github.com/CERT-Polska/mwdb-core/pull/1174)
- UI (dev): Debug boxes to enhance discoverability of Extendable components (by @psrok1 in https://github.com/CERT-Polska/mwdb-core/pull/1182)
- UI (dev): Add more Extendable wrappers to improve UI extensibility (by @psrok1 in https://github.com/CERT-Polska/mwdb-core/pull/1183)
- Dev: Switch from python-ssdeep to simple ctypes wrapper over libfuzzy2 (by @psrok1 in https://github.com/CERT-Polska/mwdb-core/pull/1151)
- Dev: Switch from black/isort to ruff for linting and formatting (by @psrok1 in https://github.com/CERT-Polska/mwdb-core/pull/1155)
- Dev: Better SQL profiler - counting SQL queries, more context about emitted query by @psrok1 in https://github.com/CERT-Polska/mwdb-core/pull/1210

**Bugfixes:**

- Fix: installation issues on setuptools<82 (by @psrok1 in https://github.com/CERT-Polska/mwdb-core/pull/1137)
- Fix ISE 500 when too long password was provided during login (by @psrok1 in https://github.com/CERT-Polska/mwdb-core/pull/1135)
- Fix e-mail address validation in UI that doesn't accept various gTLD (by @psrok1 in https://github.com/CERT-Polska/mwdb-core/pull/1166)
- Fix deprecated datetime.utcnow() calls (17 instances across 9 files) (by @MichaelMVS in https://github.com/CERT-Polska/mwdb-core/pull/1178)
- Fix: 'admin' initial private group should be immutable (as all private groups) (by @psrok1 in https://github.com/CERT-Polska/mwdb-core/pull/1206)

**New Contributors**

* @MichaelMVS made their first contribution in https://github.com/CERT-Polska/mwdb-core/pull/1178
* @dev-cti made their first contribution in https://github.com/CERT-Polska/mwdb-core/pull/1147

**Full Changelog**: https://github.com/CERT-Polska/mwdb-core/compare/v2.17.0...v2.18.0