### PR TITLE
Fix CI: Don't pull images on e2e tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,7 +214,7 @@ jobs:
           ./gen_vars.sh test
       - name: Perform tests
         run: |
-          ./compose.sh --with e2e ${{ matrix.with_args }} up --no-build -d mwdb-tests
+          ./compose.sh --with e2e ${{ matrix.with_args }} up --no-build --quiet-pull -d mwdb-tests
           ./compose.sh --with e2e ${{ matrix.with_args }} logs -f -t mwdb-tests
           ([ $(docker wait mwdb_core_e2e_tests) == 0 ])
       - name: Job failed - storing application logs
@@ -252,7 +252,7 @@ jobs:
           ./gen_vars.sh test
       - name: Perform tests
         run: |
-          ./compose.sh --with karton --with e2e up --no-build -d web-tests
+          ./compose.sh --with karton --with e2e up --no-build --quiet-pull -d web-tests
           ./compose.sh --with karton --with e2e logs -f -t web-tests
           ([ $(docker wait mwdb_core_e2e_web_tests) == 0 ])
       - name: Job failed - storing videos from e2e tests
@@ -286,7 +286,7 @@ jobs:
           ./gen_vars.sh test
       - name: Perform tests
         run: |
-          docker compose -f compose/compose.web-unit-tests.yml up --no-build -d
+          docker compose -f compose/compose.web-unit-tests.yml up --no-build --quiet-pull -d
           docker compose -f compose/compose.web-unit-tests.yml logs -f -t
   push_images:
     needs: [test_backend_e2e, test_frontend_e2e, test_frontend_unit]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,7 +207,7 @@ jobs:
           docker load --input ./mwdb-tests-image/mwdb-tests-image
           docker tag certpl/mwdb:${{ github.sha }} mwdb-core-mwdb:latest
           docker tag certpl/mwdb-web:${{ github.sha }} mwdb-core-mwdb-web:latest
-          docker tag certpl/mwdb-tests:${{ github.sha }} mwdb-core-mwdb-tests:latest
+          docker tag certpl/mwdb-tests:${{ github.sha }} certpl/mwdb-tests:latest
       - name: Setup configuration      
         run: |
           chmod +x gen_vars.sh
@@ -245,7 +245,7 @@ jobs:
           docker load --input ./mwdb-web-tests-image/mwdb-web-tests-image
           docker tag certpl/mwdb:${{ github.sha }} mwdb-core-mwdb:latest
           docker tag certpl/mwdb-web:${{ github.sha }} mwdb-core-mwdb-web:latest
-          docker tag certpl/mwdb-web-tests:${{ github.sha }} mwdb-core-mwdb-web-tests:latest
+          docker tag certpl/mwdb-web-tests:${{ github.sha }} certpl/mwdb-web-tests:latest
       - name: Setup configuration
         run: |
           chmod +x gen_vars.sh

--- a/compose/compose.web-unit-tests.yml
+++ b/compose/compose.web-unit-tests.yml
@@ -5,3 +5,4 @@ services:
       dockerfile: deploy/docker/Dockerfile-web-unit-test
     container_name: mwdb_core_unit_web_tests
     image: certpl/mwdb-web-unit-tests
+    pull_policy: never

--- a/compose/compose.with-e2e.yml
+++ b/compose/compose.with-e2e.yml
@@ -2,6 +2,7 @@
 services:
   mwdb:
     image: !reset null
+    pull_policy: never
     environment:
       MWDB_POSTGRES_URI: postgresql://mwdb:e2e-postgres-password@postgres/mwdb
       # Hardcoded secret key for consistent JWT testing
@@ -15,6 +16,7 @@ services:
       MWDB_ENABLE_PROMETHEUS_METRICS: 1
   mwdb-web:
     image: !reset null
+    pull_policy: never
   postgres:
     image: postgres:17
     restart: always
@@ -34,6 +36,7 @@ services:
       mwdb-web:
         condition: service_healthy
     image: certpl/mwdb-tests
+    pull_policy: never
     environment:
       MWDB_ADMIN_LOGIN: admin
       MWDB_ADMIN_PASSWORD: e2e-mwdb-admin-password
@@ -47,6 +50,7 @@ services:
       mwdb-web:
         condition: service_healthy
     image: certpl/mwdb-web-tests
+    pull_policy: never
     environment:
       MWDB_ADMIN_LOGIN: admin
       MWDB_ADMIN_PASSWORD: e2e-mwdb-admin-password


### PR DESCRIPTION
There is inconsistency in current CI that leads to testing using images pulled from Docker Hub instead of built via CI. Noticed in https://github.com/CERT-Polska/mwdb-core/pull/1254

This PR applies `pull_policy:never` when compose is run in e2e context.