### PR TITLE
Feature: support for Range request headers in file download

### DIFF
--- a/mwdb/model/file.py
+++ b/mwdb/model/file.py
@@ -403,12 +403,6 @@ class File(Object):
 
         return FileIterator(iterate_bytes(), opened_file_metadata)
 
-    def iterate_obfuscated(self, chunk_size=1024 * 256):
-        r"""
-        Iterates over bytes in the file contents with xor applied
-        """
-        return self.iterate(chunk_size=chunk_size, obfuscate=True)
-
     @staticmethod
     def close(fh):
         """

--- a/mwdb/model/file.py
+++ b/mwdb/model/file.py
@@ -29,7 +29,9 @@ class EmptyFileError(ValueError):
 
 
 class InvalidRangeError(ValueError):
-    pass
+    def __init__(self, reason: str | None = None):
+        super().__init__()
+        self.reason = reason
 
 
 class File(Object):
@@ -343,6 +345,12 @@ class File(Object):
 
         def negate_bits(chunk):
             return strxor_c(chunk, 255)
+
+        if range is not None:
+            if len(range.ranges) > 1:
+                raise InvalidRangeError("Multiple ranges unsupported")
+            if range.units != "bytes":
+                raise InvalidRangeError("Unsupported range unit")
 
         try:
             opened_file, opened_file_metadata = self._open_range_from_storage(

--- a/mwdb/model/file.py
+++ b/mwdb/model/file.py
@@ -231,8 +231,6 @@ class File(Object):
                 into proper length and may be longer than requested range.
         """
         if app_config.mwdb.storage_provider == StorageProviderType.S3:
-            # Stream coming from Boto3 get_object is not buffered and not seekable.
-            # We need to download it to the temporary file first.
             s3_client = get_s3_client(
                 app_config.mwdb.s3_storage_endpoint,
                 app_config.mwdb.s3_storage_access_key,

--- a/mwdb/model/file.py
+++ b/mwdb/model/file.py
@@ -264,14 +264,20 @@ class File(Object):
             try:
                 file_size = stream.seek(0, io.SEEK_END)
                 stream.seek(0, io.SEEK_SET)
-                offsets = range.range_for_length(file_size)
-                if not offsets:
-                    raise InvalidRangeError()
-                stream.seek(offsets[0], io.SEEK_SET)
-                metadata = {
-                    "ContentLength": offsets[1] - offsets[0],
-                    "ContentRange": range.to_content_range_header(file_size),
-                }
+                if range is not None:
+                    offsets = range.range_for_length(file_size)
+                    if not offsets:
+                        raise InvalidRangeError()
+                    stream.seek(offsets[0], io.SEEK_SET)
+                    metadata = {
+                        "ContentLength": offsets[1] - offsets[0],
+                        "ContentRange": range.to_content_range_header(file_size),
+                    }
+                else:
+                    metadata = {
+                        "ContentLength": file_size,
+                        "ContentRange": None,
+                    }
                 return stream, metadata
             except:
                 stream.close()
@@ -357,19 +363,18 @@ class File(Object):
             # range_end is not really respected by _open_from_storage
             # because there is no easy way to "truncate" the opened file stream
             # We need to do it on our own based on returned ContentLength
-            bytes_to_read = opened_file_metadata["ContentLength"]
+            file_size = opened_file_metadata["ContentLength"]
             try:
                 while True:
-                    size_to_read = min(chunk_size, bytes_to_read)
+                    size_to_read = min(chunk_size, file_size)
                     chunk = opened_file.read(size_to_read)
                     if obfuscate:
                         chunk = negate_bits(chunk)
-                    if chunk:
-                        yield chunk
-                    else:
+                    if not chunk:
                         return
-                    bytes_to_read -= size_to_read
-                    if bytes_to_read <= 0:
+                    yield chunk
+                    file_size -= size_to_read
+                    if file_size <= 0:
                         return
             finally:
                 opened_file.close()

--- a/mwdb/model/file.py
+++ b/mwdb/model/file.py
@@ -268,6 +268,7 @@ class File(Object):
                 stream.seek(0, io.SEEK_SET)
                 if range is not None:
                     offsets = range.range_for_length(file_size)
+                    print("RANGE OFFSETS", offsets, flush=True)
                     if not offsets:
                         raise InvalidRangeError()
                     stream.seek(offsets[0], io.SEEK_SET)

--- a/mwdb/model/file.py
+++ b/mwdb/model/file.py
@@ -266,7 +266,6 @@ class File(Object):
                 stream.seek(0, io.SEEK_SET)
                 if range is not None:
                     offsets = range.range_for_length(file_size)
-                    print("RANGE OFFSETS", offsets, flush=True)
                     if not offsets:
                         raise InvalidRangeError()
                     stream.seek(offsets[0], io.SEEK_SET)
@@ -280,7 +279,7 @@ class File(Object):
                         "ContentRange": None,
                     }
                 return stream, metadata
