### PR TITLE
Fix: remove postgresql-dev from Dockerfile

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -34,7 +34,7 @@ FROM python:3.12-alpine
 
 LABEL maintainer="info@cert.pl"
 
-RUN apk add --no-cache postgresql-client postgresql-dev libmagic libfuzzy2
+RUN apk add --no-cache postgresql-client libmagic libfuzzy2
 
 # Copy the application from the builder
 COPY --from=builder --chown=nobody:nobody /app /app


### PR DESCRIPTION
`postgresql-dev` is quite heavy dependency which highly inflates the size of Docker image. In the same time, it's completely unneeded because we use `psycopg2-binary` package that doesn't require compiling along with postgresql headers and dev dependencies.