### PR TITLE
Fix CI: Pin ruff 0.15.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,9 +12,9 @@ jobs:
   lint_core:
     runs-on: ubuntu-latest
     steps:
-      - uses: astral-sh/ruff-action@v3
       - name: Check out repository
         uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3
       - run: ruff check
       - run: ruff format --check --diff
   lint_web:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ test = [
     "pyzipper",
 ]
 dev = [
-    "ruff>=0.15.7",
+    "ruff>=0.15.7,<0.16.0",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -1366,7 +1366,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.15.7" }]
+dev = [{ name = "ruff", specifier = ">=0.15.7,<0.16.0" }]
 test = [
     { name = "pyjwt" },
     { name = "pytest" },


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [x] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

Ruff 0.16.0 was recently released which highly extended the default ruleset (https://astral.sh/blog/ruff-v0.16.0). We're not yet compliant with it.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

Ruff is temporarily pinned to <0.16.0 to fix CI failing due to reasons unrelated with the tested commits.