-            except:
+            except BaseException:
                 stream.close()
                 raise
         else:
@@ -375,12 +374,12 @@ class File(Object):
                 while True:
                     size_to_read = min(chunk_size, file_size)
                     chunk = opened_file.read(size_to_read)
-                    if obfuscate:
-                        chunk = negate_bits(chunk)
                     if not chunk:
                         return
+                    if obfuscate:
+                        chunk = negate_bits(chunk)
                     yield chunk
-                    file_size -= size_to_read
+                    file_size -= len(chunk)
                     if file_size <= 0:
                         return
             finally:

--- a/mwdb/model/file.py
+++ b/mwdb/model/file.py
@@ -5,6 +5,9 @@ import shutil
 import tempfile
 from typing import Any, Dict
 
+import botocore.exceptions
+import werkzeug
+import werkzeug.datastructures
 from Cryptodome.Util.strxor import strxor_c
 from sqlalchemy import or_
 from sqlalchemy.dialects.postgresql.array import ARRAY
@@ -22,6 +25,10 @@ from .object import Object
 
 
 class EmptyFileError(ValueError):
+    pass
+
+
+class InvalidRangeError(ValueError):
     pass
 
 
@@ -207,6 +214,73 @@ class File(Object):
                 f"StorageProvider {app_config.mwdb.storage_provider} is not supported"
             )
 
+    def _open_range_from_storage(
+        self,
+        fallback_path=False,
+        range: werkzeug.datastructures.Range | None = None,
+    ):
+        """
+        Opens file from storage. Internal method.
+
+        :param fallback_path: Use fallback path (switch hash pathing)
+        :param range: |
+            Werkzeug Range object representing the parsed Range request header.
+            Warning: If file is streamed from DISK, the stream is not truncated
+                into proper length and may be longer than requested range.
+        """
+        if app_config.mwdb.storage_provider == StorageProviderType.S3:
+            # Stream coming from Boto3 get_object is not buffered and not seekable.
+            # We need to download it to the temporary file first.
+            s3_client = get_s3_client(
+                app_config.mwdb.s3_storage_endpoint,
+                app_config.mwdb.s3_storage_access_key,
+                app_config.mwdb.s3_storage_secret_key,
+                app_config.mwdb.s3_storage_region_name,
+                app_config.mwdb.s3_storage_secure,
+                app_config.mwdb.s3_storage_iam_auth,
+            )
+            kwargs = {}
+            if range is not None:
+                kwargs["Range"] = range.to_header()
+            try:
+                obj = s3_client.get_object(
+                    Bucket=app_config.mwdb.s3_storage_bucket_name,
+                    Key=self._calculate_path(fallback_path=fallback_path),
+                    **kwargs,
+                )
+                stream = obj["Body"]
+                metadata = {
+                    "ContentLength": obj["ContentLength"],
+                    "ContentRange": obj.get("ContentRange"),
+                }
+                return stream, metadata
+            except botocore.exceptions.ClientError as error:
+                if error.response["Error"]["Code"] == "InvalidRange":
+                    raise InvalidRangeError() from error
+                else:
+                    raise
+        elif app_config.mwdb.storage_provider == StorageProviderType.DISK:
+            stream = open(self._calculate_path(fallback_path=fallback_path), "rb")
+            try:
+                file_size = stream.seek(0, io.SEEK_END)
+                stream.seek(0, io.SEEK_SET)
+                offsets = range.range_for_length(file_size)
+                if not offsets:
+                    raise InvalidRangeError()
+                stream.seek(offsets[0], io.SEEK_SET)
+                metadata = {
+                    "ContentLength": offsets[1] - offsets[0],
+                    "ContentRange": range.to_content_range_header(file_size),
+                }
+                return stream, metadata
+            except:
+                stream.close()
+                raise
+        else:
+            raise RuntimeError(
+                f"StorageProvider {app_config.mwdb.storage_provider} is not supported"
+            )
+
     def open(self):
         """
         Opens the file stream with contents.
@@ -244,49 +318,84 @@ class File(Object):
         finally:
             File.close(fh)
 
-    def iterate(self, chunk_size=1024 * 256):
+    def iterate(
+        self,
+        chunk_size=1024 * 256,
+        obfuscate: bool = False,
+        range: werkzeug.datastructures.Range | None = None,
+    ):
         """
         Iterates over bytes in the file contents
