### PR TITLE
Fix: remove undocumented and unintended POST method in legacy /config/<parent_dhash>, /blob/<parent_dhash> endpoints

### DIFF
--- a/mwdb/resources/blob.py
+++ b/mwdb/resources/blob.py
@@ -13,7 +13,7 @@ from mwdb.schema.blob import (
     BlobListResponseSchema,
 )
 
-from . import loads_schema, requires_authorization, requires_capabilities
+from . import load_schema, loads_schema, requires_authorization, requires_capabilities
 from .object import ObjectItemResource, ObjectResource, ObjectUploader
 
 
@@ -315,7 +315,9 @@ class TextBlobItemResource(ObjectItemResource, TextBlobUploader):
                 description: |
                     Request canceled due to database statement timeout.
         """
-        return super().put(identifier)
+        schema = self.CreateRequestSchema()
+        obj = load_schema(self._get_upload_args(identifier), schema)
+        return self.create_object(obj)
 
     @requires_authorization
     @requires_capabilities(Capabilities.removing_objects)

--- a/mwdb/resources/config.py
+++ b/mwdb/resources/config.py
@@ -442,7 +442,9 @@ class ConfigItemResource(ObjectItemResource, ConfigUploader):
                 description: |
                     Request canceled due to database statement timeout.
         """
-        return super().put(identifier)
+        schema = self.CreateRequestSchema()
+        obj = load_schema(self._get_upload_args(identifier), schema)
+        return self.create_object(obj)
 
     @requires_authorization
     @requires_capabilities(Capabilities.removing_objects)

--- a/mwdb/resources/file.py
+++ b/mwdb/resources/file.py
@@ -334,7 +334,9 @@ class FileItemResource(ObjectItemResource, FileUploader):
                 description: |
                     Request canceled due to database statement timeout.
         """
-        return super().post(identifier)
+        schema = self.CreateRequestSchema()
+        obj = load_schema(self._get_upload_args(identifier), schema)
+        return self.create_object(obj)
 
     @requires_authorization
     @requires_capabilities(Capabilities.removing_objects)

--- a/mwdb/resources/object.py
+++ b/mwdb/resources/object.py
@@ -2,7 +2,7 @@ import json
 from uuid import UUID
 
 from flask import g, request
-from werkzeug.exceptions import BadRequest, Forbidden, MethodNotAllowed, NotFound
+from werkzeug.exceptions import BadRequest, Forbidden, NotFound
 
 from mwdb.core.capabilities import Capabilities
 from mwdb.core.config import app_config
@@ -315,20 +315,6 @@ class ObjectItemResource(Resource, ObjectUploader):
                 args["upload_as"] = request.form["upload_as"]
         args["parent"] = parent_identifier if parent_identifier != "root" else None
         return args
-
-    @requires_authorization
-    def post(self, identifier):
-        if self.ObjectType is Object:
-            raise MethodNotAllowed()
-
-        schema = self.CreateRequestSchema()
-        obj = load_schema(self._get_upload_args(identifier), schema)
-
-        return self.create_object(obj)
-
-    @requires_authorization
-    def put(self, identifier):
-        return self.post(identifier)
 
     @requires_authorization
     @requires_capabilities(Capabilities.removing_objects)

--- a/tests/backend/test_blobs.py
+++ b/tests/backend/test_blobs.py
@@ -1,5 +1,5 @@
 from .relations import *
-from .utils import random_name, rand_string
+from .utils import random_name, rand_string, ShouldRaise
 
 
 def test_adding_blobs(admin_session):
@@ -14,6 +14,23 @@ def test_adding_blobs(admin_session):
     ========""" + random_name() + "XPADDINGX" * 60)
 
     assert "\x00\x01" in Alice.session.get_blob(blob["id"])["content"]
+
+
+def test_adding_blobs_legacy_post(admin_session):
+    testCase = RelationTestCase(admin_session)
+
+    Alice = testCase.new_user("Alice", capabilities=[])
+    mwdb_session = Alice.session.session
+    with ShouldRaise(405):
+        request = mwdb_session.post(
+            Alice.session.mwdb_url + "/blob/root",
+            json={
+                "blob_name": "blob_name",
+                "blob_type": "blob_type",
+                "content": "content",
+            },
+        )
+        request.raise_for_status()
 
 
 def test_blob_permissions(admin_session):

--- a/tests/backend/test_config.py
+++ b/tests/backend/test_config.py
@@ -1,5 +1,5 @@
 from .relations import *
-from .utils import rand_string
+from .utils import rand_string, ShouldRaise
 
 
 def test_adding_config_with_inblobs(admin_session):
@@ -35,6 +35,22 @@ def test_adding_config_with_inblobs(admin_session):
 
     assert blob1["blob_name"] in ["In blob name", "Peers blob name"] and \
            blob2["blob_name"] in ["In blob name", "Peers blob name"]
+
+
+def test_adding_configs_legacy_post(admin_session):
+    testCase = RelationTestCase(admin_session)
+
+    Alice = testCase.new_user("Alice", capabilities=[])
+    mwdb_session = Alice.session.session
+    with ShouldRaise(405):
+        request = mwdb_session.post(
+            Alice.session.mwdb_url + "/config/root",
+            json={
+                "family": "family",
+                "cfg": {"request": "should-fail"}
+            },
+        )
+        request.raise_for_status()
 
 
 def test_config_search_by_tags_transactional_added(admin_session):


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [x] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

Due to tangled logic in the legacy code, MWDB Core allows to upload config and blob using `POST` method without proper authorization checks.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

`POST` method for `/config/<dhash>` and `/blob/<dhash>` is explicitly disallowed as it was unintended and undocumented.

Added proper automated test for that case (response is expected to be 405 Method not allowed)

**Test plan**
<!-- Explain how to test your changes -->

- Covered by automated tests

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->
