### PR TITLE
UI: Load only first 20MiB of preview when file is bigger than that

### DIFF
--- a/mwdb/web/src/commons/api/index.tsx
+++ b/mwdb/web/src/commons/api/index.tsx
@@ -575,10 +575,13 @@ function removeAttributePermission(
     });
 }
 
-function downloadFile(id: string, obfuscate: number = 0): DownloadFileResponse {
+function downloadFile(id: string, obfuscate: number = 0, range: string|null = null): DownloadFileResponse {
     return axios.get(`/file/${id}/download?obfuscate=${obfuscate}`, {
         responseType: "arraybuffer",
         responseEncoding: "binary",
+        headers: {
+            ...(range !== null ? { "Range": range } : {})
+        }
     });
 }
 

--- a/mwdb/web/src/commons/api/index.tsx
+++ b/mwdb/web/src/commons/api/index.tsx
@@ -575,13 +575,17 @@ function removeAttributePermission(
     });
 }
 
-function downloadFile(id: string, obfuscate: number = 0, range: string|null = null): DownloadFileResponse {
+function downloadFile(
+    id: string,
+    obfuscate: number = 0,
+    range: string | null = null
+): DownloadFileResponse {
     return axios.get(`/file/${id}/download?obfuscate=${obfuscate}`, {
         responseType: "arraybuffer",
         responseEncoding: "binary",
         headers: {
-            ...(range !== null ? { "Range": range } : {})
-        }
+            ...(range !== null ? { Range: range } : {}),
+        },
     });
 }
 