-        """
-        fh = self.open()
-        try:
-            if hasattr(fh, "stream"):
-                yield from fh.stream(chunk_size)
-            else:
-                while True:
-                    chunk = fh.read(chunk_size)
-                    if chunk:
-                        yield chunk
-                    else:
-                        return
-        finally:
-            File.close(fh)
 
-    def iterate_obfuscated(self, chunk_size=1024 * 256):
-        r"""
-        Iterates over bytes in the file contents with xor applied
-        The idea behind xoring before send is to prevent browsers
-        from caching original samples (malware). Unxoring is provided
-        in mwdb\web\src\components\ShowSample.js in SamplePreview
+        :param obfuscate: |
+            Negate bits. The idea behind xoring before send is to prevent EDR
+            from triggering on malware downloaded while previewing file in UI.
+            Unxoring is provided in mwdb/web/src/components/ShowSample.js in SamplePreview.
+        :param range: |
+            Werkzeug Range object representing the parsed Range request header
         """
 
         def negate_bits(chunk):
             return strxor_c(chunk, 255)
 
-        fh = self.open()
         try:
-            if hasattr(fh, "stream"):
-                yield from map(negate_bits, fh.stream(chunk_size))
+            opened_file, opened_file_metadata = self._open_range_from_storage(
+                range=range
+            )
+        except InvalidRangeError:
+            raise
+        except Exception:
+            if app_config.mwdb.hash_pathing_fallback:
+                opened_file, opened_file_metadata = self._open_range_from_storage(
+                    fallback_path=True,
+                    range=range,
+                )
             else:
+                raise
+
+        def iterate_bytes():
+            # range_end is not really respected by _open_from_storage
+            # because there is no easy way to "truncate" the opened file stream
+            # We need to do it on our own based on returned ContentLength
+            bytes_to_read = opened_file_metadata["ContentLength"]
+            try:
                 while True:
-                    chunk = fh.read(chunk_size)
-                    chunk = negate_bits(chunk)
+                    size_to_read = min(chunk_size, bytes_to_read)
+                    chunk = opened_file.read(size_to_read)
+                    if obfuscate:
+                        chunk = negate_bits(chunk)
                     if chunk:
                         yield chunk
                     else:
                         return
-        finally:
-            File.close(fh)
+                    bytes_to_read -= size_to_read
+                    if bytes_to_read <= 0:
+                        return
+            finally:
+                opened_file.close()
+
+        class FileIterator:
+            def __init__(self, _it, _metadata):
+                self._it = _it
+                self._metadata = _metadata
+
+            @property
+            def metadata(self):
+                return self._metadata
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                return next(self._it)
+
+        return FileIterator(iterate_bytes(), opened_file_metadata)
+
+    def iterate_obfuscated(self, chunk_size=1024 * 256):
+        r"""
+        Iterates over bytes in the file contents with xor applied
+        """
+        return self.iterate(chunk_size=chunk_size, obfuscate=True)
 
     @staticmethod
     def close(fh):

--- a/mwdb/resources/file.py
+++ b/mwdb/resources/file.py
@@ -530,14 +530,10 @@ class FileDownloadResource(Resource):
                 raise NotFound("Object not found")
 
         if request.range:
-            if len(request.range.ranges) > 1:
-                raise BadRequest("Multiple ranges unsupported")
-            if request.range.units != "bytes":
-                raise BadRequest("Unsupported range unit")
             try:
                 file_stream = file_obj.iterate(obfuscate=obfuscate, range=request.range)
-            except InvalidRangeError:
-                raise RequestedRangeNotSatisfiable()
+            except InvalidRangeError as exc:
+                raise RequestedRangeNotSatisfiable(description=exc.reason) from exc
             return Response(
                 file_stream,
                 status=206,

--- a/mwdb/resources/file.py
+++ b/mwdb/resources/file.py
@@ -373,87 +373,6 @@ class FileItemResource(ObjectItemResource, FileUploader):
 
 
 class FileDownloadResource(Resource):
-    def head(self, identifier):
-        """
-        ---
-        summary: Get metadata for file download
-        description: |
-            Returns metadata about the file download.
-
-            This method can be used for token validation or
-            getting the size of the file contents
-        tags:
-            - file
-        parameters:
-            - in: path
-              name: identifier
-              schema:
-                type: string
-              description: File identifier (SHA256/SHA512/SHA1/MD5)
-            - in: query
-              name: token
-              schema:
-                type: string
-              description: |
-                File download token for direct link purpose
-              required: false
-            - in: query
-              name: obfuscate
-              schema:
-                type: string
-              description: |
-                Obfuscated response flag to avoid AV detection on preview
-              required: false
-        responses:
-            200:
-                description: File contents
-                content:
-                  application/octet-stream:
-                    schema:
-                      type: string
-                      format: binary
-            403:
-                description: |
-                    When file download token is no longer valid
-                    or was generated for different object
-            404:
-                description: |
-                    When file doesn't exist, object is not a file
-                    or user doesn't have access to this object.
-            503:
-                description: |
-                    Request canceled due to database statement timeout.
-        """
-        access_token = request.args.get("token")
-        if access_token:
-            file_obj = File.get_by_download_token(access_token)
-            if not file_obj:
-                raise Forbidden("Download token expired, please re-request download.")
-            if not (
-                file_obj.sha1 == identifier
-                or file_obj.sha256 == identifier
-                or file_obj.sha512 == identifier
-                or file_obj.md5 == identifier
-            ):
-                raise Forbidden(
-                    "Download token doesn't apply to the chosen object. "
-                    "Please re-request download."
-                )
-        else:
-            if not g.auth_user:
-                raise Unauthorized("Not authenticated.")
-            file_obj = File.access(identifier)
-            if file_obj is None:
-                raise NotFound("Object not found")
-            return Response(
-                content_type="application/octet-stream",
-                headers={
-                    "Content-Length": file_obj.file_size,
-                    "Content-Disposition": f"attachment; filename={file_obj.sha256}",
-                    "Accept-Ranges": "bytes",
-                },
-            )
-
     def get(self, identifier):
         """
         ---
