### PR TITLE
Bump pyjwt to 2.13.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "prometheus-client==0.21.1",
     "psycopg2-binary==2.9.10",
     "pycryptodomex==3.23.0",
-    "pyjwt==2.12.1",
+    "pyjwt==2.13.0",
     "python-dateutil==2.8.2",
     "python-json-logger==2.0.2",
     "python-magic==0.4.18",
@@ -67,7 +67,7 @@ version = {attr = "mwdb.version.app_version"}
 [dependency-groups]
 test = [
     "python-dateutil",
-    "pyJWT",
+    "pyjwt",
     "pytest",
     "pytest-rerunfailures",
     "requests",

--- a/uv.lock
+++ b/uv.lock
@@ -1353,7 +1353,7 @@ requires-dist = [
     { name = "prometheus-client", specifier = "==0.21.1" },
     { name = "psycopg2-binary", specifier = "==2.9.10" },
     { name = "pycryptodomex", specifier = "==3.23.0" },
-    { name = "pyjwt", specifier = "==2.12.1" },
+    { name = "pyjwt", specifier = "==2.13.0" },
     { name = "python-dateutil", specifier = "==2.8.2" },
     { name = "python-json-logger", specifier = "==2.0.2" },
     { name = "python-magic", specifier = "==0.4.18" },
@@ -1732,14 +1732,14 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixing failed dependabot update (probably due to uppercase identifier in [dependency-groups].test)