### PR TITLE
Fix: add proper authorization requirement to Remote API endpoints

### DIFF
--- a/mwdb/resources/remotes.py
+++ b/mwdb/resources/remotes.py
@@ -17,7 +17,13 @@ from mwdb.schema.file import FileItemResponseSchema
 from mwdb.schema.remotes import RemoteOptionsRequestSchema, RemotesListResponseSchema
 from mwdb.version import app_build_version
 
-from . import get_shares_for_upload, loads_schema, logger, requires_authorization
+from . import (
+    get_shares_for_upload,
+    loads_schema,
+    logger,
+    requires_authorization,
+    requires_capabilities,
+)
 
 
 class RemoteListResource(Resource):
@@ -96,15 +102,19 @@ class RemoteAPIResource(Resource):
             mimetype=response.headers["content-type"],
         )
 
+    @requires_authorization
     def get(self, remote_name, remote_path):
         return self.do_request("get", remote_name, remote_path)
 
+    @requires_authorization
     def post(self, remote_name, remote_path):
         return self.do_request("post", remote_name, remote_path)
 
+    @requires_authorization
     def put(self, remote_name, remote_path):
         return self.do_request("put", remote_name, remote_path)
 
+    @requires_authorization
     def delete(self, remote_name, remote_path):
         return self.do_request("delete", remote_name, remote_path)
 
@@ -145,6 +155,7 @@ class RemoteFilePullResource(RemotePullResource):
     on_reuploaded = hooks.on_reuploaded_file
 
     @requires_authorization
+    @requires_capabilities(Capabilities.adding_files)
     def post(self, remote_name, identifier):
         """
         ---
@@ -223,6 +234,7 @@ class RemoteConfigPullResource(RemotePullResource):
     on_reuploaded = hooks.on_reuploaded_config
 
     @requires_authorization
+    @requires_capabilities(Capabilities.adding_configs)
     def post(self, remote_name, identifier):
         """
         ---
@@ -329,6 +341,7 @@ class RemoteTextBlobPullResource(RemotePullResource):
     on_reuploaded = hooks.on_reuploaded_text_blob
 
     @requires_authorization
+    @requires_capabilities(Capabilities.adding_blobs)
     def post(self, remote_name, identifier):
         """
         ---


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

Remote instances API has missing authorization checks:
- `RemoteAPIResource` doesn't check if user is authenticated
- `RemotePullResource` group doesn't check if used is authorized to add objects with given type

Remote instances is an undercooked and experimental feature that is going to be deprecated and removed in future versions.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

Added proper authentication and authorization requirements.

**Test plan**
<!-- Explain how to test your changes -->

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