@@ -529,6 +448,11 @@ class FileDownloadResource(Resource):
             if file_obj is None:
                 raise NotFound("Object not found")
 
+        if not request.range and request.headers.get("Range"):
+            # As of 3.1.8, Werkzeug simply sets request.range to None when
+            # Range header can't be understood. It's better to reject such requests.
+            raise RequestedRangeNotSatisfiable()
+
         if request.range:
             try:
                 file_stream = file_obj.iterate(obfuscate=obfuscate, range=request.range)
@@ -539,6 +463,7 @@ class FileDownloadResource(Resource):
                 status=206,
                 content_type="application/octet-stream",
                 headers={
+                    "Accept-Ranges": "bytes",
                     "Content-Length": file_stream.metadata["ContentLength"],
                     "Content-Range": file_stream.metadata["ContentRange"],
                     "Content-Disposition": f"attachment; filename={file_obj.sha256}",
@@ -550,6 +475,7 @@ class FileDownloadResource(Resource):
                 file_stream,
                 content_type="application/octet-stream",
                 headers={
+                    "Accept-Ranges": "bytes",
                     "Content-Length": file_stream.metadata["ContentLength"],
                     "Content-Disposition": f"attachment; filename={file_obj.sha256}",
                 },

--- a/mwdb/resources/file.py
+++ b/mwdb/resources/file.py
@@ -1,5 +1,12 @@
 from flask import Response, g, request
-from werkzeug.exceptions import BadRequest, Conflict, Forbidden, NotFound, Unauthorized
+from werkzeug.exceptions import (
+    BadRequest,
+    Conflict,
+    Forbidden,
+    NotFound,
+    Unauthorized,
+    RequestedRangeNotSatisfiable,
+)
 
 from mwdb.core.capabilities import Capabilities
 from mwdb.core.config import app_config
@@ -7,7 +14,7 @@ from mwdb.core.deprecated import DeprecatedFeature, deprecated_endpoint
 from mwdb.core.hooks import hooks
 from mwdb.core.service import Resource
 from mwdb.model import File
-from mwdb.model.file import EmptyFileError
+from mwdb.model.file import EmptyFileError, InvalidRangeError
 from mwdb.model.object import ObjectTypeConflictError
 from mwdb.schema.file import (
     FileCreateRequestSchema,
@@ -366,17 +373,15 @@ class FileItemResource(ObjectItemResource, FileUploader):
 
 
 class FileDownloadResource(Resource):
-    def get(self, identifier):
+    def head(self, identifier):
         """
         ---
-        summary: Download file
+        summary: Get metadata for file download
         description: |
-            Returns file contents.
+            Returns metadata about the file download.
 
-            Optionally accepts file download token to get
-            the file via direct link (without Authorization header)
-        security:
-            - bearerAuth: []
+            This method can be used for token validation or
+            getting the size of the file contents
         tags:
             - file
         parameters:
@@ -420,7 +425,88 @@ class FileDownloadResource(Resource):
                     Request canceled due to database statement timeout.
         """
         access_token = request.args.get("token")
-        obfuscate = request.args.get("obfuscate")
+        if access_token:
+            file_obj = File.get_by_download_token(access_token)
+            if not file_obj:
+                raise Forbidden("Download token expired, please re-request download.")
+            if not (
+                file_obj.sha1 == identifier
+                or file_obj.sha256 == identifier
+                or file_obj.sha512 == identifier
+                or file_obj.md5 == identifier
+            ):
+                raise Forbidden(
+                    "Download token doesn't apply to the chosen object. "
+                    "Please re-request download."
+                )
+        else:
+            if not g.auth_user:
+                raise Unauthorized("Not authenticated.")
+            file_obj = File.access(identifier)
+            if file_obj is None:
+                raise NotFound("Object not found")
+            return Response(
+                content_type="application/octet-stream",
+                headers={
+                    "Content-Length": file_obj.file_size,
+                    "Content-Disposition": f"attachment; filename={file_obj.sha256}",
+                    "Accept-Ranges": "bytes",
+                },
+            )
+
+    def get(self, identifier):
+        """
+        ---
+        summary: Download file
+        description: |
+            Returns file contents.
+
+            Optionally accepts file download token to get
+            the file via direct link (without Authorization header)
+        tags:
+            - file
+        parameters:
+            - in: path
+              name: identifier
+              schema:
+                type: string
+              description: File identifier (SHA256/SHA512/SHA1/MD5)
+            - in: query
+              name: token
+              schema:
+                type: string
+              description: |
+                File download token for direct link purpose
+              required: false
+            - in: query
+              name: obfuscate
+              schema:
+                type: string
+              description: |
+                Obfuscated response flag to avoid AV detection on preview
+              required: false
+        responses:
+            200:
+                description: File contents
+                content:
+                  application/octet-stream:
+                    schema:
+                      type: string
+                      format: binary
+            403:
+                description: |
+                    When file download token is no longer valid
+                    or was generated for different object
+            404:
+                description: |
+                    When file doesn't exist, object is not a file
+                    or user doesn't have access to this object.
+            503:
+                description: |
+                    Request canceled due to database statement timeout.
+        """
+        access_token = request.args.get("token")
+        obfuscate = request.args.get("obfuscate") == "1"
 
         if access_token:
             file_obj = File.get_by_download_token(access_token)
@@ -443,20 +529,33 @@ class FileDownloadResource(Resource):
             if file_obj is None:
                 raise NotFound("Object not found")
 
-        if obfuscate == "1":
+        if request.range:
+            if len(request.range.ranges) > 1:
+                raise BadRequest("Multiple ranges unsupported")
+            if request.range.units != "bytes":
+                raise BadRequest("Unsupported range unit")
+            try:
+                file_stream = file_obj.iterate(obfuscate=obfuscate, range=request.range)
+            except InvalidRangeError:
+                raise RequestedRangeNotSatisfiable()
             return Response(
-                file_obj.iterate_obfuscated(),
+                file_stream,
+                status=206,
                 content_type="application/octet-stream",
                 headers={
-                    "Content-disposition": f"attachment; filename={file_obj.sha256}"
+                    "Content-Length": file_stream.metadata["ContentLength"],
+                    "Content-Range": file_stream.metadata["ContentRange"],
+                    "Content-Disposition": f"attachment; filename={file_obj.sha256}",
                 },
             )
         else:
+            file_stream = file_obj.iterate(obfuscate=obfuscate)
             return Response(
-                file_obj.iterate(),
+                file_stream,
                 content_type="application/octet-stream",
                 headers={
-                    "Content-disposition": f"attachment; filename={file_obj.sha256}"
+                    "Content-Length": file_stream.metadata["ContentLength"],
+                    "Content-Disposition": f"attachment; filename={file_obj.sha256}",
                 },
             )
 

--- a/tests/backend/test_api.py
+++ b/tests/backend/test_api.py
@@ -1,8 +1,4 @@
-from io import BytesIO
-
 import pytest
-import pyzipper
-import requests
 from dateutil.parser import parse
 
 from .relations import RelationTestCase
@@ -193,46 +189,6 @@ def test_delete_comment(admin_session):
     # delete comment not associated with object    
     with ShouldRaise(status_code=404):
         admin_session.delete_comment(identifier_1, comment_added_2['id'])
-
-
-def test_download_sample(admin_session):
-    expected = rand_string()
-    sample = admin_session.add_sample(content=expected)
-
-    downloaded = admin_session.download_file(sample['id'])
-    assert downloaded.decode() == expected
-
-
-def test_download_sample_with_token(admin_session):
-    expected = rand_string()
-    sample = admin_session.add_sample(content=expected)
-
-    token = admin_session.get_download_token(sample['id'])
-    r = requests.get(
-        admin_session.mwdb_url + f'/file/{sample["id"]}/download',
-        params={
-            "token": token
-        }
-    )
-    r.raise_for_status()
-    downloaded = r.text
-
-    assert downloaded == expected
-
-def test_download_zipped_sample(admin_session):
-    expected = rand_string(size=4096)
-    sample = admin_session.add_sample(filename="sample.bin", content=expected)
-    token = admin_session.get_download_token(sample['id'])
-    r = requests.get(
-        admin_session.mwdb_url + f'/file/{sample["id"]}/download/zip',
-        params={
-            "token": token
-        }
-    )
-    r.raise_for_status()
-    with pyzipper.AESZipFile(BytesIO(r.content)) as zipped_file:
-        zipped_file.setpassword(b"infected")
-        assert zipped_file.read("sample.bin") == expected.encode()
 
 
 def test_object_conflict(admin_session):

--- a/tests/backend/test_download.py
+++ b/tests/backend/test_download.py
@@ -103,3 +103,9 @@ def test_download_invalid_range(admin_session, sample_for_download):
 
     with ShouldRaise(416):
         admin_session.download_file(sample['id'], range_header=f"bytes={too_big_size}-{too_big_size}")
+
+    with ShouldRaise(416):
+        admin_session.download_file(sample['id'], range_header=f"words=0-100")
+
+    with ShouldRaise(416):
+        admin_session.download_file(sample['id'], range_header=f"bytes=0-100,100-200")

--- a/tests/backend/test_download.py
+++ b/tests/backend/test_download.py
@@ -1,0 +1,66 @@
+from io import BytesIO
+
+import pytest
+import pyzipper
+import requests
+
+from .utils import rand_string, ShouldRaise
+
+@pytest.fixture(scope="session")
+def sample_for_download(admin_session):
+    # 5 x 128kB + 1
+    content = rand_string(size=655361)
+    sample = admin_session.add_sample(filename="sample.bin", content=content)
+    return sample, content
+
+
+def test_download_sample(admin_session, sample_for_download):
+    sample, expected = sample_for_download
+
+    downloaded = admin_session.download_file(sample['id'])
+    assert downloaded.decode() == expected
+
+
+def test_download_sample_with_token(admin_session, sample_for_download):
+    sample, expected = sample_for_download
+
+    token = admin_session.get_download_token(sample['id'])
+    r = requests.get(
+        admin_session.mwdb_url + f'/file/{sample["id"]}/download',
+        params={
+            "token": token
+        }
+    )
+    r.raise_for_status()
+    downloaded = r.text
+    assert downloaded == expected
+
+
+def test_download_sample_with_incorrect_token(admin_session, sample_for_download):
+    sample, expected = sample_for_download
+
+    token = admin_session.get_download_token(sample['id'])
+    with ShouldRaise(403):
+        r = requests.get(
+            admin_session.mwdb_url + f'/file/{sample["id"]}/download',
+            params={
+                "token": token[:-16]
+            }
+        )
+        r.raise_for_status()
+
+
+def test_download_zipped_sample(admin_session, sample_for_download):
+    sample, expected = sample_for_download
+    token = admin_session.get_download_token(sample['id'])
+    r = requests.get(
+        admin_session.mwdb_url + f'/file/{sample["id"]}/download/zip',
+        params={
+            "token": token
+        }
+    )
+    r.raise_for_status()
+    with pyzipper.AESZipFile(BytesIO(r.content)) as zipped_file:
+        zipped_file.setpassword(b"infected")
+        assert zipped_file.read("sample.bin") == expected.encode()
+

--- a/tests/backend/test_download.py
+++ b/tests/backend/test_download.py
@@ -64,3 +64,42 @@ def test_download_zipped_sample(admin_session, sample_for_download):
         zipped_file.setpassword(b"infected")
         assert zipped_file.read("sample.bin") == expected.encode()
 
+
+def test_download_range_sample(admin_session, sample_for_download):
+    sample, expected = sample_for_download
+    downloaded = admin_session.download_file(sample['id'], range_header="bytes=0-512")
+    assert downloaded.decode() == expected[:513]
+
+    downloaded = admin_session.download_file(sample['id'], range_header="bytes=512-1024")
+    assert downloaded.decode() == expected[512:1025]
+
+    downloaded = admin_session.download_file(sample['id'], range_header="bytes=130048-132096")
+    assert downloaded.decode() == expected[130048:132097]
+
+    downloaded = admin_session.download_file(sample['id'], range_header="bytes=130048-")
+    assert downloaded.decode() == expected[130048:]
+
+    downloaded = admin_session.download_file(sample['id'], range_header="bytes=-512")
+    assert downloaded.decode() == expected[-512:]
+
+
+def test_download_invalid_range(admin_session, sample_for_download):
+    sample, expected = sample_for_download
+    too_big_size = len(expected) + 1024
+    downloaded = admin_session.download_file(sample['id'], range_header=f"bytes=0-{too_big_size}")
+    assert downloaded.decode() == expected
+
+    with ShouldRaise(416):
+        admin_session.download_file(sample['id'], range_header=f"bytes={too_big_size}-")
+
+    with ShouldRaise(416):
+        admin_session.download_file(sample['id'], range_header=f"bytes=-100-")
+
+    with ShouldRaise(416):
+        admin_session.download_file(sample['id'], range_header=f"bytes=100000-100")
+
+    with ShouldRaise(416):
+        admin_session.download_file(sample['id'], range_header=f"bytes=-{too_big_size}")
+
+    with ShouldRaise(416):
+        admin_session.download_file(sample['id'], range_header=f"bytes={too_big_size}-{too_big_size}")

--- a/tests/backend/test_download.py
+++ b/tests/backend/test_download.py
@@ -99,9 +99,6 @@ def test_download_invalid_range(admin_session, sample_for_download):
         admin_session.download_file(sample['id'], range_header=f"bytes=100000-100")
 
     with ShouldRaise(416):
-        admin_session.download_file(sample['id'], range_header=f"bytes=-{too_big_size}")
-
-    with ShouldRaise(416):
         admin_session.download_file(sample['id'], range_header=f"bytes={too_big_size}-{too_big_size}")
 
     with ShouldRaise(416):

--- a/tests/backend/utils.py
+++ b/tests/backend/utils.py
@@ -400,8 +400,8 @@ class MwdbTest(object):
         res.raise_for_status()
         return res.json()["token"]
 
-    def download_file(self, identifier, range_header):
-        if range_header:
+    def download_file(self, identifier, range_header=None):
+        if range_header is not None:
             headers = {"Range": range_header}
         else:
             headers = {}

--- a/tests/backend/utils.py
+++ b/tests/backend/utils.py
@@ -400,8 +400,12 @@ class MwdbTest(object):
         res.raise_for_status()
         return res.json()["token"]
 
-    def download_file(self, identifier):
-        res = self.session.get(self.mwdb_url + f"/file/{identifier}/download")
+    def download_file(self, identifier, range_header):
+        if range_header:
+            headers = {"Range": range_header}
+        else:
+            headers = {}
+        res = self.session.get(self.mwdb_url + f"/file/{identifier}/download", headers=headers)
         res.raise_for_status()
         return res.content
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [x] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

This is the first PR of the "huge file support" series.

MWDB Core doesn't support Range request header in file download endpoint. This feature could be used for downloading part of the file and showing only first few megabytes in the Preview. In addition, if we advertise the Range support via `Accept-Ranges: bytes` - clients (browsers) should be able to resume the interrupted download.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

This PR implements support for Range request header in file download endpoint. Core implementation is contained in `File.iterate(...)` and `File._open_range_from_storage` methods that are used for streaming the file contents for download.

There are also few optimizations:
- merged `File.iterate_obfuscated` with `File.iterate` by adding `obfuscate` argument. There was unnecessary code duplication and low chances that `iterate_obfuscated` is used anywhere in the plugins.
- we don't use `File._open_from_storage` and `File.open` - these methods are a bit more complicated and meant to be used by plugins. For example: if we're currently processing the file upload request, `open()` tries to reuse the local temporary file instead of re-downloading the file contents back from S3. Another quirk is that S3 response stream is not seekable and some plugins may need to seek over the file, so we download the file if it's not locally available. We don't need these features in file download.

This feature should be paired with the following changes in mwdblib:

- support for Range argument and partial download
- support for HTTP 416 error in case of unsatisfiable range

**Test plan**
<!-- Explain how to test your changes -->

Test cases should be already covered by automated tests

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

