### PR TITLE
web: Add Extendable to RecentView  query buttons

### DIFF
--- a/mwdb/web/src/components/RecentView/Views/RecentView.tsx
+++ b/mwdb/web/src/components/RecentView/Views/RecentView.tsx
@@ -10,6 +10,7 @@ import { QuickQuery } from "../common/QuickQuery";
 import { ObjectType } from "@mwdb-web/types/types";
 import { AxiosError } from "axios";
 import { QueryInput } from "../common/QueryInput";
+import { Extendable } from "@mwdb-web/commons/plugins";
 import { useQuerySuggestions } from "../common/useQuerySuggestions";
 
 type Props = {
@@ -168,52 +169,54 @@ export function RecentView(props: Props) {
                             loadingSuggestions={loadingSuggestions}
                         />
                         <div className="input-group-append">
-                            <div className="btn-group">
-                                <input
-                                    className="btn btn-outline-success rounded-0"
-                                    type="submit"
-                                    value="Search"
-                                />
-                            </div>
-                            <div
-                                className="btn-group"
-                                data-toggle="tooltip"
-                                title={`Turn ${
-                                    countingEnabled ? "off" : "on"
-                                } results counting`}
-                            >
-                                <input
-                                    type="button"
-                                    className={`btn btn-outline-info rounded-0 shadow-none ${
-                                        searchParams.get("count") === "1"
-                                            ? "active"
-                                            : ""
-                                    }`}
-                                    value="Count"
-                                    onClick={() => {
-                                        setSearchParams(
-                                            (prev) => {
-                                                return {
-                                                    ...Object.fromEntries(
-                                                        prev.entries()
-                                                    ),
-                                                    q: prev.get("q") || "",
-                                                    count: countingEnabled
-                                                        ? "0"
-                                                        : "1",
-                                                };
-                                            },
-                                            { replace: true }
-                                        );
-                                    }}
-                                />
-                            </div>
-                            <a
-                                href="https://mwdb.readthedocs.io/en/latest/user-guide/7-Lucene-search.html"
-                                className="btn btn-outline-primary"
-                            >
-                                ?
-                            </a>
+                            <Extendable ident="queryInputButtons">
+                                <div className="btn-group">
+                                    <input
+                                        className="btn btn-outline-success rounded-0"
+                                        type="submit"
+                                        value="Search"
+                                    />
+                                </div>
+                                <div
+                                    className="btn-group"
+                                    data-toggle="tooltip"
+                                    title={`Turn ${
+                                        countingEnabled ? "off" : "on"
+                                    } results counting`}
+                                >
+                                    <input
+                                        type="button"
+                                        className={`btn btn-outline-info rounded-0 shadow-none ${
+                                            searchParams.get("count") === "1"
+                                                ? "active"
+                                                : ""
+                                        }`}
+                                        value="Count"
+                                        onClick={() => {
+                                            setSearchParams(
+                                                (prev) => {
+                                                    return {
+                                                        ...Object.fromEntries(
+                                                            prev.entries()
+                                                        ),
+                                                        q: prev.get("q") || "",
+                                                        count: countingEnabled
+                                                            ? "0"
+                                                            : "1",
+                                                    };
+                                                },
+                                                { replace: true }
+                                            );
+                                        }}
+                                    />
+                                </div>
+                                <a
+                                    href="https://mwdb.readthedocs.io/en/latest/user-guide/7-Lucene-search.html"
+                                    className="btn btn-outline-primary"
+                                >
+                                    ?
+                                </a>
+                            </Extendable>
                         </div>
                     </div>
                     <div className="input-group">


### PR DESCRIPTION
Hello all,

Another Extendable, for the query button bar this time.
Can you please add it?

Your checklist for this pull request:

[X]  I've read the [contributing guideline](https://github.com/CERT-Polska/mwdb-core/pull/CONTRIBUTING.md).
[X]   I've tested my changes by building and running the project, and testing changed functionality (if applicable)
[]    I've added automated tests for my change (if applicable, optional)
[]    I've updated documentation to reflect my change (if applicable)

What is the current behaviour?
No Extendable on the query buttons.

What is the new behaviour?
Extendable on the query buttons.

Test plan
Go to recent file page, check extendable with the debug view.