### PR TITLE
Fix: nullify image for dev and e2e environments to always use locally built image

### DIFF
--- a/compose/compose.with-dev.yml
+++ b/compose/compose.with-dev.yml
@@ -1,6 +1,7 @@
 # Enables development environment with auto-reload
 services:
   mwdb:
+    image: !reset null
     environment:
       HOT_RELOAD: 1
       MWDB_MAIL_SMTP: "mailhog:1025"
@@ -17,6 +18,7 @@ services:
     build:
       context: .
       dockerfile: deploy/docker/Dockerfile-web-dev
+    image: !reset null
     ports: !override
       - "80:3000"
     healthcheck:

--- a/compose/compose.with-e2e.yml
+++ b/compose/compose.with-e2e.yml
@@ -1,6 +1,7 @@
 # End-to-end test suite
 services:
   mwdb:
+    image: !reset null
     environment:
       MWDB_POSTGRES_URI: postgresql://mwdb:e2e-postgres-password@postgres/mwdb
       # Hardcoded secret key for consistent JWT testing
@@ -12,6 +13,8 @@ services:
       MWDB_RECAPTCHA_SECRET: "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe"
       MWDB_ENABLE_REGISTRATION: 1
       MWDB_ENABLE_PROMETHEUS_METRICS: 1
+  mwdb-web:
+    image: !reset null
   postgres:
     image: postgres:17
     restart: always


### PR DESCRIPTION
E2E tests doesn't work correctly because `certpl/mwdb:v2.18.0` is used/pulled instead of imported local image.

Bug introduced by https://github.com/CERT-Polska/mwdb-core/pull/1215 where we changed structure of Docker Compose files