--- a/mwdb/web/src/components/SamplePreview.tsx
+++ b/mwdb/web/src/components/SamplePreview.tsx
@@ -23,12 +23,13 @@ export function SamplePreview() {
             const fileContentResponse = await api.downloadFile(
                 fileId,
                 obfuscate,
-                loadAll ? "" : `bytes=0-${CONTENT_LENGTH_LIMIT-1}`
+                loadAll ? "" : `bytes=0-${CONTENT_LENGTH_LIMIT - 1}`
             );
             console.log(fileContentResponse.headers);
-            const fullContentLength = fileContentResponse.headers["content-range"]?.split("/")[1];
+            const fullContentLength =
+                fileContentResponse.headers["content-range"]?.split("/")[1];
             console.log(fullContentLength);
-            if(fullContentLength) {
+            if (fullContentLength) {
                 console.log(fullContentLength);
                 setFullContentLength(parseInt(fullContentLength));
             }
@@ -48,30 +49,30 @@ export function SamplePreview() {
 
     return (
         <>
-            {
-                !loadAll && fullContentLength > content.byteLength ? (
-                    <div className="alert alert-warning" role="alert">
-                        <FontAwesomeIcon
-                            className="ml-1 mt-1"
-                            icon={faTriangleExclamation}
-                            size="1x"
-                            pull="left"
-                        />
-                        <span className="ml-1">
-                            File size is {humanFileSize(fullContentLength)}. Only the
-                            first {humanFileSize(CONTENT_LENGTH_LIMIT)} is currently
-                            displayed.{" "}
-                            <button
-                                className="unstyled-btn btn-link"
-                                style={{"textDecoration": "underline"}}
-                                onClick={() => setLoadAll(true)}
-                            >
-                                (Load the full content anyway?)
-                            </button>
-                        </span>
-                    </div>
-                ): []
-            }
+            {!loadAll && fullContentLength > content.byteLength ? (
+                <div className="alert alert-warning" role="alert">
+                    <FontAwesomeIcon
+                        className="ml-1 mt-1"
+                        icon={faTriangleExclamation}
+                        size="1x"
+                        pull="left"
+                    />
+                    <span className="ml-1">
+                        File size is {humanFileSize(fullContentLength)}. Only
+                        the first {humanFileSize(CONTENT_LENGTH_LIMIT)} is
+                        currently displayed.{" "}
+                        <button
+                            className="unstyled-btn btn-link"
+                            style={{ textDecoration: "underline" }}
+                            onClick={() => setLoadAll(true)}
+                        >
+                            (Load the full content anyway?)
+                        </button>
+                    </span>
+                </div>
+            ) : (
+                []
+            )}
             <ObjectPreview
                 content={content}
                 mode={tabContext.subTab || "raw"}

--- a/mwdb/web/src/components/SamplePreview.tsx
+++ b/mwdb/web/src/components/SamplePreview.tsx
@@ -1,23 +1,37 @@
 import { APIContext } from "@mwdb-web/commons/api";
-import { useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useState } from "react";
 import { ObjectContext, useTabContext } from "./ShowObject";
-import { negateBuffer } from "@mwdb-web/commons/helpers";
+import { negateBuffer, humanFileSize } from "@mwdb-web/commons/helpers";
 import { ObjectPreview } from "@mwdb-web/commons/ui";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faTriangleExclamation } from "@fortawesome/free-solid-svg-icons";
+
+const CONTENT_LENGTH_LIMIT = 20 * 1048576; // 20 MiB
 
 export function SamplePreview() {
     const [content, setContent] = useState<ArrayBuffer>(new ArrayBuffer(0));
+    const [fullContentLength, setFullContentLength] = useState<number>(0);
+    const [loadAll, setLoadAll] = useState<boolean>(false);
     const api = useContext(APIContext);
     const objectContext = useContext(ObjectContext);
     const tabContext = useTabContext();
 
-    async function updateSample() {
+    const updateSample = useCallback(async () => {
         try {
             const fileId = objectContext!.object!.id!;
             const obfuscate = 1;
             const fileContentResponse = await api.downloadFile(
                 fileId,
-                obfuscate
+                obfuscate,
+                loadAll ? "" : `bytes=0-${CONTENT_LENGTH_LIMIT-1}`
             );
+            console.log(fileContentResponse.headers);
+            const fullContentLength = fileContentResponse.headers["content-range"]?.split("/")[1];
+            console.log(fullContentLength);
+            if(fullContentLength) {
+                console.log(fullContentLength);
+                setFullContentLength(parseInt(fullContentLength));
+            }
             const fileContentResponseData = negateBuffer(
                 fileContentResponse.data
             );
@@ -25,18 +39,44 @@ export function SamplePreview() {
         } catch (e) {
             objectContext.setObjectError(e);
         }
-    }
+    }, [objectContext?.object?.id, loadAll]);
 
     useEffect(() => {
         updateSample();
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [objectContext?.object?.id]);
+    }, [updateSample]);
 
     return (
-        <ObjectPreview
-            content={content}
-            mode={tabContext.subTab || "raw"}
-            showInvisibles
-        />
+        <>
+            {
+                !loadAll && fullContentLength > content.byteLength ? (
+                    <div className="alert alert-warning" role="alert">
+                        <FontAwesomeIcon
+                            className="ml-1 mt-1"
+                            icon={faTriangleExclamation}
+                            size="1x"
+                            pull="left"
+                        />
+                        <span className="ml-1">
+                            File size is {humanFileSize(fullContentLength)}. Only the
+                            first {humanFileSize(CONTENT_LENGTH_LIMIT)} is currently
+                            displayed.{" "}
+                            <button
+                                className="unstyled-btn btn-link"
+                                style={{"textDecoration": "underline"}}
+                                onClick={() => setLoadAll(true)}
+                            >
+                                (Load the full content anyway?)
+                            </button>
+                        </span>
+                    </div>
+                ): []
+            }
+            <ObjectPreview
+                content={content}
+                mode={tabContext.subTab || "raw"}
+                showInvisibles
+            />
+        </>
     );
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

When we try to switch to Preview tab while exploring a huge file, browser may hang. Web application loads whole file contents into memory and Ace.js isn't very optimal in rendering such content.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

Download for preview is by default limited to 20MiB (which is possible thanks to https://github.com/CERT-Polska/mwdb-core/pull/1214). User may still load whole contents after additional confirmation:

<img width="905" height="291" alt="image" src="https://github.com/user-attachments/assets/29b39b73-75be-4d37-ab59-74812bf948ef" />


